### PR TITLE
[REPO-03] Publish SDK workflow from contract source

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,54 @@
+name: publish-sdk
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Set to true to publish to npm. Default is dry-run."
+        required: false
+        default: "false"
+  push:
+    tags:
+      - "sdk-v*"
+
+jobs:
+  publish-sdk:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Regenerate SDK from canonical OpenAPI
+        run: bash contracts/scripts/generate-sdk.sh
+
+      - name: Verify SDK drift
+        run: bash contracts/scripts/verify-sdk-drift.sh
+
+      - name: Prepare SDK release
+        run: bash contracts/scripts/prepare-sdk-release.sh
+
+      - name: Publish SDK to npm
+        if: ${{ github.event_name == 'push' || inputs.publish == 'true' }}
+        working-directory: sdk/typescript
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_CACHE: /tmp/trade-nexus-npm-cache
+        run: npm publish --access public
+
+      - name: Dry-run complete
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish != 'true' }}
+        run: echo "Dry-run complete. Set workflow input publish=true to publish to npm."

--- a/contracts/scripts/prepare-sdk-release.sh
+++ b/contracts/scripts/prepare-sdk-release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SPEC_PATH="${REPO_ROOT}/docs/architecture/specs/platform-api.openapi.yaml"
+SDK_PACKAGE_JSON="${REPO_ROOT}/sdk/typescript/package.json"
+SDK_DIR="${REPO_ROOT}/sdk/typescript"
+
+OPENAPI_VERSION="$(awk '/^  version: / {print $2; exit}' "${SPEC_PATH}")"
+SDK_VERSION="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('${SDK_PACKAGE_JSON}','utf8'));process.stdout.write(p.version);")"
+
+if [[ "${OPENAPI_VERSION}" != "${SDK_VERSION}" ]]; then
+  echo "Version mismatch: OpenAPI=${OPENAPI_VERSION}, SDK=${SDK_VERSION}" >&2
+  exit 1
+fi
+
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+  EXPECTED_TAG="sdk-v${SDK_VERSION}"
+  if [[ "${GITHUB_REF_NAME}" != "${EXPECTED_TAG}" ]]; then
+    echo "Tag mismatch: expected ${EXPECTED_TAG}, got ${GITHUB_REF_NAME}" >&2
+    exit 1
+  fi
+fi
+
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-/tmp/trade-nexus-npm-cache}"
+export NPM_CONFIG_UPDATE_NOTIFIER="false"
+
+pushd "${SDK_DIR}" >/dev/null
+npm install --no-package-lock
+npm run build
+npm pack --dry-run --ignore-scripts
+popd >/dev/null
+
+echo "SDK release preparation passed for version ${SDK_VERSION}."

--- a/docs/architecture/specs/SDK_RELEASE.md
+++ b/docs/architecture/specs/SDK_RELEASE.md
@@ -1,0 +1,40 @@
+# SDK Release Workflow (`@trade-nexus/sdk`)
+
+This document describes how the SDK publishing pipeline works from the
+canonical OpenAPI source.
+
+## Workflow file
+
+- `/Users/txena/sandbox/16.enjoy/trading/trade-nexus/.github/workflows/publish-sdk.yml`
+
+## Triggers
+
+1. `workflow_dispatch`:
+   - default is dry-run (`publish=false`)
+   - set `publish=true` to publish to npm
+2. `push` on tags matching `sdk-v*`:
+   - publishes automatically
+
+## Required repository secret
+
+- `NPM_TOKEN` (npm automation token with publish access for `@trade-nexus/sdk`)
+
+## Release gates in workflow
+
+1. Regenerate SDK from canonical OpenAPI:
+   - `bash contracts/scripts/generate-sdk.sh`
+2. Drift verification:
+   - `bash contracts/scripts/verify-sdk-drift.sh`
+3. Release preparation:
+   - `bash contracts/scripts/prepare-sdk-release.sh`
+   - enforces OpenAPI version == SDK package version
+   - enforces tag format `sdk-v<version>` on tag-triggered runs
+   - runs SDK build and package dry-run
+
+## Local validation command
+
+```bash
+bash /Users/txena/sandbox/16.enjoy/trading/trade-nexus/contracts/scripts/prepare-sdk-release.sh
+```
+
+This command is the same release-prep gate used by the workflow.


### PR DESCRIPTION
## What changed
- added npm publish workflow at `.github/workflows/publish-sdk.yml` with triggers:
  - `workflow_dispatch` (default dry-run, optional publish=true)
  - `push` tags matching `sdk-v*`
- added release prep gate script `contracts/scripts/prepare-sdk-release.sh` that enforces:
  - OpenAPI `info.version` equals SDK package version
  - tag format `sdk-v<version>` on tag-triggered runs
  - SDK install/build/package dry-run
- added SDK release runbook at `docs/architecture/specs/SDK_RELEASE.md`

## Why
- #19 requires a publishable SDK release path directly from canonical contract source
- workflow_dispatch dry-run mode supports safe verification without publishing
- explicit version/tag parity checks reduce accidental release drift

## How validated
- `bash /Users/txena/sandbox/16.enjoy/trading/trade-nexus/contracts/scripts/prepare-sdk-release.sh`
- script passed with build + package dry-run and version parity checks

Fixes iamtxena/trade-nexus#19

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates npm publishing in CI and adds new release gates; misconfiguration of secrets/tags or version parsing could block releases or publish an unintended version.
> 
> **Overview**
> Adds a GitHub Actions workflow to regenerate the TypeScript SDK from the canonical OpenAPI spec, verify no generated-artifact drift, run release prep checks, and (optionally) publish `@trade-nexus/sdk` to npm.
> 
> Introduces `contracts/scripts/prepare-sdk-release.sh` to gate releases by enforcing OpenAPI `info.version` == `sdk/typescript/package.json` version, validating tag format `sdk-v<version>` on tag-triggered runs, and running install/build plus `npm pack --dry-run` before publishing. Documents the end-to-end release process in `docs/architecture/specs/SDK_RELEASE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 272ffc6e6f903c29db7cfd0be5621ba49e7a828a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->