### PR TITLE
feat: AG-RISK-03 drawdown breach handling and kill-switch

### DIFF
--- a/backend/src/platform_api/services/risk_killswitch_service.py
+++ b/backend/src/platform_api/services/risk_killswitch_service.py
@@ -1,0 +1,71 @@
+"""Drawdown breach handling and kill-switch activation (AG-RISK-03)."""
+
+from __future__ import annotations
+
+from src.platform_api.errors import PlatformAPIError
+from src.platform_api.schemas_v1 import RequestContext
+from src.platform_api.services.risk_policy import RiskPolicyValidationError, validate_risk_policy
+from src.platform_api.state_store import InMemoryStateStore, utc_now
+
+
+class RiskKillSwitchService:
+    """Evaluates runtime drawdown and mutates kill-switch state on breaches."""
+
+    def __init__(self, *, store: InMemoryStateStore) -> None:
+        self._store = store
+
+    def evaluate_drawdown_breach(
+        self,
+        *,
+        deployment_id: str,
+        capital: float,
+        latest_pnl: float | None,
+        context: RequestContext,
+    ) -> bool:
+        policy = self._validated_policy(context=context)
+        if policy.mode != "enforced":
+            return False
+
+        kill_switch = self._store.risk_policy.get("killSwitch")
+        if not isinstance(kill_switch, dict):
+            return False
+        if not bool(kill_switch.get("enabled")):
+            return False
+        if bool(kill_switch.get("triggered")):
+            return True
+        if latest_pnl is None or capital <= 0:
+            return False
+        if latest_pnl >= 0:
+            return False
+
+        drawdown_pct = (abs(latest_pnl) / capital) * 100
+        if drawdown_pct < policy.limits.maxDrawdownPct:
+            return False
+
+        kill_switch["triggered"] = True
+        kill_switch["triggeredAt"] = utc_now()
+        kill_switch["reason"] = (
+            f"Deployment {deployment_id} drawdown {drawdown_pct:.2f}% breached limit "
+            f"{policy.limits.maxDrawdownPct:.2f}%."
+        )
+        return True
+
+    def kill_switch_reason(self) -> str | None:
+        kill_switch = self._store.risk_policy.get("killSwitch")
+        if not isinstance(kill_switch, dict):
+            return None
+        reason = kill_switch.get("reason")
+        if isinstance(reason, str) and reason.strip():
+            return reason
+        return None
+
+    def _validated_policy(self, *, context: RequestContext):
+        try:
+            return validate_risk_policy(self._store.risk_policy)
+        except RiskPolicyValidationError as exc:
+            raise PlatformAPIError(
+                status_code=500,
+                code="RISK_POLICY_INVALID",
+                message=f"Risk policy validation failed: {exc}",
+                request_id=context.request_id,
+            ) from exc

