### PR TITLE
feat: AG-RISK-04 persist risk decision audit trail

### DIFF
--- a/backend/src/platform_api/services/risk_audit_service.py
+++ b/backend/src/platform_api/services/risk_audit_service.py
@@ -1,0 +1,46 @@
+"""Risk decision audit trail persistence (AG-RISK-04)."""
+
+from __future__ import annotations
+
+from src.platform_api.schemas_v1 import RequestContext
+from src.platform_api.state_store import InMemoryStateStore, RiskAuditRecord
+
+
+class RiskAuditService:
+    """Persists machine-readable allow/block decisions for risk checks."""
+
+    def __init__(self, *, store: InMemoryStateStore) -> None:
+        self._store = store
+
+    def record_decision(
+        self,
+        *,
+        decision: str,
+        check_type: str,
+        resource_type: str,
+        resource_id: str | None,
+        context: RequestContext,
+        policy_version: str | None = None,
+        policy_mode: str | None = None,
+        outcome_code: str | None = None,
+        reason: str | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> RiskAuditRecord:
+        record_id = self._store.next_id("risk_audit")
+        record = RiskAuditRecord(
+            id=record_id,
+            decision=decision,
+            check_type=check_type,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            request_id=context.request_id,
+            tenant_id=context.tenant_id,
+            user_id=context.user_id,
+            policy_version=policy_version,
+            policy_mode=policy_mode,
+            outcome_code=outcome_code,
+            reason=reason,
+            metadata=dict(metadata or {}),
+        )
+        self._store.risk_audit_trail[record.id] = record
+        return record

--- a/backend/src/platform_api/services/risk_killswitch_service.py
+++ b/backend/src/platform_api/services/risk_killswitch_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from src.platform_api.errors import PlatformAPIError
 from src.platform_api.schemas_v1 import RequestContext
+from src.platform_api.services.risk_audit_service import RiskAuditService
 from src.platform_api.services.risk_policy import RiskPolicyValidationError, validate_risk_policy
 from src.platform_api.state_store import InMemoryStateStore, utc_now
 
@@ -13,6 +14,7 @@ class RiskKillSwitchService:
 
     def __init__(self, *, store: InMemoryStateStore) -> None:
         self._store = store
+        self._risk_audit_service = RiskAuditService(store=store)
 
     def evaluate_drawdown_breach(
         self,
@@ -24,22 +26,69 @@ class RiskKillSwitchService:
     ) -> bool:
         policy = self._validated_policy(context=context)
         if policy.mode != "enforced":
+            self._record_approved(
+                deployment_id=deployment_id,
+                context=context,
+                policy_version=policy.version,
+                policy_mode=policy.mode,
+                metadata={"reason": "advisory_mode", "latestPnl": latest_pnl, "capital": capital},
+            )
             return False
 
         kill_switch = self._store.risk_policy.get("killSwitch")
-        if not isinstance(kill_switch, dict):
-            return False
-        if not bool(kill_switch.get("enabled")):
+        if not isinstance(kill_switch, dict) or not bool(kill_switch.get("enabled")):
+            self._record_approved(
+                deployment_id=deployment_id,
+                context=context,
+                policy_version=policy.version,
+                policy_mode=policy.mode,
+                metadata={"reason": "kill_switch_disabled", "latestPnl": latest_pnl, "capital": capital},
+            )
             return False
         if bool(kill_switch.get("triggered")):
+            self._record_blocked(
+                deployment_id=deployment_id,
+                context=context,
+                policy_version=policy.version,
+                policy_mode=policy.mode,
+                outcome_code="RISK_KILL_SWITCH_ACTIVE",
+                reason="Kill-switch already active from prior risk breach.",
+                metadata={"latestPnl": latest_pnl, "capital": capital},
+            )
             return True
         if latest_pnl is None or capital <= 0:
+            self._record_approved(
+                deployment_id=deployment_id,
+                context=context,
+                policy_version=policy.version,
+                policy_mode=policy.mode,
+                metadata={"reason": "insufficient_runtime_data", "latestPnl": latest_pnl, "capital": capital},
+            )
             return False
         if latest_pnl >= 0:
+            self._record_approved(
+                deployment_id=deployment_id,
+                context=context,
+                policy_version=policy.version,
+                policy_mode=policy.mode,
+                metadata={"reason": "non_negative_pnl", "latestPnl": latest_pnl, "capital": capital},
+            )
             return False
 
         drawdown_pct = (abs(latest_pnl) / capital) * 100
         if drawdown_pct < policy.limits.maxDrawdownPct:
+            self._record_approved(
+                deployment_id=deployment_id,
+                context=context,
+                policy_version=policy.version,
+                policy_mode=policy.mode,
+                metadata={
+                    "drawdownPct": drawdown_pct,
+                    "limitPct": policy.limits.maxDrawdownPct,
+                    "latestPnl": latest_pnl,
+                    "capital": capital,
+                },
+            )
             return False
 
         kill_switch["triggered"] = True
@@ -47,6 +96,20 @@ class RiskKillSwitchService:
         kill_switch["reason"] = (
             f"Deployment {deployment_id} drawdown {drawdown_pct:.2f}% breached limit "
             f"{policy.limits.maxDrawdownPct:.2f}%."
+        )
+        self._record_blocked(
+            deployment_id=deployment_id,
+            context=context,
+            policy_version=policy.version,
+            policy_mode=policy.mode,
+            outcome_code="RISK_DRAWDOWN_BREACH",
+            reason=str(kill_switch["reason"]),
+            metadata={
+                "drawdownPct": drawdown_pct,
+                "limitPct": policy.limits.maxDrawdownPct,
+                "latestPnl": latest_pnl,
+                "capital": capital,
+            },
         )
         return True
 
@@ -63,9 +126,70 @@ class RiskKillSwitchService:
         try:
             return validate_risk_policy(self._store.risk_policy)
         except RiskPolicyValidationError as exc:
+            self._record_invalid_policy(context=context, reason=str(exc))
             raise PlatformAPIError(
                 status_code=500,
                 code="RISK_POLICY_INVALID",
                 message=f"Risk policy validation failed: {exc}",
                 request_id=context.request_id,
             ) from exc
+
+    def _record_approved(
+        self,
+        *,
+        deployment_id: str,
+        context: RequestContext,
+        policy_version: str | None,
+        policy_mode: str | None,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        self._risk_audit_service.record_decision(
+            decision="approved",
+            check_type="runtime_drawdown",
+            resource_type="deployment",
+            resource_id=deployment_id,
+            context=context,
+            policy_version=policy_version,
+            policy_mode=policy_mode,
+            metadata=metadata,
+        )
+
+    def _record_blocked(
+        self,
+        *,
+        deployment_id: str,
+        context: RequestContext,
+        policy_version: str | None,
+        policy_mode: str | None,
+        outcome_code: str,
+        reason: str,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        self._risk_audit_service.record_decision(
+            decision="blocked",
+            check_type="runtime_drawdown",
+            resource_type="deployment",
+            resource_id=deployment_id,
+            context=context,
+            policy_version=policy_version,
+            policy_mode=policy_mode,
+            outcome_code=outcome_code,
+            reason=reason,
+            metadata=metadata,
+        )
+
+    def _record_invalid_policy(self, *, context: RequestContext, reason: str) -> None:
+        policy = self._store.risk_policy
+        version = policy.get("version") if isinstance(policy, dict) else None
+        mode = policy.get("mode") if isinstance(policy, dict) else None
+        self._risk_audit_service.record_decision(
+            decision="blocked",
+            check_type="runtime_drawdown",
+            resource_type="deployment",
+            resource_id=None,
+            context=context,
+            policy_version=version if isinstance(version, str) else None,
+            policy_mode=mode if isinstance(mode, str) else None,
+            outcome_code="RISK_POLICY_INVALID",
+            reason=reason,
+        )

--- a/backend/src/platform_api/services/risk_pretrade_service.py
+++ b/backend/src/platform_api/services/risk_pretrade_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from src.platform_api.errors import PlatformAPIError
 from src.platform_api.schemas_v1 import CreateDeploymentRequest, CreateOrderRequest, RequestContext
+from src.platform_api.services.risk_audit_service import RiskAuditService
 from src.platform_api.services.risk_policy import RiskPolicyValidationError, validate_risk_policy
 from src.platform_api.state_store import InMemoryStateStore
 
@@ -15,6 +16,7 @@ class RiskPreTradeService:
 
     def __init__(self, *, store: InMemoryStateStore) -> None:
         self._store = store
+        self._risk_audit_service = RiskAuditService(store=store)
 
     def ensure_deployment_allowed(
         self,
@@ -22,34 +24,69 @@ class RiskPreTradeService:
         request: CreateDeploymentRequest,
         context: RequestContext,
     ) -> None:
-        policy = self._validated_policy(context=context)
-        if policy.mode == "advisory":
-            return
-        self._ensure_kill_switch_not_triggered(context=context)
+        try:
+            policy = self._validated_policy(context=context)
+            if policy.mode == "advisory":
+                self._record_allow(
+                    check_type="pretrade_deployment",
+                    resource_type="deployment",
+                    resource_id=request.strategyId,
+                    context=context,
+                    policy_version=policy.version,
+                    policy_mode=policy.mode,
+                    metadata={"capital": request.capital, "mode": request.mode, "reason": "advisory_mode"},
+                )
+                return
+            self._ensure_kill_switch_not_triggered(context=context)
 
-        active_deployment_capital = sum(
-            deployment.capital
-            for deployment in self._store.deployments.values()
-            if deployment.status in _ACTIVE_DEPLOYMENT_STATES
-        )
-        projected_total = active_deployment_capital + request.capital
+            active_deployment_capital = sum(
+                deployment.capital
+                for deployment in self._store.deployments.values()
+                if deployment.status in _ACTIVE_DEPLOYMENT_STATES
+            )
+            projected_total = active_deployment_capital + request.capital
 
-        if request.capital > policy.limits.maxNotionalUsd:
-            raise self._limit_breach(
+            if request.capital > policy.limits.maxNotionalUsd:
+                raise self._limit_breach(
+                    context=context,
+                    message=(
+                        "Deployment capital exceeds risk maxNotionalUsd "
+                        f"({request.capital} > {policy.limits.maxNotionalUsd})."
+                    ),
+                )
+            if projected_total > policy.limits.maxNotionalUsd:
+                raise self._limit_breach(
+                    context=context,
+                    message=(
+                        "Projected active deployment capital exceeds risk maxNotionalUsd "
+                        f"({projected_total} > {policy.limits.maxNotionalUsd})."
+                    ),
+                )
+
+            self._record_allow(
+                check_type="pretrade_deployment",
+                resource_type="deployment",
+                resource_id=request.strategyId,
                 context=context,
-                message=(
-                    "Deployment capital exceeds risk maxNotionalUsd "
-                    f"({request.capital} > {policy.limits.maxNotionalUsd})."
-                ),
+                policy_version=policy.version,
+                policy_mode=policy.mode,
+                metadata={
+                    "capital": request.capital,
+                    "mode": request.mode,
+                    "projectedCapital": projected_total,
+                },
             )
-        if projected_total > policy.limits.maxNotionalUsd:
-            raise self._limit_breach(
+        except PlatformAPIError as exc:
+            self._record_block(
+                check_type="pretrade_deployment",
+                resource_type="deployment",
+                resource_id=request.strategyId,
                 context=context,
-                message=(
-                    "Projected active deployment capital exceeds risk maxNotionalUsd "
-                    f"({projected_total} > {policy.limits.maxNotionalUsd})."
-                ),
+                outcome_code=exc.code,
+                reason=exc.message,
+                metadata={"capital": request.capital, "mode": request.mode},
             )
+            raise
 
     def ensure_order_allowed(
         self,
@@ -57,83 +94,132 @@ class RiskPreTradeService:
         request: CreateOrderRequest,
         context: RequestContext,
     ) -> None:
-        policy = self._validated_policy(context=context)
-        if policy.mode == "advisory":
-            return
-        self._ensure_kill_switch_not_triggered(context=context)
+        try:
+            policy = self._validated_policy(context=context)
+            if policy.mode == "advisory":
+                self._record_allow(
+                    check_type="pretrade_order",
+                    resource_type="order",
+                    resource_id=request.deploymentId,
+                    context=context,
+                    policy_version=policy.version,
+                    policy_mode=policy.mode,
+                    metadata={
+                        "symbol": request.symbol,
+                        "side": request.side,
+                        "quantity": request.quantity,
+                        "reason": "advisory_mode",
+                    },
+                )
+                return
+            self._ensure_kill_switch_not_triggered(context=context)
 
-        reference_price = self._resolve_reference_price(request=request)
-        if reference_price is None:
-            raise PlatformAPIError(
-                status_code=422,
-                code="RISK_REFERENCE_PRICE_REQUIRED",
-                message=(
-                    "Market order risk checks require a reference price; provide a limit price "
-                    "or ensure symbol context is available."
-                ),
-                request_id=context.request_id,
-            )
-        order_notional = request.quantity * reference_price
+            reference_price = self._resolve_reference_price(request=request)
+            if reference_price is None:
+                raise PlatformAPIError(
+                    status_code=422,
+                    code="RISK_REFERENCE_PRICE_REQUIRED",
+                    message=(
+                        "Market order risk checks require a reference price; provide a limit price "
+                        "or ensure symbol context is available."
+                    ),
+                    request_id=context.request_id,
+                )
+            order_notional = request.quantity * reference_price
 
-        existing_symbol_notional = 0.0
-        for portfolio in self._store.portfolios.values():
-            for position in portfolio.positions:
-                if position.symbol == request.symbol:
-                    existing_symbol_notional += abs(position.quantity * position.current_price)
+            existing_symbol_notional = 0.0
+            for portfolio in self._store.portfolios.values():
+                for position in portfolio.positions:
+                    if position.symbol == request.symbol:
+                        existing_symbol_notional += abs(position.quantity * position.current_price)
 
-        if request.side == "sell":
-            projected_symbol_notional = max(0.0, existing_symbol_notional - order_notional)
-        else:
-            projected_symbol_notional = existing_symbol_notional + order_notional
+            if request.side == "sell":
+                projected_symbol_notional = max(0.0, existing_symbol_notional - order_notional)
+            else:
+                projected_symbol_notional = existing_symbol_notional + order_notional
 
-        if projected_symbol_notional > policy.limits.maxPositionNotionalUsd:
-            raise self._limit_breach(
+            if projected_symbol_notional > policy.limits.maxPositionNotionalUsd:
+                raise self._limit_breach(
+                    context=context,
+                    message=(
+                        "Projected symbol notional exceeds risk maxPositionNotionalUsd "
+                        f"({projected_symbol_notional} > {policy.limits.maxPositionNotionalUsd})."
+                    ),
+                )
+
+            if order_notional > policy.limits.maxNotionalUsd:
+                raise self._limit_breach(
+                    context=context,
+                    message=(
+                        "Order notional exceeds risk maxNotionalUsd "
+                        f"({order_notional} > {policy.limits.maxNotionalUsd})."
+                    ),
+                )
+
+            estimated_portfolio_notional = 0.0
+            for portfolio in self._store.portfolios.values():
+                for position in portfolio.positions:
+                    estimated_portfolio_notional += abs(position.quantity * position.current_price)
+
+            if request.side == "sell":
+                projected_notional = max(0.0, estimated_portfolio_notional - order_notional)
+            else:
+                projected_notional = estimated_portfolio_notional + order_notional
+            if projected_notional > policy.limits.maxNotionalUsd:
+                raise self._limit_breach(
+                    context=context,
+                    message=(
+                        "Projected total notional exceeds risk maxNotionalUsd "
+                        f"({projected_notional} > {policy.limits.maxNotionalUsd})."
+                    ),
+                )
+
+            current_daily_loss = 0.0
+            for portfolio in self._store.portfolios.values():
+                if portfolio.pnl_total is not None and portfolio.pnl_total < 0:
+                    current_daily_loss += abs(portfolio.pnl_total)
+            if current_daily_loss >= policy.limits.maxDailyLossUsd:
+                raise self._limit_breach(
+                    context=context,
+                    message=(
+                        "Daily loss limit reached; new orders are blocked "
+                        f"({current_daily_loss} >= {policy.limits.maxDailyLossUsd})."
+                    ),
+                )
+
+            self._record_allow(
+                check_type="pretrade_order",
+                resource_type="order",
+                resource_id=request.deploymentId,
                 context=context,
-                message=(
-                    "Projected symbol notional exceeds risk maxPositionNotionalUsd "
-                    f"({projected_symbol_notional} > {policy.limits.maxPositionNotionalUsd})."
-                ),
+                policy_version=policy.version,
+                policy_mode=policy.mode,
+                metadata={
+                    "symbol": request.symbol,
+                    "side": request.side,
+                    "quantity": request.quantity,
+                    "referencePrice": reference_price,
+                    "orderNotional": order_notional,
+                    "projectedSymbolNotional": projected_symbol_notional,
+                    "projectedTotalNotional": projected_notional,
+                },
             )
-
-        if order_notional > policy.limits.maxNotionalUsd:
-            raise self._limit_breach(
+        except PlatformAPIError as exc:
+            self._record_block(
+                check_type="pretrade_order",
+                resource_type="order",
+                resource_id=request.deploymentId,
                 context=context,
-                message=(
-                    "Order notional exceeds risk maxNotionalUsd "
-                    f"({order_notional} > {policy.limits.maxNotionalUsd})."
-                ),
+                outcome_code=exc.code,
+                reason=exc.message,
+                metadata={
+                    "symbol": request.symbol,
+                    "side": request.side,
+                    "quantity": request.quantity,
+                    "price": request.price,
+                },
             )
-
-        estimated_portfolio_notional = 0.0
-        for portfolio in self._store.portfolios.values():
-            for position in portfolio.positions:
-                estimated_portfolio_notional += abs(position.quantity * position.current_price)
-
-        if request.side == "sell":
-            projected_notional = max(0.0, estimated_portfolio_notional - order_notional)
-        else:
-            projected_notional = estimated_portfolio_notional + order_notional
-        if projected_notional > policy.limits.maxNotionalUsd:
-            raise self._limit_breach(
-                context=context,
-                message=(
-                    "Projected total notional exceeds risk maxNotionalUsd "
-                    f"({projected_notional} > {policy.limits.maxNotionalUsd})."
-                ),
-            )
-
-        current_daily_loss = 0.0
-        for portfolio in self._store.portfolios.values():
-            if portfolio.pnl_total is not None and portfolio.pnl_total < 0:
-                current_daily_loss += abs(portfolio.pnl_total)
-        if current_daily_loss >= policy.limits.maxDailyLossUsd:
-            raise self._limit_breach(
-                context=context,
-                message=(
-                    "Daily loss limit reached; new orders are blocked "
-                    f"({current_daily_loss} >= {policy.limits.maxDailyLossUsd})."
-                ),
-            )
+            raise
 
     def _validated_policy(self, *, context: RequestContext):
         try:
@@ -179,3 +265,52 @@ class RiskPreTradeService:
                 if position.symbol == request.symbol:
                     return position.current_price
         return None
+
+    def _record_allow(
+        self,
+        *,
+        check_type: str,
+        resource_type: str,
+        resource_id: str | None,
+        context: RequestContext,
+        policy_version: str | None,
+        policy_mode: str | None,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        self._risk_audit_service.record_decision(
+            decision="approved",
+            check_type=check_type,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            context=context,
+            policy_version=policy_version,
+            policy_mode=policy_mode,
+            metadata=metadata,
+        )
+
+    def _record_block(
+        self,
+        *,
+        check_type: str,
+        resource_type: str,
+        resource_id: str | None,
+        context: RequestContext,
+        outcome_code: str,
+        reason: str,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        policy = self._store.risk_policy
+        policy_version = policy.get("version") if isinstance(policy, dict) else None
+        policy_mode = policy.get("mode") if isinstance(policy, dict) else None
+        self._risk_audit_service.record_decision(
+            decision="blocked",
+            check_type=check_type,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            context=context,
+            policy_version=policy_version if isinstance(policy_version, str) else None,
+            policy_mode=policy_mode if isinstance(policy_mode, str) else None,
+            outcome_code=outcome_code,
+            reason=reason,
+            metadata=metadata,
+        )

--- a/backend/src/platform_api/state_store.py
+++ b/backend/src/platform_api/state_store.py
@@ -145,6 +145,24 @@ class DriftEventRecord:
 
 
 @dataclass
+class RiskAuditRecord:
+    id: str
+    decision: str
+    check_type: str
+    resource_type: str
+    resource_id: str | None
+    request_id: str
+    tenant_id: str
+    user_id: str
+    policy_version: str | None = None
+    policy_mode: str | None = None
+    outcome_code: str | None = None
+    reason: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str = field(default_factory=utc_now)
+
+
+@dataclass
 class ConversationSessionRecord:
     id: str
     channel: str
@@ -277,6 +295,7 @@ class InMemoryStateStore:
         self.knowledge_ingestion_events: set[str] = set()
         self.data_exports: dict[str, DataExportRecord] = {}
         self.drift_events: dict[str, DriftEventRecord] = {}
+        self.risk_audit_trail: dict[str, RiskAuditRecord] = {}
         self.conversation_sessions: dict[str, ConversationSessionRecord] = {}
         self.conversation_turns: dict[str, list[ConversationTurnRecord]] = {}
         self.risk_policy: dict[str, Any] = {
@@ -313,6 +332,7 @@ class InMemoryStateStore:
             "knowledge_corr": 1,
             "export": 1,
             "drift": 1,
+            "risk_audit": 1,
             "conversation_session": 1,
             "conversation_turn": 1,
         }
@@ -348,6 +368,8 @@ class InMemoryStateStore:
             return f"exp-{idx:04d}"
         if scope == "drift":
             return f"drift-{idx:04d}"
+        if scope == "risk_audit":
+            return f"risk-audit-{idx:04d}"
         if scope == "conversation_session":
             return f"conv-{idx:04d}"
         if scope == "conversation_turn":

--- a/backend/tests/contracts/test_risk_audit_trail.py
+++ b/backend/tests/contracts/test_risk_audit_trail.py
@@ -1,0 +1,193 @@
+"""Contract tests for AG-RISK-04 risk decision audit persistence."""
+
+from __future__ import annotations
+
+import asyncio
+
+from src.platform_api.errors import PlatformAPIError
+from src.platform_api.schemas_v1 import CreateOrderRequest, RequestContext
+from src.platform_api.services.execution_service import ExecutionService
+from src.platform_api.state_store import InMemoryStateStore, RiskAuditRecord
+
+
+class _StubExecutionAdapter:
+    def __init__(self, *, latest_pnl: float = -100.0) -> None:
+        self.latest_pnl = latest_pnl
+        self.place_order_calls = 0
+        self.stop_calls = 0
+
+    async def place_order(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        symbol: str,
+        side: str,
+        order_type: str,
+        quantity: float,
+        price: float | None,
+        deployment_id: str | None,
+        tenant_id: str,
+        user_id: str,
+        idempotency_key: str,
+    ):
+        _ = (symbol, side, order_type, quantity, price, deployment_id, tenant_id, user_id, idempotency_key)
+        self.place_order_calls += 1
+        return {
+            "providerOrderId": "live-order-risk-audit-001",
+            "orderId": "ord-risk-audit-001",
+            "status": "pending",
+        }
+
+    async def get_deployment(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        provider_deployment_id: str,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (provider_deployment_id, tenant_id, user_id)
+        return {
+            "status": "running",
+            "latestPnl": self.latest_pnl,
+        }
+
+    async def stop_deployment(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        provider_deployment_id: str,
+        reason: str | None,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (provider_deployment_id, reason, tenant_id, user_id)
+        self.stop_calls += 1
+        return {"status": "stopping"}
+
+
+def _context() -> RequestContext:
+    return RequestContext(
+        request_id="req-risk-audit-001",
+        tenant_id="tenant-a",
+        user_id="user-a",
+    )
+
+
+def _latest_audit_record(store: InMemoryStateStore) -> RiskAuditRecord:
+    assert store.risk_audit_trail
+    return list(store.risk_audit_trail.values())[-1]
+
+
+def test_risk_audit_records_blocked_pretrade_decision() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        store.risk_policy["killSwitch"] = {"enabled": True, "triggered": True}
+        adapter = _StubExecutionAdapter()
+        service = ExecutionService(store=store, execution_adapter=adapter)
+
+        try:
+            await service.create_order(
+                request=CreateOrderRequest(
+                    symbol="BTCUSDT",
+                    side="buy",
+                    type="limit",
+                    quantity=0.1,
+                    price=64000,
+                    deploymentId="dep-001",
+                ),
+                idempotency_key="idem-risk-audit-001",
+                context=_context(),
+            )
+            raise AssertionError("Expected risk gate to block order.")
+        except PlatformAPIError as exc:
+            assert exc.code == "RISK_KILL_SWITCH_ACTIVE"
+
+        record = _latest_audit_record(store)
+        assert record.decision == "blocked"
+        assert record.check_type == "pretrade_order"
+        assert record.outcome_code == "RISK_KILL_SWITCH_ACTIVE"
+        assert record.request_id == "req-risk-audit-001"
+        assert adapter.place_order_calls == 0
+
+    asyncio.run(_run())
+
+
+def test_risk_audit_records_approved_pretrade_decision() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        store.risk_policy["limits"]["maxNotionalUsd"] = 2_000_000
+        store.risk_policy["limits"]["maxPositionNotionalUsd"] = 500_000
+        adapter = _StubExecutionAdapter()
+        service = ExecutionService(store=store, execution_adapter=adapter)
+
+        await service.create_order(
+            request=CreateOrderRequest(
+                symbol="BTCUSDT",
+                side="buy",
+                type="limit",
+                quantity=0.05,
+                price=64000,
+                deploymentId="dep-001",
+            ),
+            idempotency_key="idem-risk-audit-002",
+            context=_context(),
+        )
+
+        record = _latest_audit_record(store)
+        assert record.decision == "approved"
+        assert record.check_type == "pretrade_order"
+        assert record.outcome_code is None
+        assert adapter.place_order_calls == 1
+
+    asyncio.run(_run())
+
+
+def test_risk_audit_records_runtime_drawdown_breach() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        store.risk_policy["limits"]["maxDrawdownPct"] = 5.0
+        adapter = _StubExecutionAdapter(latest_pnl=-1000.0)
+        service = ExecutionService(store=store, execution_adapter=adapter)
+
+        response = await service.get_deployment(deployment_id="dep-001", context=_context())
+        assert response.deployment.status == "stopping"
+
+        record = _latest_audit_record(store)
+        assert record.decision == "blocked"
+        assert record.check_type == "runtime_drawdown"
+        assert record.outcome_code == "RISK_DRAWDOWN_BREACH"
+        assert record.resource_id == "dep-001"
+        assert adapter.stop_calls == 1
+
+    asyncio.run(_run())
+
+
+def test_risk_audit_records_policy_validation_fail_closed() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        store.risk_policy["version"] = "risk-policy.v2"
+        adapter = _StubExecutionAdapter()
+        service = ExecutionService(store=store, execution_adapter=adapter)
+
+        try:
+            await service.create_order(
+                request=CreateOrderRequest(
+                    symbol="BTCUSDT",
+                    side="buy",
+                    type="limit",
+                    quantity=0.05,
+                    price=63000,
+                    deploymentId="dep-001",
+                ),
+                idempotency_key="idem-risk-audit-003",
+                context=_context(),
+            )
+            raise AssertionError("Expected invalid risk policy to fail closed.")
+        except PlatformAPIError as exc:
+            assert exc.code == "RISK_POLICY_INVALID"
+
+        record = _latest_audit_record(store)
+        assert record.decision == "blocked"
+        assert record.check_type == "pretrade_order"
+        assert record.outcome_code == "RISK_POLICY_INVALID"
+        assert adapter.place_order_calls == 0
+
+    asyncio.run(_run())

--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -333,6 +333,7 @@ Version and validation rules:
 6. Invalid schema structure or unsupported version must fail validation.
 7. Pre-trade execution side effects (`create_deployment`, `create_order`) must pass risk checks before adapter calls.
 8. Runtime drawdown breaches (`latestPnl` vs deployment capital) must trigger kill-switch and halt active deployments before further side effects.
+9. Every risk decision path (`approved` and `blocked`) must persist an audit record with request identity and outcome metadata.
 
 ## 7) Compatibility Rules
 

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -339,6 +339,7 @@ Version and validation rules:
 6. Invalid schema structure or unsupported version must fail validation.
 7. Pre-trade execution side effects (`create_deployment`, `create_order`) must pass risk checks before adapter calls.
 8. Runtime drawdown breaches (`latestPnl` vs deployment capital) must trigger kill-switch and halt active deployments before further side effects.
+9. Every risk decision path (`approved` and `blocked`) must persist an audit record with request identity and outcome metadata.
 
 ## 7) Compatibility Rules
 

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "9e70e76e57861ee12823d0d18a7cfcb6883a5de59bec655660c201fdfeeffe50",
+    "chunk_hash": "c70518b74d216f78e939bbae7e7fd3e30d7139e98bcf813b3321692ee45a0a01",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "bd625c4a83ff6ab76d8599ae5350bd3ed512160611867010bb16548d843f802e",
+    "source_hash": "8cf44bfdca9685379d938d33b7eb20d46aa1babcbce37c7157ed6bc372ffe226",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "9e70e76e57861ee12823d0d18a7cfcb6883a5de59bec655660c201fdfeeffe50",
+    "chunk_hash": "c70518b74d216f78e939bbae7e7fd3e30d7139e98bcf813b3321692ee45a0a01",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "bd625c4a83ff6ab76d8599ae5350bd3ed512160611867010bb16548d843f802e"
+    "source_hash": "8cf44bfdca9685379d938d33b7eb20d46aa1babcbce37c7157ed6bc372ffe226"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",

--- a/docs/portal/operations/gate4-risk-policy-controls.md
+++ b/docs/portal/operations/gate4-risk-policy-controls.md
@@ -53,10 +53,18 @@ Runtime drawdown checks are enforced during deployment status refresh:
 3. Active deployments are sent to adapter stop flow immediately after breach detection.
 4. Once triggered, pre-trade side-effecting commands remain blocked.
 
+## Active Risk Audit Trail (AG-RISK-04)
+
+Risk decisions now persist to runtime audit storage for both allow and block outcomes:
+
+1. Pre-trade deployment and order checks record `approved`/`blocked` decisions.
+2. Runtime drawdown checks record approval decisions and breach-triggered blocks.
+3. Records include request identity (`request_id`, `tenant_id`, `user_id`), policy version/mode, and outcome code.
+4. Invalid policy/version paths fail closed and emit blocked audit records.
+
 ## Gate4 Scope Boundary
 
-- AG-RISK-01 schema + validator, AG-RISK-02 pre-trade enforcement, and AG-RISK-03 drawdown kill-switch handling are active.
-- Risk audit trail is in AG-RISK-04 (`#57`).
+- AG-RISK-01 schema + validator, AG-RISK-02 pre-trade enforcement, AG-RISK-03 drawdown kill-switch handling, and AG-RISK-04 risk audit trail are active.
 
 ## Traceability
 
@@ -64,9 +72,11 @@ Runtime drawdown checks are enforced during deployment status refresh:
 - Runtime validator: `/backend/src/platform_api/services/risk_policy.py`
 - Pre-trade gate runtime: `/backend/src/platform_api/services/risk_pretrade_service.py`
 - Drawdown kill-switch runtime: `/backend/src/platform_api/services/risk_killswitch_service.py`
+- Risk audit runtime: `/backend/src/platform_api/services/risk_audit_service.py`
 - Contract tests:
   - `/backend/tests/contracts/test_risk_policy_schema.py`
   - `/backend/tests/contracts/test_risk_pretrade_checks.py`
   - `/backend/tests/contracts/test_risk_killswitch_drawdown.py`
+  - `/backend/tests/contracts/test_risk_audit_trail.py`
 - Interface definition: `/docs/architecture/INTERFACES.md`
 - Related epics/issues: `#77`, `#138`, `#106`


### PR DESCRIPTION
## Summary
- add `RiskAuditService` and `RiskAuditRecord` persistence model to capture risk decision outcomes
- record `approved` and `blocked` decisions for:
  - pre-trade deployment checks
  - pre-trade order checks
  - runtime drawdown kill-switch checks
- include request identity (`request_id`, `tenant_id`, `user_id`), policy metadata, outcome codes, and reason fields
- add contract tests asserting audit records are persisted on allow/block/fail-closed paths
- update interface + Gate4 risk controls portal docs and regenerate LLM package artifacts

## Validation
- `uv run --directory backend --with pytest python -m pytest tests/contracts/test_risk_audit_trail.py tests/contracts/test_risk_pretrade_checks.py tests/contracts/test_risk_killswitch_drawdown.py tests/contracts/test_platform_api_v1_handlers.py tests/contracts/test_idempotency_contract_runtime.py -q`
- `npm --prefix docs/portal-site run ci`
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`

Fixes #57
Refs #77
Refs #138
Refs #106
Refs #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core risk-gating code paths and adds new side-effectful persistence on both success and error paths; while in-memory only, mistakes could affect enforcement flow or error handling.
> 
> **Overview**
> **Adds AG-RISK-04 risk decision auditing.** Introduces `RiskAuditService` + `RiskAuditRecord` and stores records in `InMemoryStateStore.risk_audit_trail` with generated `risk-audit-*` IDs.
> 
> Updates pre-trade (`RiskPreTradeService`) and runtime drawdown kill-switch (`RiskKillSwitchService`) paths to **record `approved`/`blocked` decisions** (including advisory-mode approvals), capturing request identity, policy version/mode, outcome codes, reasons, and decision metadata; invalid policy validation now also emits a blocked audit record.
> 
> Adds contract coverage in `test_risk_audit_trail.py` for allow, block (kill-switch active), drawdown breach, and fail-closed invalid-policy scenarios, and updates interface/portal docs plus regenerated LLM package hashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 773b6f04b4011ea42e730cc13e6d939035550765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements AG-RISK-04 risk decision audit trail by adding `RiskAuditService` and `RiskAuditRecord` persistence. The PR integrates audit recording into pre-trade risk checks (`RiskPreTradeService`) and runtime drawdown kill-switch enforcement (`RiskKillSwitchService`), capturing both `approved` and `blocked` decisions with request identity, policy metadata, outcome codes, and reasons.

- Added new `RiskAuditService` with `record_decision` method to persist audit records
- Introduced `RiskAuditRecord` dataclass with comprehensive fields for audit tracking
- Updated `risk_pretrade_service.py` to record decisions for deployment and order checks in both success and error paths
- Updated `risk_killswitch_service.py` to record decisions for runtime drawdown checks including advisory mode, kill-switch disabled, and breach scenarios
- Added contract tests in `test_risk_audit_trail.py` covering blocked pre-trade, approved pre-trade, runtime drawdown breach, and fail-closed invalid policy scenarios
- Updated documentation to reflect new audit trail requirements

<h3>Confidence Score: 4/5</h3>

- Safe to merge with good test coverage, though affects critical risk enforcement paths
- Well-structured implementation with comprehensive contract tests covering success/failure paths. The audit recording is side-effectful but non-blocking (in-memory only). The integration into try-catch blocks ensures audit records are created even on errors. Confidence reduced slightly because this touches critical risk enforcement code paths where mistakes could affect system behavior.
- Pay close attention to `risk_pretrade_service.py` and `risk_killswitch_service.py` where audit recording is integrated into error handling flows

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/services/risk_audit_service.py | New service added to persist risk decision audit records with all required fields |
| backend/src/platform_api/state_store.py | Added `RiskAuditRecord` dataclass and `risk_audit_trail` storage with ID counter |
| backend/src/platform_api/services/risk_pretrade_service.py | Integrated audit recording in both success/error paths for deployments and orders |
| backend/src/platform_api/services/risk_killswitch_service.py | Added audit recording for approved/blocked runtime drawdown decisions and invalid policy |
| backend/tests/contracts/test_risk_audit_trail.py | Comprehensive contract tests covering blocked, approved, drawdown breach, and fail-closed scenarios |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant PreTradeService
    participant KillSwitchService
    participant RiskAuditService
    participant StateStore

    Note over Client,StateStore: Pre-Trade Risk Check Flow

    Client->>PreTradeService: ensure_order_allowed(request, context)
    PreTradeService->>PreTradeService: validate_policy()
    
    alt Policy Valid & Limits OK
        PreTradeService->>RiskAuditService: record_decision(decision="approved")
        RiskAuditService->>StateStore: persist RiskAuditRecord
        StateStore-->>RiskAuditService: risk-audit-NNNN
        PreTradeService-->>Client: ✓ Order Allowed
    else Limit Breach or Kill-Switch Active
        PreTradeService->>RiskAuditService: record_decision(decision="blocked")
        RiskAuditService->>StateStore: persist RiskAuditRecord
        StateStore-->>RiskAuditService: risk-audit-NNNN
        PreTradeService-->>Client: ✗ PlatformAPIError
    end

    Note over Client,StateStore: Runtime Drawdown Check Flow

    Client->>KillSwitchService: evaluate_drawdown_breach(deployment_id, pnl, capital)
    KillSwitchService->>KillSwitchService: validate_policy()
    KillSwitchService->>KillSwitchService: calculate drawdown_pct
    
    alt Drawdown Within Limits
        KillSwitchService->>RiskAuditService: record_decision(decision="approved")
        RiskAuditService->>StateStore: persist RiskAuditRecord
        KillSwitchService-->>Client: false (no breach)
    else Drawdown Breach
        KillSwitchService->>StateStore: set killSwitch.triggered=true
        KillSwitchService->>RiskAuditService: record_decision(decision="blocked")
        RiskAuditService->>StateStore: persist RiskAuditRecord
        KillSwitchService-->>Client: true (breach detected)
    end
```

<sub>Last reviewed commit: 773b6f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->