### PR TITLE
[#119] Reconcile dataset API scope between INTERFACES and OpenAPI

### DIFF
--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -31,10 +31,13 @@ Public endpoints exposed to clients (CLI, web, agents):
 - research
 - strategies
 - backtests
-- datasets
 - deployments
 - portfolios
 - orders
+
+Planned public endpoints (not part of current OpenAPI v1 freeze):
+
+- datasets (target issue: `#97`, target gate: `G2`)
 
 ### Contract shape
 
@@ -253,7 +256,7 @@ Long-running operations use resource status:
 Affected resources:
 
 - backtests
-- datasets
+- datasets (planned public API surface in `#97`; internal lifecycle resources until then)
 - deployments
 - research jobs (if promoted to async)
 

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -37,10 +37,13 @@ Public endpoints exposed to clients (CLI, web, agents):
 - research
 - strategies
 - backtests
-- datasets
 - deployments
 - portfolios
 - orders
+
+Planned public endpoints (not part of current OpenAPI v1 freeze):
+
+- datasets (target issue: `#97`, target gate: `G2`)
 
 ### Contract shape
 
@@ -259,7 +262,7 @@ Long-running operations use resource status:
 Affected resources:
 
 - backtests
-- datasets
+- datasets (planned public API surface in `#97`; internal lifecycle resources until then)
 - deployments
 - research jobs (if promoted to async)
 

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "cd682197b12fdd0b74c5b597d2f3040779c6bc0b45fdf9ee7740c938062b2103",
+    "chunk_hash": "a3690179514bf58633125f37ad1bc687a92b3e77b6118131262fdcc5f7cb524b",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "aa7d6c2712b1d15efdb89e6908f2b627972d507e0f168a6b0a67f3e5709014c0",
+    "source_hash": "fadc4059ad882c825afddf2185091d6e270b00d2efdf3d285021b77e71426df7",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "cd682197b12fdd0b74c5b597d2f3040779c6bc0b45fdf9ee7740c938062b2103",
+    "chunk_hash": "a3690179514bf58633125f37ad1bc687a92b3e77b6118131262fdcc5f7cb524b",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "aa7d6c2712b1d15efdb89e6908f2b627972d507e0f168a6b0a67f3e5709014c0"
+    "source_hash": "fadc4059ad882c825afddf2185091d6e270b00d2efdf3d285021b77e71426df7"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",

--- a/docs/portal/data-lifecycle/command-model.md
+++ b/docs/portal/data-lifecycle/command-model.md
@@ -27,6 +27,7 @@ updated: 2026-02-14
 
 - CLI and clients do not call provider APIs directly.
 - Dataset handling is performed through Platform API surfaces.
+- Dataset lifecycle endpoints are planned for Gate2 (`#97`) and are not in the current OpenAPI v1 path set.
 - Data module implementation details are owned in [`trader-data`](https://github.com/iamtxena/trader-data).
 
 ## References

--- a/docs/portal/data-lifecycle/dataset-lifecycle.md
+++ b/docs/portal/data-lifecycle/dataset-lifecycle.md
@@ -17,6 +17,12 @@ Data lifecycle behavior is documented and implemented behind architecture bounda
 3. Publish versioned dataset.
 4. Reference dataset in backtest/deployment workflows.
 
+## Contract Status
+
+- Dataset lifecycle API endpoints are planned for Gate2 (`#97`).
+- Current canonical OpenAPI v1 does not include `/v1/datasets` routes.
+- Until `#97` lands, treat dataset lifecycle as planned interface work, not active public v1 contract.
+
 ## Canonical References
 
 - `/docs/architecture/DATA_LIFECYCLE_AND_LONA_CONNECTOR_V2.md`


### PR DESCRIPTION
## What changed
- updated `/docs/architecture/INTERFACES.md` to remove `datasets` from current public v1 scope and mark dataset endpoints as planned work targeting `#97` (Gate2)
- added explicit dataset contract status notes in:
  - `/docs/portal/data-lifecycle/dataset-lifecycle.md`
  - `/docs/portal/data-lifecycle/command-model.md`
- regenerated LLM package artifacts so contract status is aligned in chunked references:
  - `/docs/llm/chunks/architecture_interfaces_v1.md`
  - `/docs/llm/index.json`
  - `/docs/llm/traceability.json`

## Why
- review follow-up `#119` identified a scope mismatch: `INTERFACES.md` treated datasets as current public API while canonical OpenAPI v1 has no `/v1/datasets` paths.
- this change removes ambiguity by making current vs planned status explicit and consistent across docs + LLM package.

## How validated
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_frontmatter.py`
- `python3 scripts/docs/check_links.py`
- `python3 scripts/docs/check_llm_package.py`
- `npm --prefix docs/portal-site run ci`

Fixes iamtxena/trade-nexus#119

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus regenerated metadata/hashes; no runtime code or contract implementation is modified.
> 
> **Overview**
> Clarifies the public API contract by **removing `datasets` from the current public v1 scope** and explicitly marking dataset lifecycle endpoints as *planned* work targeting `#97`/Gate2, including notes that OpenAPI v1 has no `/v1/datasets` routes.
> 
> Updates the data-lifecycle portal docs to reflect this contract status, and regenerates the LLM documentation package artifacts (`docs/llm/chunks/*`, `docs/llm/index.json`, `docs/llm/traceability.json`) so hashes and chunked content stay aligned with the revised interface doc.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 700769a1d6551fa9ac36770a0efadcb9928358e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR resolves a scope mismatch identified in issue `#119` by removing `datasets` from the current public v1 API scope and explicitly marking dataset endpoints as planned work targeting issue `#97` (Gate2).

**Changes Made:**
- Removed `datasets` from the current public v1 endpoint list in `INTERFACES.md`
- Added explicit "Planned public endpoints" section noting datasets target Gate2
- Updated async resource contract section to clarify datasets are planned public API surface
- Added "Contract Status" sections to dataset lifecycle documentation files explaining current vs planned status
- Regenerated LLM package artifacts (`chunks/`, `index.json`, `traceability.json`) to keep hashes aligned

**Impact:**
- Eliminates ambiguity between `INTERFACES.md` and canonical OpenAPI v1 spec (which has no `/v1/datasets` paths)
- Makes contract boundaries explicit for teams working on dataset features
- Maintains documentation consistency across architecture docs, portal docs, and LLM-friendly documentation package

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only changes that align contract definitions with actual OpenAPI spec; no runtime code modified, validation scripts passed, and all metadata regenerated correctly
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/architecture/INTERFACES.md | Moved `datasets` from current public v1 scope to planned Gate2 endpoints, clarifying contract status |
| docs/llm/chunks/architecture_interfaces_v1.md | Auto-regenerated chunk mirrors INTERFACES.md changes, maintaining LLM package consistency |
| docs/llm/index.json | Updated source and chunk hashes for architecture_interfaces_v1 to reflect documentation changes |
| docs/llm/traceability.json | Updated source and chunk hashes for architecture_interfaces_v1 to maintain traceability |
| docs/portal/data-lifecycle/command-model.md | Added note clarifying dataset lifecycle endpoints are planned for Gate2, not in current OpenAPI v1 |
| docs/portal/data-lifecycle/dataset-lifecycle.md | Added contract status section explaining datasets are planned for Gate2, not active public v1 contract |

</details>


</details>


<sub>Last reviewed commit: 700769a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->