### PR TITLE
feat: AG-EXE-01 execution command layer via adapter

### DIFF
--- a/backend/src/platform_api/services/execution_command_service.py
+++ b/backend/src/platform_api/services/execution_command_service.py
@@ -1,0 +1,91 @@
+"""Execution command layer enforcing adapter-only side effects (AG-EXE-01)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.platform_api.adapters.execution_adapter import ExecutionAdapter
+
+
+@dataclass(frozen=True)
+class CreateDeploymentCommand:
+    strategy_id: str
+    mode: str
+    capital: float
+    tenant_id: str
+    user_id: str
+    idempotency_key: str
+
+
+@dataclass(frozen=True)
+class StopDeploymentCommand:
+    provider_deployment_id: str
+    reason: str | None
+    tenant_id: str
+    user_id: str
+
+
+@dataclass(frozen=True)
+class PlaceOrderCommand:
+    symbol: str
+    side: str
+    order_type: str
+    quantity: float
+    price: float | None
+    deployment_id: str | None
+    tenant_id: str
+    user_id: str
+    idempotency_key: str
+
+
+@dataclass(frozen=True)
+class CancelOrderCommand:
+    provider_order_id: str
+    tenant_id: str
+    user_id: str
+
+
+class ExecutionCommandService:
+    """Executes side-effecting commands exclusively through ExecutionAdapter."""
+
+    def __init__(self, *, execution_adapter: ExecutionAdapter) -> None:
+        self._execution_adapter = execution_adapter
+
+    async def create_deployment(self, *, command: CreateDeploymentCommand) -> dict[str, Any]:
+        return await self._execution_adapter.create_deployment(
+            strategy_id=command.strategy_id,
+            mode=command.mode,
+            capital=command.capital,
+            tenant_id=command.tenant_id,
+            user_id=command.user_id,
+            idempotency_key=command.idempotency_key,
+        )
+
+    async def stop_deployment(self, *, command: StopDeploymentCommand) -> dict[str, Any]:
+        return await self._execution_adapter.stop_deployment(
+            provider_deployment_id=command.provider_deployment_id,
+            reason=command.reason,
+            tenant_id=command.tenant_id,
+            user_id=command.user_id,
+        )
+
+    async def place_order(self, *, command: PlaceOrderCommand) -> dict[str, Any]:
+        return await self._execution_adapter.place_order(
+            symbol=command.symbol,
+            side=command.side,
+            order_type=command.order_type,
+            quantity=command.quantity,
+            price=command.price,
+            deployment_id=command.deployment_id,
+            tenant_id=command.tenant_id,
+            user_id=command.user_id,
+            idempotency_key=command.idempotency_key,
+        )
+
+    async def cancel_order(self, *, command: CancelOrderCommand) -> dict[str, Any]:
+        return await self._execution_adapter.cancel_order(
+            provider_order_id=command.provider_order_id,
+            tenant_id=command.tenant_id,
+            user_id=command.user_id,
+        )

--- a/backend/tests/contracts/test_execution_command_layer.py
+++ b/backend/tests/contracts/test_execution_command_layer.py
@@ -1,0 +1,194 @@
+"""Contract tests for AG-EXE-01 execution command layer boundary."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.platform_api.schemas_v1 import CreateDeploymentRequest, CreateOrderRequest, RequestContext
+from src.platform_api.services.execution_service import ExecutionService
+from src.platform_api.state_store import InMemoryStateStore, OrderRecord
+
+
+class _NoSideEffectAdapter:
+    """Adapter double that raises if side-effecting methods are called directly."""
+
+    def __init__(self, *, latest_pnl: float = 0.0) -> None:
+        self.latest_pnl = latest_pnl
+
+    async def create_deployment(self, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        raise AssertionError("create_deployment must be invoked via execution command layer.")
+
+    async def stop_deployment(self, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        raise AssertionError("stop_deployment must be invoked via execution command layer.")
+
+    async def place_order(self, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        raise AssertionError("place_order must be invoked via execution command layer.")
+
+    async def cancel_order(self, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        raise AssertionError("cancel_order must be invoked via execution command layer.")
+
+    async def get_deployment(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        provider_deployment_id: str,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (provider_deployment_id, tenant_id, user_id)
+        return {"status": "running", "latestPnl": self.latest_pnl}
+
+    async def list_deployments(self, *, status: str | None):  # type: ignore[no-untyped-def]
+        _ = status
+        return []
+
+    async def list_orders(self, *, status: str | None):  # type: ignore[no-untyped-def]
+        _ = status
+        return []
+
+    async def get_order(self, *, provider_order_id: str, tenant_id: str, user_id: str):  # type: ignore[no-untyped-def]
+        _ = (provider_order_id, tenant_id, user_id)
+        return None
+
+    async def get_portfolio_snapshot(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        portfolio_id: str,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (portfolio_id, tenant_id, user_id)
+        return None
+
+    async def list_portfolios(self):  # type: ignore[no-untyped-def]
+        return []
+
+
+@dataclass
+class _StubExecutionCommandService:
+    create_deployment_calls: int = 0
+    stop_deployment_calls: int = 0
+    place_order_calls: int = 0
+    cancel_order_calls: int = 0
+    received_commands: list[Any] = field(default_factory=list)
+
+    async def create_deployment(self, *, command):  # type: ignore[no-untyped-def]
+        self.create_deployment_calls += 1
+        self.received_commands.append(command)
+        return {
+            "providerDeploymentId": "live-dep-cmd-001",
+            "deploymentId": "dep-cmd-001",
+            "status": "queued",
+        }
+
+    async def stop_deployment(self, *, command):  # type: ignore[no-untyped-def]
+        self.stop_deployment_calls += 1
+        self.received_commands.append(command)
+        return {"status": "stopping"}
+
+    async def place_order(self, *, command):  # type: ignore[no-untyped-def]
+        self.place_order_calls += 1
+        self.received_commands.append(command)
+        return {
+            "providerOrderId": "live-order-cmd-001",
+            "orderId": "ord-cmd-001",
+            "status": "pending",
+        }
+
+    async def cancel_order(self, *, command):  # type: ignore[no-untyped-def]
+        self.cancel_order_calls += 1
+        self.received_commands.append(command)
+        return {"status": "cancelled"}
+
+
+def _context() -> RequestContext:
+    return RequestContext(
+        request_id="req-exe-command-001",
+        tenant_id="tenant-a",
+        user_id="user-a",
+    )
+
+
+def test_execution_side_effects_use_command_layer() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        adapter = _NoSideEffectAdapter()
+        command_service = _StubExecutionCommandService()
+        service = ExecutionService(
+            store=store,
+            execution_adapter=adapter,
+            execution_command_service=command_service,  # type: ignore[arg-type]
+        )
+
+        create_dep_response = await service.create_deployment(
+            request=CreateDeploymentRequest(strategyId="strat-001", mode="paper", capital=20_000),
+            idempotency_key="idem-cmd-dep-001",
+            context=_context(),
+        )
+        assert create_dep_response.deployment.id == "dep-cmd-001"
+
+        create_order_response = await service.create_order(
+            request=CreateOrderRequest(
+                symbol="BTCUSDT",
+                side="buy",
+                type="limit",
+                quantity=0.1,
+                price=64000,
+                deploymentId="dep-001",
+            ),
+            idempotency_key="idem-cmd-order-001",
+            context=_context(),
+        )
+        assert create_order_response.order.id == "ord-cmd-001"
+
+        stop_response = await service.stop_deployment(
+            deployment_id="dep-001",
+            reason="manual stop",
+            context=_context(),
+        )
+        assert stop_response.deployment.status == "stopping"
+
+        store.orders["ord-cmd-cancel-001"] = OrderRecord(
+            id="ord-cmd-cancel-001",
+            symbol="BTCUSDT",
+            side="buy",
+            order_type="limit",
+            quantity=0.1,
+            price=64000,
+            status="pending",
+            deployment_id="dep-001",
+            provider_order_id="live-order-cmd-cancel-001",
+        )
+        cancel_response = await service.cancel_order(order_id="ord-cmd-cancel-001", context=_context())
+        assert cancel_response.order.status == "cancelled"
+
+        assert command_service.create_deployment_calls == 1
+        assert command_service.place_order_calls == 1
+        assert command_service.stop_deployment_calls == 1
+        assert command_service.cancel_order_calls == 1
+
+    asyncio.run(_run())
+
+
+def test_drawdown_stop_path_uses_command_layer() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        store.risk_policy["limits"]["maxDrawdownPct"] = 5.0
+        adapter = _NoSideEffectAdapter(latest_pnl=-2000.0)
+        command_service = _StubExecutionCommandService()
+        service = ExecutionService(
+            store=store,
+            execution_adapter=adapter,
+            execution_command_service=command_service,  # type: ignore[arg-type]
+        )
+
+        response = await service.get_deployment(deployment_id="dep-001", context=_context())
+        assert response.deployment.status == "stopping"
+        assert command_service.stop_deployment_calls == 1
+
+    asyncio.run(_run())

--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -335,14 +335,25 @@ Version and validation rules:
 8. Runtime drawdown breaches (`latestPnl` vs deployment capital) must trigger kill-switch and halt active deployments before further side effects.
 9. Every risk decision path (`approved` and `blocked`) must persist an audit record with request identity and outcome metadata.
 
-## 7) Compatibility Rules
+## 7) Execution Command Boundary (AG-EXE-01)
+
+Execution side effects are mediated by an internal command layer that delegates only to `ExecutionAdapter`.
+
+Required rules:
+
+1. Side-effecting execution paths (`create_deployment`, `stop_deployment`, `place_order`, `cancel_order`) execute through command objects.
+2. The command layer is the only component that can call side-effecting adapter operations.
+3. Read-only status/snapshot calls can use adapter read methods directly.
+4. Risk gating remains mandatory before command execution for side-effecting actions.
+
+## 8) Compatibility Rules
 
 1. Public API changes follow semantic versioning and `/vN` URLs.
 2. Internal adapter interfaces can evolve, but each change must be released with adapter tests.
 3. Existing fields are never repurposed with different meaning.
 4. Deprecated fields must have a removal date.
 
-## 8) Team Independence Checklist
+## 9) Team Independence Checklist
 
 A workstream is considered independent when:
 
@@ -351,7 +362,7 @@ A workstream is considered independent when:
 3. It passes contract tests against mock responses.
 4. It does not require undocumented endpoints.
 
-## 9) Migration Notes from Prototype Interfaces
+## 10) Migration Notes from Prototype Interfaces
 
 Prototype routes that do not match OpenAPI should be treated as `legacy` and excluded from new integrations.
 

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -341,14 +341,25 @@ Version and validation rules:
 8. Runtime drawdown breaches (`latestPnl` vs deployment capital) must trigger kill-switch and halt active deployments before further side effects.
 9. Every risk decision path (`approved` and `blocked`) must persist an audit record with request identity and outcome metadata.
 
-## 7) Compatibility Rules
+## 7) Execution Command Boundary (AG-EXE-01)
+
+Execution side effects are mediated by an internal command layer that delegates only to `ExecutionAdapter`.
+
+Required rules:
+
+1. Side-effecting execution paths (`create_deployment`, `stop_deployment`, `place_order`, `cancel_order`) execute through command objects.
+2. The command layer is the only component that can call side-effecting adapter operations.
+3. Read-only status/snapshot calls can use adapter read methods directly.
+4. Risk gating remains mandatory before command execution for side-effecting actions.
+
+## 8) Compatibility Rules
 
 1. Public API changes follow semantic versioning and `/vN` URLs.
 2. Internal adapter interfaces can evolve, but each change must be released with adapter tests.
 3. Existing fields are never repurposed with different meaning.
 4. Deprecated fields must have a removal date.
 
-## 8) Team Independence Checklist
+## 9) Team Independence Checklist
 
 A workstream is considered independent when:
 
@@ -357,7 +368,7 @@ A workstream is considered independent when:
 3. It passes contract tests against mock responses.
 4. It does not require undocumented endpoints.
 
-## 9) Migration Notes from Prototype Interfaces
+## 10) Migration Notes from Prototype Interfaces
 
 Prototype routes that do not match OpenAPI should be treated as `legacy` and excluded from new integrations.
 

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "c70518b74d216f78e939bbae7e7fd3e30d7139e98bcf813b3321692ee45a0a01",
+    "chunk_hash": "015ef2ed7e0bffe2340d054b4a10dd143d4dabecfb314d89c477aab41a4bd5f5",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "8cf44bfdca9685379d938d33b7eb20d46aa1babcbce37c7157ed6bc372ffe226",
+    "source_hash": "0d28f1b069502fa37c95bd8098af91fefe2788ce077cebf9da6998a65cff467a",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "c70518b74d216f78e939bbae7e7fd3e30d7139e98bcf813b3321692ee45a0a01",
+    "chunk_hash": "015ef2ed7e0bffe2340d054b4a10dd143d4dabecfb314d89c477aab41a4bd5f5",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "8cf44bfdca9685379d938d33b7eb20d46aa1babcbce37c7157ed6bc372ffe226"
+    "source_hash": "0d28f1b069502fa37c95bd8098af91fefe2788ce077cebf9da6998a65cff467a"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",

--- a/docs/portal/operations/gate4-orchestrator-controls.md
+++ b/docs/portal/operations/gate4-orchestrator-controls.md
@@ -1,6 +1,6 @@
 ---
 title: Gate4 Orchestrator Controls
-summary: Deterministic orchestrator state machine contract and failure boundary semantics.
+summary: Deterministic orchestrator state machine and execution command boundary semantics.
 owners:
   - Team B
   - Team F
@@ -12,7 +12,7 @@ updated: 2026-02-14
 
 ## Objective
 
-Define a deterministic orchestrator lifecycle so runtime behavior can be tested, audited, and safely hardened in follow-up issues.
+Define a deterministic orchestrator lifecycle and execution command boundary so runtime behavior can be tested, audited, and safely hardened in follow-up issues.
 
 ## State Contract
 
@@ -40,9 +40,20 @@ States:
 - Queue/cancellation runtime processing lands in AG-ORCH-02 (`#47`).
 - Retry and failure budget policy lands in AG-ORCH-03 (`#48`).
 
+## Execution Command Boundary (AG-EXE-01)
+
+Execution side-effect operations are routed through internal command handlers before adapter calls:
+
+1. Deployment create/stop commands are emitted via command layer abstractions.
+2. Order place/cancel commands are emitted via command layer abstractions.
+3. Command layer delegates side effects to `ExecutionAdapter`; provider APIs remain adapter-only.
+4. Read paths (list/get) remain non-command adapter reads.
+
 ## Traceability
 
 - Architecture interface contract: `/docs/architecture/INTERFACES.md`
 - Runtime implementation: `/backend/src/platform_api/services/orchestrator_state_machine.py`
+- Execution command runtime: `/backend/src/platform_api/services/execution_command_service.py`
 - Contract tests: `/backend/tests/contracts/test_orchestrator_state_machine.py`
+- Contract tests: `/backend/tests/contracts/test_execution_command_layer.py`
 - Related epics/issues: `#77`, `#138`, `#106`


### PR DESCRIPTION
## Summary
- add `ExecutionCommandService` with explicit command objects for side-effecting execution operations
- route `ExecutionService` side effects through command layer:
  - deployment create/stop
  - order place/cancel
  - drawdown kill-switch stop path
- keep adapter direct access for read-only operations only (list/get)
- add contract tests that fail if side-effecting adapter methods are called directly
- update interface + runtime controls docs and regenerate LLM artifacts

## Validation
- `uv run --directory backend --with pytest python -m pytest tests/contracts/test_execution_command_layer.py tests/contracts/test_platform_api_v1_handlers.py tests/contracts/test_idempotency_contract_runtime.py tests/contracts/test_risk_pretrade_checks.py tests/contracts/test_risk_killswitch_drawdown.py tests/contracts/test_risk_audit_trail.py -q`
- `npm --prefix docs/portal-site run ci`
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`

Fixes #58
Refs #77
Refs #138
Refs #106
Refs #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order/deployment execution paths (including kill-switch stops), so any wiring or payload-mapping mistakes could change runtime behavior despite being largely a refactor with contract-test coverage.
> 
> **Overview**
> Introduces an **execution command boundary (AG-EXE-01)** by adding `ExecutionCommandService` and immutable command objects to mediate all side-effecting execution operations.
> 
> `ExecutionService` now routes deployment create/stop, order place/cancel, and the drawdown kill-switch stop path through this command layer (while keeping read-only adapter calls direct), and adds contract tests that fail if side-effecting `ExecutionAdapter` methods are invoked directly. Documentation is updated to codify the boundary and regenerates the LLM packaging hashes/traceability metadata accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2111c994e151a25a96f393ae830ff43a27865d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces an execution command layer (AG-EXE-01) that mediates all side-effecting execution operations through immutable command objects before delegating to `ExecutionAdapter`.

**Key changes:**
- New `ExecutionCommandService` with frozen dataclass commands for deployment create/stop, order place/cancel operations
- `ExecutionService` now routes all side effects (including drawdown kill-switch stops) through command layer while preserving direct adapter access for read-only operations
- Contract tests verify the boundary: adapter methods that cause side effects raise `AssertionError` if called directly
- Documentation updates codify the AG-EXE-01 boundary in architecture contracts and regenerate LLM artifacts with updated traceability hashes

**Architecture impact:**
The command layer enforces a clear separation: side effects flow through commands → adapter, while reads use adapter directly. Risk gating (pre-trade checks) remains mandatory before command execution.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe but requires careful validation of execution paths due to risk-sensitive operations
- Score reflects clean architectural refactoring with comprehensive contract tests, but execution/order paths (including kill-switch stops) are risk-sensitive and any payload mapping errors could alter runtime behavior despite strong test coverage
- Pay close attention to `execution_service.py` where command objects are constructed and kill-switch stop logic is triggered

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/services/execution_command_service.py | New command layer with immutable command objects routing side effects through ExecutionAdapter |
| backend/src/platform_api/services/execution_service.py | Routes deployment/order operations through command service; preserves direct adapter access for reads |
| backend/tests/contracts/test_execution_command_layer.py | Contract tests verify side effects use command layer and drawdown stop path routes correctly |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as API Client
    participant ES as ExecutionService
    participant RPS as RiskPreTradeService
    participant ECS as ExecutionCommandService
    participant EA as ExecutionAdapter
    participant LE as Live Engine

    Note over Client,LE: Deployment Creation Flow (AG-EXE-01)
    Client->>ES: create_deployment(request, context)
    ES->>RPS: ensure_deployment_allowed()
    RPS-->>ES: ✓ approved
    ES->>ECS: create_deployment(command)
    ECS->>EA: create_deployment(params)
    EA->>LE: POST /api/internal/deployments
    LE-->>EA: {deploymentId, status}
    EA-->>ECS: provider_result
    ECS-->>ES: provider_result
    ES-->>Client: DeploymentResponse

    Note over Client,LE: Drawdown Kill-Switch Stop Path
    Client->>ES: get_deployment(deployment_id)
    ES->>EA: get_deployment(provider_ref)
    EA->>LE: GET /api/internal/deployments/{id}
    LE-->>EA: {status, latestPnl}
    EA-->>ES: deployment_state
    ES->>ES: evaluate_drawdown_breach()
    alt drawdown breach detected
        ES->>ECS: stop_deployment(command)
        ECS->>EA: stop_deployment(provider_ref)
        EA->>LE: POST /api/internal/deployments/{id}/stop
        LE-->>EA: {status: stopping}
        EA-->>ECS: stop_result
        ECS-->>ES: stop_result
    end
    ES-->>Client: DeploymentResponse

    Note over Client,LE: Order Placement Flow
    Client->>ES: create_order(request, context)
    ES->>RPS: ensure_order_allowed()
    RPS-->>ES: ✓ approved
    ES->>ECS: place_order(command)
    ECS->>EA: place_order(params)
    EA->>LE: POST /api/internal/orders
    LE-->>EA: {orderId, status}
    EA-->>ECS: provider_result
    ECS-->>ES: provider_result
    ES-->>Client: OrderResponse

    Note over ES,EA: Read-Only Operations (Direct Adapter)
    ES->>EA: list_deployments(status)
    EA-->>ES: deployment_records
    ES->>EA: get_order(provider_order_id)
    EA-->>ES: order_record
```

<sub>Last reviewed commit: c2111c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->