### PR TITLE
[C-04] Add contract CI gates

### DIFF
--- a/.github/workflows/contracts-governance.yml
+++ b/.github/workflows/contracts-governance.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Install test tooling
         run: python -m pip install --upgrade pip pytest
 

--- a/contracts/scripts/check-breaking-changes.sh
+++ b/contracts/scripts/check-breaking-changes.sh
@@ -6,7 +6,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 SPEC_PATH="${REPO_ROOT}/docs/architecture/specs/platform-api.openapi.yaml"
 BASE_SPEC_PATH="/tmp/platform-api.base.openapi.yaml"
-OPENAPI_DIFF_VERSION="0.24.1"
 
 if [[ ! -f "${SPEC_PATH}" ]]; then
   echo "OpenAPI spec not found at ${SPEC_PATH}" >&2
@@ -26,12 +25,211 @@ fi
 git -C "${REPO_ROOT}" fetch origin "${GITHUB_BASE_REF}" --depth=1
 git -C "${REPO_ROOT}" show "origin/${GITHUB_BASE_REF}:docs/architecture/specs/platform-api.openapi.yaml" > "${BASE_SPEC_PATH}"
 
-export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-/tmp/trade-nexus-npm-cache}"
-export NPM_CONFIG_UPDATE_NOTIFIER="false"
+ruby - "${BASE_SPEC_PATH}" "${SPEC_PATH}" <<'RUBY'
+require 'set'
+require 'yaml'
 
-npx --yes "openapi-diff@${OPENAPI_DIFF_VERSION}" \
-  "${BASE_SPEC_PATH}" \
-  "${SPEC_PATH}" \
-  --fail-on-incompatible
+base_path = ARGV[0]
+current_path = ARGV[1]
 
-echo "No incompatible OpenAPI changes detected vs origin/${GITHUB_BASE_REF}."
+HTTP_METHODS = %w[get put post delete patch options head trace].freeze
+
+def deref(doc, schema)
+  return schema unless schema.is_a?(Hash)
+  return schema unless schema.key?('$ref')
+
+  ref = schema['$ref']
+  return schema unless ref.start_with?('#/')
+
+  ref.split('/').drop(1).reduce(doc) { |acc, key| acc[key] }
+end
+
+def schema_label(schema)
+  return '{}' unless schema.is_a?(Hash)
+  return schema['$ref'] if schema['$ref']
+  schema['type'] || 'object'
+end
+
+def compare_schemas(base_doc, current_doc, base_schema, current_schema, location, errors)
+  base_schema = deref(base_doc, base_schema)
+  current_schema = deref(current_doc, current_schema)
+
+  return if base_schema.nil? || current_schema.nil?
+  unless current_schema.is_a?(Hash)
+    errors << "#{location}: schema became non-object."
+    return
+  end
+
+  if base_schema['type'] && current_schema['type'] && base_schema['type'] != current_schema['type']
+    errors << "#{location}: type changed from #{base_schema['type']} to #{current_schema['type']}."
+  end
+
+  if base_schema['enum'].is_a?(Array)
+    current_enum = current_schema['enum'].is_a?(Array) ? current_schema['enum'] : []
+    removed = base_schema['enum'] - current_enum
+    unless removed.empty?
+      errors << "#{location}: enum values removed: #{removed.join(', ')}."
+    end
+  end
+
+  base_required = Set.new(base_schema.fetch('required', []))
+  current_required = Set.new(current_schema.fetch('required', []))
+  newly_required = current_required - base_required
+
+  base_props = base_schema.fetch('properties', {})
+  current_props = current_schema.fetch('properties', {})
+  unless base_props.is_a?(Hash) && current_props.is_a?(Hash)
+    errors << "#{location}: properties shape changed from #{schema_label(base_schema)} to #{schema_label(current_schema)}."
+    return
+  end
+
+  newly_required.each do |name|
+    next unless base_props.key?(name)
+    errors << "#{location}.#{name}: field changed from optional to required."
+  end
+
+  base_props.each do |name, prop_schema|
+    unless current_props.key?(name)
+      errors << "#{location}.#{name}: field removed."
+      next
+    end
+
+    compare_schemas(
+      base_doc,
+      current_doc,
+      prop_schema,
+      current_props[name],
+      "#{location}.#{name}",
+      errors
+    )
+  end
+
+  if base_schema['items']
+    unless current_schema['items']
+      errors << "#{location}: array items schema removed."
+    else
+      compare_schemas(
+        base_doc,
+        current_doc,
+        base_schema['items'],
+        current_schema['items'],
+        "#{location}[]",
+        errors
+      )
+    end
+  end
+end
+
+def effective_security(doc, operation)
+  operation.key?('security') ? operation['security'] : doc['security']
+end
+
+base_doc = YAML.safe_load(File.read(base_path))
+current_doc = YAML.safe_load(File.read(current_path))
+errors = []
+
+base_paths = base_doc.fetch('paths', {})
+current_paths = current_doc.fetch('paths', {})
+
+base_paths.each do |path, path_item|
+  unless current_paths.key?(path)
+    errors << "Path removed: #{path}"
+    next
+  end
+
+  HTTP_METHODS.each do |method|
+    next unless path_item.is_a?(Hash) && path_item.key?(method)
+    unless current_paths[path].is_a?(Hash) && current_paths[path].key?(method)
+      errors << "Operation removed: #{method.upcase} #{path}"
+      next
+    end
+
+    base_operation = path_item[method]
+    current_operation = current_paths[path][method]
+
+    if effective_security(base_doc, base_operation) != effective_security(current_doc, current_operation)
+      errors << "Security requirements changed: #{method.upcase} #{path}"
+    end
+
+    base_params = Array(base_operation['parameters']).map { |p| p.is_a?(Hash) ? (p['name'] ? "#{p['in']}:#{p['name']}" : p['$ref']) : p }.compact.to_set
+    current_params = Array(current_operation['parameters']).map { |p| p.is_a?(Hash) ? (p['name'] ? "#{p['in']}:#{p['name']}" : p['$ref']) : p }.compact.to_set
+    removed_params = base_params - current_params
+    removed_params.each { |param| errors << "Parameter removed for #{method.upcase} #{path}: #{param}" }
+
+    base_request = base_operation['requestBody']
+    current_request = current_operation['requestBody']
+    if base_request && !current_request
+      errors << "Request body removed: #{method.upcase} #{path}"
+    elsif base_request && current_request
+      if base_request['required'] == false && current_request['required'] == true
+        errors << "Request body changed from optional to required: #{method.upcase} #{path}"
+      end
+
+      base_schema = base_request.dig('content', 'application/json', 'schema')
+      current_schema = current_request.dig('content', 'application/json', 'schema')
+      if base_schema && current_schema
+        compare_schemas(
+          base_doc,
+          current_doc,
+          base_schema,
+          current_schema,
+          "#{method.upcase} #{path} requestBody",
+          errors
+        )
+      elsif base_schema && !current_schema
+        errors << "JSON request schema removed: #{method.upcase} #{path}"
+      end
+    end
+
+    base_responses = base_operation.fetch('responses', {})
+    current_responses = current_operation.fetch('responses', {})
+    base_responses.each do |status, response|
+      unless current_responses.key?(status)
+        errors << "Response removed for #{method.upcase} #{path}: #{status}"
+        next
+      end
+
+      base_schema = response.dig('content', 'application/json', 'schema')
+      current_schema = current_responses[status].dig('content', 'application/json', 'schema')
+      if base_schema && current_schema
+        compare_schemas(
+          base_doc,
+          current_doc,
+          base_schema,
+          current_schema,
+          "#{method.upcase} #{path} response #{status}",
+          errors
+        )
+      elsif base_schema && !current_schema
+        errors << "JSON response schema removed for #{method.upcase} #{path}: #{status}"
+      end
+    end
+  end
+end
+
+base_components = base_doc.dig('components', 'schemas') || {}
+current_components = current_doc.dig('components', 'schemas') || {}
+base_components.each do |name, schema|
+  unless current_components.key?(name)
+    errors << "Schema removed: components.schemas.#{name}"
+    next
+  end
+
+  compare_schemas(
+    base_doc,
+    current_doc,
+    schema,
+    current_components[name],
+    "components.schemas.#{name}",
+    errors
+  )
+end
+
+if errors.empty?
+  puts "No incompatible OpenAPI changes detected."
+else
+  warn "Detected incompatible OpenAPI changes:"
+  errors.uniq.each { |error| warn "- #{error}" }
+  exit 1
+end
+RUBY


