### PR TITLE
[DOC-01] Define documentation IA and governance (#107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Trade Nexus is the central orchestration layer for an autonomous trading system.
     └─────────┘                        └─────────────┘
 ```
 
+## Documentation
+
+- [Documentation Index](./docs/README.md)
+- [Architecture Baseline](./docs/architecture/README.md)
+- [Documentation IA and Governance](./docs/architecture/DOCUMENTATION_IA_AND_GOVERNANCE.md)
+
 ## Tech Stack
 
 ### Frontend

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# Trade Nexus Documentation Index
+
+This index is the canonical navigation entry point for Gate-based documentation delivery.
+
+## Audience Lanes
+
+- End users: workflow and troubleshooting guides in `/docs/portal/cli/` and `/docs/portal/operations/`.
+- API consumers: contract and integration docs in `/docs/architecture/INTERFACES.md` and `/docs/portal/api/`.
+- Operators: deployment and operational docs in `/docs/architecture/DEPLOYMENT.md` and `/docs/portal/operations/`.
+- Internal developers: architecture boundaries and gate playbooks in `/docs/architecture/`.
+- LLM/agent consumers: machine-readable package artifacts in `/docs/llm/`.
+
+## Core Program Docs
+
+- Architecture overview: `/docs/architecture/README.md`
+- Documentation IA and governance: `/docs/architecture/DOCUMENTATION_IA_AND_GOVERNANCE.md`
+- Gate execution playbook: `/docs/architecture/GATE_TEAM_EXECUTION_PLAYBOOK.md`
+- Contract governance: `/docs/architecture/API_CONTRACT_GOVERNANCE.md`
+
+## Parent Epic Delivery Mapping
+
+- `#76` Contracts and Governance Program
+- `#77` Platform Core Program
+- `#78` Data and Knowledge Program
+- `#79` Execution Integration Program
+- `#80` Client Surface Program
+- `#81` Program Governance Program
+- `#106` Documentation and Knowledge Distribution Program
+
+Parent deliverable expectations are defined in `/docs/architecture/DOCUMENTATION_IA_AND_GOVERNANCE.md`.

--- a/docs/architecture/DOCUMENTATION_IA_AND_GOVERNANCE.md
+++ b/docs/architecture/DOCUMENTATION_IA_AND_GOVERNANCE.md
@@ -1,0 +1,98 @@
+# Documentation Information Architecture and Governance
+
+## Purpose
+
+Define one canonical documentation information architecture (IA) for Trade Nexus so all teams publish in a consistent structure and reviewers can apply gate-level quality rules.
+
+## Audience Lanes
+
+| Lane | Primary Questions | Canonical Entry Points |
+| --- | --- | --- |
+| End user | How do I run common research/backtest/deploy workflows? | `/docs/README.md`, workflow docs under `/docs/portal/cli/` |
+| API consumer | How do I integrate with the Platform API and SDK safely? | `/docs/architecture/INTERFACES.md`, `/docs/architecture/specs/platform-api.openapi.yaml`, SDK docs |
+| Operator | How do I run/deploy/troubleshoot platform services? | `/docs/architecture/DEPLOYMENT.md`, `/docs/portal/operations/` |
+| Internal developer | What boundaries and gates apply to implementation? | `/docs/architecture/TARGET_ARCHITECTURE_V2.md`, `/docs/architecture/GATE_TEAM_EXECUTION_PLAYBOOK.md` |
+| LLM/agent | What machine-readable references define contracts, ownership, and workflows? | `/docs/llm/` package artifacts and traceability index |
+
+## Source of Truth by Repository
+
+| Repository | Scope | Canonical Documentation Sources | Owning Parent(s) |
+| --- | --- | --- | --- |
+| `trade-nexus` | Platform API, architecture, governance, gate program | `/docs/architecture/`, `/docs/portal/`, `/docs/llm/` | `#76`, `#77`, `#78`, `#79`, `#80`, `#81`, `#106` |
+| `trading-cli` | External CLI behavior and usage | `trading-cli/README.md`, `trading-cli/docs/` | `#80`, `#106` |
+| `trader-data` | Data adapter boundaries and contracts | `trader-data/README.md`, `trader-data/docs/` | `#78`, `#106` |
+| `live-engine` | Execution runtime behavior and operating constraints | `live-engine/README.md`, `live-engine/docs/` | `#79`, `#106` |
+
+## Versioning and Ownership Policy
+
+1. Contract-facing documentation is versioned with API contract versions (`v1`, `v2`, etc.) and must reference the canonical OpenAPI file path.
+2. Gate delivery documentation is versioned by gate (`G0` to `G4`) and parent epic (`#76` to `#81`, `#106`).
+3. Any PR that changes architecture or contract behavior must include docs updates before merge.
+4. Breaking contract proposals require:
+   - an API contract change issue created from `.github/ISSUE_TEMPLATE/api_contract_change.yml`,
+   - an explicit architecture approval comment URL,
+   - a documented major-version strategy.
+5. Parent owners are accountable for final gate closeout docs; child issue owners are accountable for per-PR accuracy.
+
+## Required Documentation Artifacts Per Feature Ticket
+
+| Artifact | Required For | Location Convention |
+| --- | --- | --- |
+| Problem/decision statement | Any architecture or contract ticket | Issue body + `/docs/architecture/decisions/` for ADR-worthy decisions |
+| Interface/contract reference | Any API-facing feature | `/docs/architecture/INTERFACES.md` and OpenAPI-linked docs |
+| User workflow impact | Any CLI or API consumer change | `/docs/portal/cli/` or `/docs/portal/api/` |
+| Operational impact | Runtime/deploy/reliability changes | `/docs/portal/operations/` |
+| Validation evidence | Every PR | PR body (`What changed`, `Why`, `How validated`) and CI checks |
+| Ownership + handoff | Cross-team or gate-completion work | Gate update comments + handoff template below |
+
+## Documentation Taxonomy and Naming Conventions
+
+1. Use stable paths by audience lane:
+   - `/docs/portal/platform/`
+   - `/docs/portal/api/`
+   - `/docs/portal/cli/`
+   - `/docs/portal/data-lifecycle/`
+   - `/docs/portal/operations/`
+   - `/docs/llm/`
+2. Prefer lowercase, kebab-case filenames with descriptive nouns.
+3. Keep one concept per page; use index pages to aggregate links.
+4. Link with repository-relative paths to keep CI link checks deterministic.
+5. When moving or renaming docs pages, update all index/navigation pages in the same PR.
+
+## Parent Epic Documentation Deliverable Map
+
+| Parent Epic | Required Documentation Deliverables |
+| --- | --- |
+| `#76` Contracts and Governance | OpenAPI governance, SDK/mock generation docs, contract CI and templates |
+| `#77` Platform Core | Service boundaries, handler behavior docs, API implementation traceability |
+| `#78` Data and Knowledge | Data lifecycle contracts, ingestion/publish workflows, ownership boundaries |
+| `#79` Execution Integration | Execution adapter contracts, error semantics, operational runbooks |
+| `#80` Client Surface | CLI usage guides, examples, release notes, API consumption constraints |
+| `#81` Program Governance | Cross-parent delivery tracking, gate closeout summaries, signoff records |
+
+## Gate Handoff Template
+
+Use this template when one team hands work to the next team in a gate sequence:
+
+```md
+Gate handoff:
+- Parent: #<id>
+- Gate: G<0-4>
+- From Team: <name>
+- To Team: <name>
+- Completed scope: <short list>
+- Open risks: <short list or none>
+- Required follow-ups: <issue links>
+- Contract/doc version: <tag/commit>
+- Evidence links: <PRs, CI runs, docs pages>
+```
+
+## Review Cadence and Gate Criteria
+
+1. Every gate requires a parent closeout comment with explicit PASS/CONDITIONAL_PASS/FAIL.
+2. Documentation is reviewed on each PR and again at gate closeout.
+3. Gate cannot close if:
+   - required audience-lane docs are missing,
+   - cross-repo links are broken,
+   - ownership or approval references are stale.
+4. Quarterly governance review updates taxonomy, ownership map, and template requirements.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -24,6 +24,7 @@ If any document conflicts with implementation prototypes, treat these files as a
 | [TARGET_ARCHITECTURE_V2.md](./TARGET_ARCHITECTURE_V2.md) | Final to-be architecture and boundaries |
 | [INTERFACES.md](./INTERFACES.md) | Interface model (public + internal adapters) |
 | [API_CONTRACT_GOVERNANCE.md](./API_CONTRACT_GOVERNANCE.md) | How contracts are changed safely |
+| [DOCUMENTATION_IA_AND_GOVERNANCE.md](./DOCUMENTATION_IA_AND_GOVERNANCE.md) | Canonical docs IA, ownership, and gate governance |
 | [GAP_ANALYSIS_ASIS_TOBE.md](./GAP_ANALYSIS_ASIS_TOBE.md) | As-is gaps and exact change proposals |
 | [DELIVERY_PLAN_AND_TEAM_TOPOLOGY.md](./DELIVERY_PLAN_AND_TEAM_TOPOLOGY.md) | Delegation model, repo plan, and ticket sectors |
 | [DATA_LIFECYCLE_AND_LONA_CONNECTOR_V2.md](./DATA_LIFECYCLE_AND_LONA_CONNECTOR_V2.md) | Large-file data lifecycle and Lona-compatible publish connector |


### PR DESCRIPTION
## What changed
- added canonical IA/governance document at `docs/architecture/DOCUMENTATION_IA_AND_GOVERNANCE.md`
- added top-level docs entrypoint at `docs/README.md` with audience lanes and parent mapping
- updated architecture index and repository README navigation links to include the new IA/governance artifacts

## Why
- Gate1 Docs Team needs one authoritative documentation architecture with ownership, taxonomy, deliverable mapping, and handoff rules before implementing portal/CI and baseline user docs

## How validated
- `python3` markdown local-link validation for updated docs files
- `uv run --with pytest python -m pytest tests/contracts/test_openapi_contract_baseline.py tests/contracts/test_openapi_contract_freeze.py` (run from `backend/`)

Fixes iamtxena/trade-nexus#107

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes (new guidance and navigation links) with no runtime or contract behavior impact.
> 
> **Overview**
> Adds a new docs entry point at `docs/README.md` that defines audience lanes, canonical doc locations, and maps documentation work to parent epics.
> 
> Introduces `docs/architecture/DOCUMENTATION_IA_AND_GOVERNANCE.md` to codify documentation information architecture, versioning/ownership rules, required per-feature doc artifacts, naming conventions, and gate handoff/review criteria.
> 
> Updates `README.md` and `docs/architecture/README.md` to link to the new documentation index and governance doc for easier navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 032a6fb618743427e88b6add34fa866b3f43af26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds canonical documentation IA and governance framework to establish consistent structure for Gate-based delivery. Introduces `docs/README.md` as the primary navigation entry point with audience lanes (end users, API consumers, operators, internal developers, LLM/agent consumers) and maps to parent epics `#76`-`#81` and `#106`. The new `DOCUMENTATION_IA_AND_GOVERNANCE.md` codifies documentation ownership, versioning policy, required artifacts per feature ticket, taxonomy conventions, and gate handoff/review criteria. Updates root and architecture README files with navigation links to the new governance artifacts.

Key additions:
- Established audience-based documentation lanes with canonical entry points
- Defined source-of-truth by repository (including future `trading-cli`, `trader-data`, `live-engine` repos)
- Codified versioning policy: contracts versioned by API version, gate docs by gate/epic number
- Required documentation artifacts table per feature type
- Gate handoff template for team-to-team transitions
- Parent epic deliverable map for `#76`-`#81` and `#106`

<h3>Confidence Score: 5/5</h3>

- Documentation-only changes with no runtime impact; safe to merge
- Changes are purely documentation establishing governance framework and navigation structure. No code execution paths affected, no breaking changes to existing functionality. References to non-existent directories and repos are intentional forward-looking design for future implementation. All internal links to existing docs are valid.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/README.md | New docs index with audience lanes and parent epic mapping; references non-existent `/docs/portal/` and `/docs/llm/` directories |
| docs/architecture/DOCUMENTATION_IA_AND_GOVERNANCE.md | New comprehensive governance doc defining IA, ownership, and gate criteria; references non-existent directories and external repos |

</details>


</details>


<sub>Last reviewed commit: 032a6fb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->