### PR TITLE
Fix CLI and MCP credential-context mismatch for data IDs

### DIFF
--- a/frontend/cli/AGENT_GUIDE.md
+++ b/frontend/cli/AGENT_GUIDE.md
@@ -41,6 +41,10 @@ Edit `frontend/.env.local` with the following:
 | `LIVE_ENGINE_SERVICE_KEY` | Yes | Must match the `SERVICE_API_KEY` env var set on the live-engine Vercel deployment. Enables CLI→live-engine bridge. |
 | `LIVE_ENGINE_USER_ID` | No | Optional. Set to your Clerk user ID (e.g. `user_2abc...`) if you want CLI-created data visible in the browser dashboard. Defaults to `cli-agent`. |
 
+Credential compatibility notes:
+- The CLI now auto-maps MCP-style vars (`LONA_API_KEY`, `LONA_USER_ID`) to `LONA_AGENT_TOKEN` / `LONA_AGENT_ID`.
+- If env vars are missing, the CLI also checks `~/.lona-credentials.json` (or `LONA_CREDENTIALS_FILE`) to align with MCP credential context.
+
 ### 4. Register with Lona Gateway
 
 ```bash

--- a/frontend/cli/lib/__tests__/config.test.ts
+++ b/frontend/cli/lib/__tests__/config.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { getLonaConfig, initializeLonaCredentials, validateConfig } from '../config';
+
+const originalEnv = { ...process.env };
+const tempDirs: string[] = [];
+
+function makeCredentialsFile(payload: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'lona-creds-'));
+  tempDirs.push(dir);
+  const filePath = join(dir, 'credentials.json');
+  writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8');
+  return filePath;
+}
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('cli config credential normalization', () => {
+  test('loads token and agent id from lona credentials file', () => {
+    delete process.env.LONA_AGENT_TOKEN;
+    delete process.env.LONA_AGENT_ID;
+    delete process.env.LONA_API_KEY;
+    delete process.env.LONA_USER_ID;
+
+    process.env.LONA_CREDENTIALS_FILE = makeCredentialsFile({
+      lona_token: 'file-token',
+      agent_id: 'file-agent',
+    });
+
+    initializeLonaCredentials({ force: true });
+    const config = getLonaConfig();
+
+    expect(config.token).toBe('file-token');
+    expect(config.agentId).toBe('file-agent');
+    expect(process.env.LONA_AGENT_TOKEN ?? '').toBe('file-token');
+    expect(process.env.LONA_AGENT_ID ?? '').toBe('file-agent');
+  });
+
+  test('maps MCP env aliases to canonical LONA_AGENT_* vars', () => {
+    delete process.env.LONA_AGENT_TOKEN;
+    delete process.env.LONA_AGENT_ID;
+    process.env.LONA_API_KEY = 'alias-token';
+    process.env.LONA_USER_ID = 'alias-user';
+
+    initializeLonaCredentials({ force: true });
+    const config = getLonaConfig();
+
+    expect(config.token).toBe('alias-token');
+    expect(config.agentId).toBe('alias-user');
+    expect(process.env.LONA_AGENT_TOKEN ?? '').toBe('alias-token');
+    expect(process.env.LONA_AGENT_ID ?? '').toBe('alias-user');
+  });
+
+  test('keeps explicit canonical env values over file fallbacks', () => {
+    process.env.LONA_AGENT_TOKEN = 'env-token';
+    process.env.LONA_AGENT_ID = 'env-agent';
+    process.env.LONA_CREDENTIALS_FILE = makeCredentialsFile({
+      lona_token: 'file-token',
+      agent_id: 'file-agent',
+    });
+
+    initializeLonaCredentials({ force: true });
+    const config = getLonaConfig();
+
+    expect(config.token).toBe('env-token');
+    expect(config.agentId).toBe('env-agent');
+  });
+
+  test('validateConfig accepts alias env after normalization', () => {
+    delete process.env.LONA_AGENT_TOKEN;
+    delete process.env.LONA_AGENT_ID;
+    process.env.LONA_API_KEY = 'alias-token';
+    process.env.LONA_USER_ID = 'alias-user';
+
+    initializeLonaCredentials({ force: true });
+
+    expect(() => validateConfig(['LONA_AGENT_TOKEN'])).not.toThrow();
+  });
+});

--- a/frontend/cli/lib/config.ts
+++ b/frontend/cli/lib/config.ts
@@ -1,8 +1,89 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 export const LONA_GATEWAY_URL = process.env.LONA_GATEWAY_URL ?? 'https://gateway.lona.agency';
 export const LIVE_ENGINE_URL = process.env.LIVE_ENGINE_URL ?? 'https://live.lona.agency';
 export const LIVE_ENGINE_SERVICE_KEY = process.env.LIVE_ENGINE_SERVICE_KEY ?? '';
 
+type LonaCredentialsFile = {
+  lona_token?: string;
+  token?: string;
+  api_key?: string;
+  lona_api_key?: string;
+  agent_id?: string;
+  user_id?: string;
+  lona_user_id?: string;
+};
+
+let lonaCredentialsInitialized = false;
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const normalized = value?.trim();
+    if (normalized) return normalized;
+  }
+  return undefined;
+}
+
+function applyAliasEnvFallbacks(): void {
+  if (!process.env.LONA_AGENT_TOKEN) {
+    const token = firstNonEmpty(process.env.LONA_API_KEY, process.env.LONA_TOKEN);
+    if (token) process.env.LONA_AGENT_TOKEN = token;
+  }
+
+  if (!process.env.LONA_AGENT_ID) {
+    const userId = firstNonEmpty(process.env.LONA_USER_ID);
+    if (userId) process.env.LONA_AGENT_ID = userId;
+  }
+}
+
+function applyCredentialsFileFallbacks(): void {
+  if (process.env.LONA_AGENT_TOKEN && process.env.LONA_AGENT_ID) return;
+
+  const credentialsPath =
+    firstNonEmpty(process.env.LONA_CREDENTIALS_FILE) ?? join(homedir(), '.lona-credentials.json');
+
+  if (!existsSync(credentialsPath)) return;
+
+  try {
+    const parsed = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as LonaCredentialsFile;
+
+    if (!process.env.LONA_AGENT_TOKEN) {
+      const token = firstNonEmpty(
+        parsed.lona_token,
+        parsed.token,
+        parsed.api_key,
+        parsed.lona_api_key,
+      );
+      if (token) process.env.LONA_AGENT_TOKEN = token;
+    }
+
+    if (!process.env.LONA_AGENT_ID) {
+      const userId = firstNonEmpty(parsed.agent_id, parsed.user_id, parsed.lona_user_id);
+      if (userId) process.env.LONA_AGENT_ID = userId;
+    }
+  } catch {
+    // Intentionally ignore invalid JSON/read errors and fall back to env defaults.
+  }
+}
+
+export function initializeLonaCredentials(options?: { force?: boolean }): void {
+  if (lonaCredentialsInitialized && !options?.force) return;
+
+  lonaCredentialsInitialized = true;
+
+  // 1) Normalize legacy env names used by MCP/older clients
+  applyAliasEnvFallbacks();
+  // 2) Load from shared credentials file if canonical vars are still missing
+  applyCredentialsFileFallbacks();
+  // 3) Re-apply alias normalization after file load
+  applyAliasEnvFallbacks();
+}
+
 export function getLonaConfig() {
+  initializeLonaCredentials();
+
   return {
     gatewayUrl: LONA_GATEWAY_URL,
     agentId: process.env.LONA_AGENT_ID ?? 'trade-nexus',
@@ -27,6 +108,8 @@ export function getAIConfig() {
 }
 
 export function validateConfig(required: string[]) {
+  initializeLonaCredentials();
+
   const missing = required.filter((key) => !process.env[key]);
   if (missing.length > 0) {
     throw new Error(`Missing required env vars: ${missing.join(', ')}`);

--- a/frontend/src/lib/lona/client.ts
+++ b/frontend/src/lib/lona/client.ts
@@ -30,10 +30,10 @@ export class LonaClientError extends Error {
 function getConfig() {
   return {
     gatewayUrl: process.env.LONA_GATEWAY_URL ?? 'https://gateway.lona.agency',
-    agentId: process.env.LONA_AGENT_ID ?? 'trade-nexus',
+    agentId: process.env.LONA_AGENT_ID ?? process.env.LONA_USER_ID ?? 'trade-nexus',
     agentName: process.env.LONA_AGENT_NAME ?? 'Trade Nexus Orchestrator',
     registrationSecret: process.env.LONA_AGENT_REGISTRATION_SECRET ?? '',
-    token: process.env.LONA_AGENT_TOKEN ?? '',
+    token: process.env.LONA_AGENT_TOKEN ?? process.env.LONA_API_KEY ?? '',
     tokenTtlDays: Number(process.env.LONA_TOKEN_TTL_DAYS ?? '30'),
   };
 }


### PR DESCRIPTION
Summary:
- normalize MCP env aliases into CLI canonical vars (LONA_API_KEY to LONA_AGENT_TOKEN, LONA_USER_ID to LONA_AGENT_ID)
- auto-load CLI credentials from ~/.lona-credentials.json (or LONA_CREDENTIALS_FILE) when env vars are missing
- ensure CLI config validation runs after credential normalization so commands work with MCP-style credentials
- add fallback alias support in frontend Lona client config for token and user ID
- add tests for file-based loading, alias mapping, precedence, and validation behavior
- document credential compatibility in CLI agent guide

Testing:
- bun run typecheck
- bun test cli/lib/__tests__/config.test.ts
- bun test cli/commands/__tests__/data.test.ts

Closes #13