--- a/backend/tests/contracts/test_risk_killswitch_drawdown.py
+++ b/backend/tests/contracts/test_risk_killswitch_drawdown.py
@@ -1,0 +1,133 @@
+"""Contract tests for AG-RISK-03 drawdown breach and kill-switch handling."""
+
+from __future__ import annotations
+
+import asyncio
+
+from src.platform_api.errors import PlatformAPIError
+from src.platform_api.schemas_v1 import CreateOrderRequest, RequestContext
+from src.platform_api.services.execution_service import ExecutionService
+from src.platform_api.state_store import InMemoryStateStore
+
+
+class _StubExecutionAdapter:
+    def __init__(self, *, latest_pnl: float) -> None:
+        self.latest_pnl = latest_pnl
+        self.stop_calls = 0
+        self.place_order_calls = 0
+
+    async def get_deployment(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        provider_deployment_id: str,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (provider_deployment_id, tenant_id, user_id)
+        return {
+            "status": "running",
+            "latestPnl": self.latest_pnl,
+        }
+
+    async def stop_deployment(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        provider_deployment_id: str,
+        reason: str | None,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (provider_deployment_id, reason, tenant_id, user_id)
+        self.stop_calls += 1
+        return {"status": "stopping"}
+
+    async def place_order(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        symbol: str,
+        side: str,
+        order_type: str,
+        quantity: float,
+        price: float | None,
+        deployment_id: str | None,
+        tenant_id: str,
+        user_id: str,
+        idempotency_key: str,
+    ):
+        _ = (symbol, side, order_type, quantity, price, deployment_id, tenant_id, user_id, idempotency_key)
+        self.place_order_calls += 1
+        return {
+            "providerOrderId": "live-order-risk-ks-001",
+            "orderId": "ord-risk-ks-001",
+            "status": "pending",
+        }
+
+
+def _context() -> RequestContext:
+    return RequestContext(
+        request_id="req-risk-killswitch-001",
+        tenant_id="tenant-a",
+        user_id="user-a",
+    )
+
+
+def test_drawdown_breach_triggers_killswitch_and_stop_flow() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        store.risk_policy["limits"]["maxDrawdownPct"] = 5.0
+        adapter = _StubExecutionAdapter(latest_pnl=-1000.0)  # 5% drawdown on 20k capital.
+        service = ExecutionService(store=store, execution_adapter=adapter)
+
+        response = await service.get_deployment(deployment_id="dep-001", context=_context())
+        assert response.deployment.status == "stopping"
+        assert adapter.stop_calls == 1
+        assert bool(store.risk_policy["killSwitch"]["triggered"])
+        assert "dep-001" in str(store.risk_policy["killSwitch"]["reason"])
+
+    asyncio.run(_run())
+
+
+def test_non_breach_drawdown_does_not_trigger_killswitch() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        store.risk_policy["limits"]["maxDrawdownPct"] = 5.0
+        adapter = _StubExecutionAdapter(latest_pnl=-100.0)  # 0.5% drawdown on 20k capital.
+        service = ExecutionService(store=store, execution_adapter=adapter)
+
+        response = await service.get_deployment(deployment_id="dep-001", context=_context())
+        assert response.deployment.status == "running"
+        assert adapter.stop_calls == 0
+        assert not bool(store.risk_policy["killSwitch"]["triggered"])
+
+    asyncio.run(_run())
+
+
+def test_triggered_killswitch_blocks_followup_order_side_effects() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        store.risk_policy["limits"]["maxDrawdownPct"] = 5.0
+        adapter = _StubExecutionAdapter(latest_pnl=-1000.0)
+        service = ExecutionService(store=store, execution_adapter=adapter)
+
+        await service.get_deployment(deployment_id="dep-001", context=_context())
+
+        try:
+            await service.create_order(
+                request=CreateOrderRequest(
+                    symbol="BTCUSDT",
+                    side="buy",
+                    type="limit",
+                    quantity=0.1,
+                    price=64000,
+                    deploymentId="dep-001",
+                ),
+                idempotency_key="idem-risk-ks-order-001",
+                context=_context(),
+            )
+            raise AssertionError("Expected kill-switch to block follow-up order.")
+        except PlatformAPIError as exc:
+            assert exc.status_code == 423
+            assert exc.code == "RISK_KILL_SWITCH_ACTIVE"
+        assert adapter.place_order_calls == 0
+
+    asyncio.run(_run())

--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -332,6 +332,7 @@ Version and validation rules:
 5. `actionsOnBreach` is required and must contain one or more canonical breach actions.
 6. Invalid schema structure or unsupported version must fail validation.
 7. Pre-trade execution side effects (`create_deployment`, `create_order`) must pass risk checks before adapter calls.
+8. Runtime drawdown breaches (`latestPnl` vs deployment capital) must trigger kill-switch and halt active deployments before further side effects.
 
 ## 7) Compatibility Rules
 

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -338,6 +338,7 @@ Version and validation rules:
 5. `actionsOnBreach` is required and must contain one or more canonical breach actions.
 6. Invalid schema structure or unsupported version must fail validation.
 7. Pre-trade execution side effects (`create_deployment`, `create_order`) must pass risk checks before adapter calls.
+8. Runtime drawdown breaches (`latestPnl` vs deployment capital) must trigger kill-switch and halt active deployments before further side effects.
 
 ## 7) Compatibility Rules
 

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "9216896072af6ddcd9a583ee56dba0ff770ca37f4781c3dfb4b1be786700adce",
+    "chunk_hash": "9e70e76e57861ee12823d0d18a7cfcb6883a5de59bec655660c201fdfeeffe50",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "23a36d21deb04de4debb277f9c0a755318592009972d805a54a8b53afe9b2751",
+    "source_hash": "bd625c4a83ff6ab76d8599ae5350bd3ed512160611867010bb16548d843f802e",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "9216896072af6ddcd9a583ee56dba0ff770ca37f4781c3dfb4b1be786700adce",
+    "chunk_hash": "9e70e76e57861ee12823d0d18a7cfcb6883a5de59bec655660c201fdfeeffe50",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "23a36d21deb04de4debb277f9c0a755318592009972d805a54a8b53afe9b2751"
+    "source_hash": "bd625c4a83ff6ab76d8599ae5350bd3ed512160611867010bb16548d843f802e"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",

--- a/docs/portal/operations/gate4-risk-policy-controls.md
+++ b/docs/portal/operations/gate4-risk-policy-controls.md
@@ -12,7 +12,7 @@ updated: 2026-02-15
 
 ## Objective
 
-Define a machine-readable risk policy contract and enforce it before execution side effects.
+Define a machine-readable risk policy contract and enforce it before execution side effects, then halt runtime execution on drawdown breaches.
 
 ## Schema Contract
 
@@ -44,10 +44,18 @@ Pre-trade checks are mandatory gates before side effects:
 3. Triggered kill-switch blocks deployment/order side effects.
 4. Invalid or unsupported policy fails closed (no side effects).
 
+## Active Drawdown Kill-Switch Runtime Handling (AG-RISK-03)
+
+Runtime drawdown checks are enforced during deployment status refresh:
+
+1. `latestPnl` is evaluated against deployment capital and `limits.maxDrawdownPct`.
+2. Breach sets `killSwitch.triggered=true` with timestamp and breach reason.
+3. Active deployments are sent to adapter stop flow immediately after breach detection.
+4. Once triggered, pre-trade side-effecting commands remain blocked.
+
 ## Gate4 Scope Boundary
 
-- AG-RISK-01 schema + validator and AG-RISK-02 pre-trade enforcement are active.
-- Drawdown kill-switch runtime handling is in AG-RISK-03 (`#56`).
+- AG-RISK-01 schema + validator, AG-RISK-02 pre-trade enforcement, and AG-RISK-03 drawdown kill-switch handling are active.
 - Risk audit trail is in AG-RISK-04 (`#57`).
 
 ## Traceability
@@ -55,8 +63,10 @@ Pre-trade checks are mandatory gates before side effects:
 - Schema: `/contracts/schemas/risk-policy.v1.schema.json`
 - Runtime validator: `/backend/src/platform_api/services/risk_policy.py`
 - Pre-trade gate runtime: `/backend/src/platform_api/services/risk_pretrade_service.py`
+- Drawdown kill-switch runtime: `/backend/src/platform_api/services/risk_killswitch_service.py`
 - Contract tests:
   - `/backend/tests/contracts/test_risk_policy_schema.py`
   - `/backend/tests/contracts/test_risk_pretrade_checks.py`
+  - `/backend/tests/contracts/test_risk_killswitch_drawdown.py`
 - Interface definition: `/docs/architecture/INTERFACES.md`
 - Related epics/issues: `#77`, `#138`, `#106`


### PR DESCRIPTION
## Summary
- add AG-RISK-03 drawdown kill-switch runtime service (`RiskKillSwitchService`)
- enforce drawdown breach evaluation inside deployment refresh flow and stop active deployments via adapter boundary
- add contract tests for breach-triggered stop, non-breach no-op, and post-trigger side-effect blocking
- update interface and Gate4 risk controls docs, then regenerate LLM package artifacts

## Contract and boundary notes
- keeps provider side effects inside execution adapter calls only
- does not add undocumented endpoints
- preserves AG-RISK-02 pre-trade gate as the mandatory side-effect guard

## Validation
- `uv run --directory backend --with pytest python -m pytest tests/contracts/test_risk_killswitch_drawdown.py tests/contracts/test_risk_pretrade_checks.py tests/contracts/test_platform_api_v1_handlers.py tests/contracts/test_idempotency_contract_runtime.py -q`
- `npm --prefix docs/portal-site run ci`
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`

Fixes #56
Refs #77
Refs #138
Refs #106
Refs #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution runtime flow by adding automatic stop behavior during deployment refresh, which could impact live deployments if policy/config is wrong; changes are scoped and covered by contract tests.
> 
> **Overview**
> Adds **runtime drawdown enforcement (AG-RISK-03)** by introducing `RiskKillSwitchService`, which validates the configured risk policy, computes drawdown from `latestPnl` vs deployment capital, and persists kill-switch trigger metadata (`triggered`, `triggeredAt`, `reason`) on breach.
> 
> Hooks this into `ExecutionService.get_deployment` so a detected breach triggers an immediate adapter `stop_deployment` call (unless already stopping/stopped/failed), and relies on existing pre-trade gating to block subsequent side effects once the kill-switch is triggered.
> 
> Adds contract tests covering breach-triggered stop, non-breach no-op, and post-trigger order blocking, and updates interface/Gate4 risk-control docs plus regenerated LLM package hashes for traceability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7faab37a470a73f6209b70b03a94d7f3daf6a5ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements AG-RISK-03 runtime drawdown kill-switch enforcement by introducing `RiskKillSwitchService`, which evaluates `latestPnl` against deployment capital during `get_deployment` refresh flow and triggers automatic deployment stops on breach.

**Key changes:**
- New `RiskKillSwitchService` validates policy, computes drawdown percentage, and mutates kill-switch state (`triggered`, `triggeredAt`, `reason`) on breach
- `ExecutionService.get_deployment` now evaluates drawdown after fetching provider state and calls `adapter.stop_deployment` if breach detected and deployment is active
- Kill-switch blocks future side effects via existing `RiskPreTradeService._ensure_kill_switch_not_triggered` gate
- Contract tests cover breach-triggered stop, non-breach no-op, and post-trigger order blocking
- Documentation and LLM package artifacts updated with traceability hashes

<h3>Confidence Score: 4/5</h3>

- Safe to merge with attention to deployment refresh behavior and risk policy configuration
- Well-structured implementation with contract tests, but touches critical execution flow where incorrect policy configuration could trigger unwanted stops; the service correctly isolates breach logic and integrates cleanly via adapter boundary, maintaining AG-RISK-02 pre-trade gate as primary side-effect guard
- Pay attention to `backend/src/platform_api/services/execution_service.py` - deployment refresh now triggers automatic stops on drawdown breach

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/services/risk_killswitch_service.py | New service implementing drawdown breach detection and kill-switch mutation with validated risk policy checks |
| backend/src/platform_api/services/execution_service.py | Integrates kill-switch service into deployment refresh flow, triggers adapter stop on breach detection |
| backend/tests/contracts/test_risk_killswitch_drawdown.py | Contract tests covering breach-triggered stop, non-breach no-op, and post-trigger order blocking scenarios |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[GET /deployments/:id] --> B[ExecutionService.get_deployment]
    B --> C[Fetch provider state via adapter]
    C --> D[Update record.latest_pnl from provider]
    D --> E{RiskKillSwitchService.evaluate_drawdown_breach}
    E --> F{Policy mode == enforced?}
    F -->|No| M[Return deployment response]
    F -->|Yes| G{Kill-switch enabled?}
    G -->|No| M
    G -->|Yes| H{Already triggered?}
    H -->|Yes| I[Return true - breach active]
    H -->|No| J{latest_pnl < 0 AND drawdown >= maxDrawdownPct?}
    J -->|No| M
    J -->|Yes| K[Mutate killSwitch state: triggered=true, triggeredAt, reason]
    K --> I
    I --> L{Deployment status NOT in stopping/stopped/failed?}
    L -->|Yes| N[Call adapter.stop_deployment with breach reason]
    L -->|No| M
    N --> O[Update record.status to stopping]
    O --> M
    M --> P[Return deployment response]
    
    Q[POST /orders] --> R[ExecutionService.create_order]
    R --> S[RiskPreTradeService.ensure_order_allowed]
    S --> T{Kill-switch triggered?}
    T -->|Yes| U[Raise 423 RISK_KILL_SWITCH_ACTIVE]
    T -->|No| V[Proceed with adapter.place_order]
```

<sub>Last reviewed commit: 7faab37</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->