### PR DESCRIPTION
## What changed
- expanded `.github/workflows/contracts-governance.yml` to enforce all Gate1 governance checks:
  - Redocly OpenAPI lint
  - baseline + freeze contract tests
  - SDK generation drift check
  - mock server smoke test
  - incompatible contract diff detection on PRs
- added `contracts/scripts/check-breaking-changes.sh` to compare current OpenAPI against PR base and fail on incompatible changes
- widened workflow path filters to include `contracts/**` and `sdk/typescript/**`
- switched checkout to `fetch-depth: 0` so PR-base contract comparisons are reliable

## Why
- #24 requires CI to block contract drift and incompatible changes before merge
- this gate is the enforceable mechanism that freezes the v1 contract while teams deliver in parallel

## How validated
- `python3` direct execution of contract baseline and freeze test functions
- `npx --yes @redocly/cli@1.34.5 lint docs/architecture/specs/platform-api.openapi.yaml`
- `bash /Users/txena/sandbox/16.enjoy/trading/trade-nexus/contracts/scripts/verify-sdk-drift.sh`
- `bash /Users/txena/sandbox/16.enjoy/trading/trade-nexus/contracts/scripts/mock-smoke-test.sh`
- `bash /Users/txena/sandbox/16.enjoy/trading/trade-nexus/contracts/scripts/check-breaking-changes.sh` (skips outside PR context)

Fixes iamtxena/trade-nexus#24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI enforcement and introduces a custom breaking-change detector that may produce false positives/negatives and block merges if miscalibrated.
> 
> **Overview**
> Strengthens the `contracts-governance` workflow to run a broader set of CI gates when contract-related files change, including OpenAPI linting, baseline+freeze tests, SDK drift verification, mock route smoke tests, and a new breaking-change detection step.
> 
> Adds `contracts/scripts/check-breaking-changes.sh`, which (on PRs) fetches the base branch OpenAPI spec and compares it to the current spec, failing the build on removals or incompatible changes (paths/operations/params, security requirements, request/response schema shape, enums, required fields, and removed component schemas).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 592853833d142f46710af7b8c851a55f2f00eefd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->