### PR TITLE
[REPO-01] Decide contracts location and add governance gate

### DIFF
--- a/.github/workflows/contracts-governance.yml
+++ b/.github/workflows/contracts-governance.yml
@@ -1,0 +1,33 @@
+name: contracts-governance
+
+on:
+  pull_request:
+    paths:
+      - "docs/architecture/**"
+      - "backend/tests/contracts/**"
+      - ".github/workflows/contracts-governance.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/architecture/**"
+      - "backend/tests/contracts/**"
+      - ".github/workflows/contracts-governance.yml"
+
+jobs:
+  contract-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test tooling
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Run OpenAPI contract baseline tests
+        run: pytest backend/tests/contracts/test_openapi_contract_baseline.py

--- a/backend/tests/contracts/test_openapi_contract_baseline.py
+++ b/backend/tests/contracts/test_openapi_contract_baseline.py
@@ -1,0 +1,65 @@
+"""Baseline governance checks for the canonical OpenAPI contract.
+
+These tests intentionally validate a stable subset of architecture rules without
+parsing provider-specific implementation details.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OPENAPI_SPEC = REPO_ROOT / "docs/architecture/specs/platform-api.openapi.yaml"
+
+
+def _spec_text() -> str:
+    return OPENAPI_SPEC.read_text(encoding="utf-8")
+
+
+def test_openapi_file_exists() -> None:
+    assert OPENAPI_SPEC.exists(), "Canonical OpenAPI file is missing."
+
+
+def test_versioned_platform_paths_are_present() -> None:
+    spec = _spec_text()
+    for path in (
+        "/v1/health:",
+        "/v1/research/market-scan:",
+        "/v1/strategies:",
+        "/v1/backtests/{backtestId}:",
+        "/v1/deployments:",
+        "/v1/portfolios:",
+        "/v1/orders:",
+    ):
+        assert path in spec, f"Missing required path in OpenAPI: {path}"
+
+
+def test_idempotency_header_required_on_side_effecting_posts() -> None:
+    spec = _spec_text()
+    required_header_ref = "$ref: '#/components/parameters/IdempotencyKey'"
+
+    deployment_block = spec.split("/v1/deployments:")[1].split("/v1/")[0]
+    order_block = spec.split("/v1/orders:")[1]
+
+    assert required_header_ref in deployment_block
+    assert required_header_ref in order_block
+
+
+def test_error_envelope_is_defined() -> None:
+    spec = _spec_text()
+    assert "ErrorResponse:" in spec
+    assert "requestId:" in spec
+    assert "error:" in spec
+
+
+def test_public_tags_are_declared() -> None:
+    spec = _spec_text()
+    for tag in (
+        "name: Health",
+        "name: Research",
+        "name: Strategies",
+        "name: Backtests",
+        "name: Deployments",
+        "name: Portfolios",
+        "name: Orders",
+    ):
+        assert tag in spec, f"Missing expected tag declaration: {tag}"

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -26,6 +26,7 @@ If any document conflicts with implementation prototypes, treat these files as a
 | [API_CONTRACT_GOVERNANCE.md](./API_CONTRACT_GOVERNANCE.md) | How contracts are changed safely |
 | [GAP_ANALYSIS_ASIS_TOBE.md](./GAP_ANALYSIS_ASIS_TOBE.md) | As-is gaps and exact change proposals |
 | [DELIVERY_PLAN_AND_TEAM_TOPOLOGY.md](./DELIVERY_PLAN_AND_TEAM_TOPOLOGY.md) | Delegation model, repo plan, and ticket sectors |
+| [decisions/](./decisions/) | Architecture decision records (ADRs) for binding program choices |
 | [specs/platform-api.openapi.yaml](./specs/platform-api.openapi.yaml) | Canonical public API specification |
 
 Legacy deep-dive documents remain useful for historical context and implementation notes:

--- a/docs/architecture/decisions/ADR-0001-contracts-repo-location.md
+++ b/docs/architecture/decisions/ADR-0001-contracts-repo-location.md
@@ -1,0 +1,43 @@
+# ADR-0001: Contracts Repository Location for Gate0
+
+- Status: Accepted
+- Date: 2026-02-13
+- Issue: [#17](https://github.com/iamtxena/trade-nexus/issues/17)
+
+## Context
+
+Trade Nexus v2 requires a single canonical contract source with governance gates.
+Gate0 must unblock parallel delivery quickly while keeping API scope frozen.
+
+## Decision
+
+For Gate0, keep the canonical contract source in `trade-nexus` at:
+
+- `/Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml`
+
+Add contract-governance CI and baseline contract behavior tests in `trade-nexus`.
+Defer splitting to `trade-nexus-contracts` until a later gate if operational pressure justifies it.
+
+## Alternatives Considered
+
+1. Create `trade-nexus-contracts` immediately in Gate0.
+2. Keep contracts in `trade-nexus` for Gate0 and harden governance first.
+
+## Rationale
+
+1. Fastest path to enforce governance without introducing repo migration risk.
+2. Preserves one authoritative OpenAPI source while Team A prepares Gate1 freeze tasks.
+3. Avoids dual-source drift during bootstrap of `trading-cli` and `trader-data`.
+
+## Consequences
+
+1. Team A owns contract lifecycle in `trade-nexus` during Gate0/Gate1.
+2. Gate1 workstreams consume artifacts from the in-repo OpenAPI source.
+3. A future split remains possible, but only after parity gates are proven.
+
+## Rollback Trigger
+
+Re-open the repo-split decision if either condition is met:
+
+1. Contract governance changes create repeated cross-team merge conflicts that block delivery.
+2. SDK/mock publication cadence requires independent release lifecycle from platform code.


### PR DESCRIPTION
## Summary\n- add ADR-0001 to keep contracts in trade-nexus for Gate0\n- add a dedicated contract-governance workflow\n- add baseline OpenAPI contract behavior tests\n- link architecture index to decisions folder\n\n## Testing\n- uv run --with pytest python -m pytest tests/contracts/test_openapi_contract_baseline.py\n\nFixes iamtxena/trade-nexus#17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds CI and documentation/tests; no production runtime logic changes, with risk primarily limited to potentially failing builds if the OpenAPI spec format/content drifts from the baseline assertions.
> 
> **Overview**
> Adds a new `contracts-governance` GitHub Actions workflow that runs on PRs/pushes touching architecture docs or contract tests and executes a dedicated pytest suite.
> 
> Introduces baseline OpenAPI governance tests (`backend/tests/contracts/test_openapi_contract_baseline.py`) that assert the canonical spec file exists and enforces required v1 paths, idempotency header usage for side-effecting POSTs, a standard error envelope, and expected public tag declarations.
> 
> Adds ADR `ADR-0001` recording the decision to keep the canonical OpenAPI contract in-repo for Gate0, and updates `docs/architecture/README.md` to link the new `decisions/` directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47f79f203a2e6df769e68f8bf67ee1a7951d4260. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->