### PR TITLE
[#118] Complete Gate1 traceability matrix with #110/#108 evidence

### DIFF
--- a/docs/portal/operations/gate0-gate1-traceability.md
+++ b/docs/portal/operations/gate0-gate1-traceability.md
@@ -29,6 +29,8 @@ updated: 2026-02-14
 | G1 | [#20](https://github.com/iamtxena/trade-nexus/issues/20) | `trade-nexus` | [#96](https://github.com/iamtxena/trade-nexus/pull/96) | Architecture/contract issue templates |
 | G1 | [#107](https://github.com/iamtxena/trade-nexus/issues/107) | `trade-nexus` | [#112](https://github.com/iamtxena/trade-nexus/pull/112) | Documentation IA and governance |
 | G1 | [#111](https://github.com/iamtxena/trade-nexus/issues/111) | `trade-nexus` | [#113](https://github.com/iamtxena/trade-nexus/pull/113) | Docs portal and docs CI gates |
+| G1 | [#110](https://github.com/iamtxena/trade-nexus/issues/110) | `trade-nexus` | [#115](https://github.com/iamtxena/trade-nexus/pull/115) | Baseline API/CLI/user and operations docs |
+| G1 | [#108](https://github.com/iamtxena/trade-nexus/issues/108) | `trade-nexus` | [#117](https://github.com/iamtxena/trade-nexus/pull/117) | LLM package generation and validation |
 
 ## Usage
 


### PR DESCRIPTION
## What changed
- added the missing Gate1 traceability evidence rows to `/docs/portal/operations/gate0-gate1-traceability.md`:
  - issue `#110` -> PR `#115`
  - issue `#108` -> PR `#117`

## Why
- independent review `#109` flagged these omissions as the only remaining Gate1 traceability gap (`#118`).
- this update restores complete Gate1 evidence mapping for reviewers and downstream teams.

## How validated
- `python3 scripts/docs/check_frontmatter.py`
- `python3 scripts/docs/check_links.py`
- `python3 scripts/docs/check_llm_package.py`
- `npm --prefix docs/portal-site run ci`

Fixes iamtxena/trade-nexus#118

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds links/rows to a traceability table; no runtime code or behavior is affected.
> 
> **Overview**
> Updates the Gate1 traceability matrix in `docs/portal/operations/gate0-gate1-traceability.md` by adding two missing evidence rows mapping issue `#110` to PR `#115` and issue `#108` to PR `#117`, completing the documented Gate1 deliverables list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 191f46933ab43babc999f2954298ec400e9f743e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR attempts to complete the Gate1 traceability matrix by adding two missing evidence rows. However, both rows contain incorrect PR mappings:

- Issue `#110` is mapped to PR `#115` but should map to PR `#110` (based on commit b8f5266)
- Issue `#108` is mapped to PR `#117` but should map to PR `#108` (based on commit 3f07d78)

The commit messages follow the pattern `[DOC-XX] Title (#PR_NUMBER)` where the number in parentheses is the PR that merged that work. Git history shows no evidence of PRs `#115` or `#117` existing. The traceability matrix must accurately reflect which PRs delivered which issues for proper evidence tracking.

<h3>Confidence Score: 0/5</h3>

- This PR introduces factually incorrect traceability data and should not be merged
- Score reflects critical data integrity issues - both new traceability rows contain wrong PR numbers that don't match git history, undermining the entire purpose of the evidence matrix
- docs/portal/operations/gate0-gate1-traceability.md requires correction of both PR mappings before merge

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/portal/operations/gate0-gate1-traceability.md | Added two Gate1 traceability rows with incorrect PR mappings - both PRs should be #110 and #108, not #115 and #117 |

</details>


</details>


<sub>Last reviewed commit: 191f469</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->