### PR TITLE
feat: add Clerk sign-in and sign-up pages

### DIFF
--- a/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from '@clerk/nextjs';
+
+export default function SignInPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <SignIn forceRedirectUrl="/dashboard" />
+    </div>
+  );
+}

--- a/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from '@clerk/nextjs';
+
+export default function SignUpPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <SignUp forceRedirectUrl="/dashboard" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/sign-in` and `/sign-up` catch-all routes with Clerk `<SignIn>` and `<SignUp>` components
- Completes the auth flow: unauthenticated users now see a Clerk form instead of a 404
- Both pages redirect to `/dashboard` after successful authentication

## Test plan
- [x] `bun run build` compiles clean — both routes registered as dynamic
- [ ] `bun run dev` → `/sign-in` renders Clerk sign-in form
- [ ] `bun run dev` → `/sign-up` renders Clerk sign-up form
- [ ] Visit `/dashboard` while logged out → redirects to `/sign-in`
- [ ] Sign in → redirects to `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)