### PR TITLE
feat: AG-EXE-03 command-layer idempotency enforcement

### DIFF
--- a/backend/src/platform_api/services/execution_command_service.py
+++ b/backend/src/platform_api/services/execution_command_service.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from src.platform_api.adapters.execution_adapter import ExecutionAdapter
+from src.platform_api.errors import PlatformAPIError
+from src.platform_api.state_store import InMemoryStateStore
 
 
 @dataclass(frozen=True)
@@ -16,6 +18,7 @@ class CreateDeploymentCommand:
     tenant_id: str
     user_id: str
     idempotency_key: str
+    request_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -37,6 +40,7 @@ class PlaceOrderCommand:
     tenant_id: str
     user_id: str
     idempotency_key: str
+    request_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -49,11 +53,33 @@ class CancelOrderCommand:
 class ExecutionCommandService:
     """Executes side-effecting commands exclusively through ExecutionAdapter."""
 
-    def __init__(self, *, execution_adapter: ExecutionAdapter) -> None:
+    def __init__(
+        self,
+        *,
+        execution_adapter: ExecutionAdapter,
+        store: InMemoryStateStore | None = None,
+    ) -> None:
         self._execution_adapter = execution_adapter
+        self._store = store
 
     async def create_deployment(self, *, command: CreateDeploymentCommand) -> dict[str, Any]:
-        return await self._execution_adapter.create_deployment(
+        payload = {
+            "strategyId": command.strategy_id,
+            "mode": command.mode,
+            "capital": command.capital,
+            "tenantId": command.tenant_id,
+            "userId": command.user_id,
+        }
+        cached = self._load_idempotent(
+            scope="execution_commands_deployments",
+            key=command.idempotency_key,
+            payload=payload,
+            request_id=command.request_id,
+        )
+        if cached is not None:
+            return cached
+
+        response = await self._execution_adapter.create_deployment(
             strategy_id=command.strategy_id,
             mode=command.mode,
             capital=command.capital,
@@ -61,6 +87,13 @@ class ExecutionCommandService:
             user_id=command.user_id,
             idempotency_key=command.idempotency_key,
         )
+        self._save_idempotent(
+            scope="execution_commands_deployments",
+            key=command.idempotency_key,
+            payload=payload,
+            response=response,
+        )
+        return response
 
     async def stop_deployment(self, *, command: StopDeploymentCommand) -> dict[str, Any]:
         return await self._execution_adapter.stop_deployment(
@@ -71,7 +104,26 @@ class ExecutionCommandService:
         )
 
     async def place_order(self, *, command: PlaceOrderCommand) -> dict[str, Any]:
-        return await self._execution_adapter.place_order(
+        payload = {
+            "symbol": command.symbol,
+            "side": command.side,
+            "type": command.order_type,
+            "quantity": command.quantity,
+            "price": command.price,
+            "deploymentId": command.deployment_id,
+            "tenantId": command.tenant_id,
+            "userId": command.user_id,
+        }
+        cached = self._load_idempotent(
+            scope="execution_commands_orders",
+            key=command.idempotency_key,
+            payload=payload,
+            request_id=command.request_id,
+        )
+        if cached is not None:
+            return cached
+
+        response = await self._execution_adapter.place_order(
             symbol=command.symbol,
             side=command.side,
             order_type=command.order_type,
@@ -82,10 +134,58 @@ class ExecutionCommandService:
             user_id=command.user_id,
             idempotency_key=command.idempotency_key,
         )
+        self._save_idempotent(
+            scope="execution_commands_orders",
+            key=command.idempotency_key,
+            payload=payload,
+            response=response,
+        )
+        return response
 
     async def cancel_order(self, *, command: CancelOrderCommand) -> dict[str, Any]:
         return await self._execution_adapter.cancel_order(
             provider_order_id=command.provider_order_id,
             tenant_id=command.tenant_id,
             user_id=command.user_id,
+        )
+
+    def _load_idempotent(
+        self,
+        *,
+        scope: str,
+        key: str,
+        payload: dict[str, Any],
+        request_id: str | None,
+    ) -> dict[str, Any] | None:
+        if self._store is None:
+            return None
+        conflict, cached = self._store.get_idempotent_response(
+            scope=scope,
+            key=key,
+            payload=payload,
+        )
+        if conflict:
+            raise PlatformAPIError(
+                status_code=409,
+                code="IDEMPOTENCY_KEY_CONFLICT",
+                message="Idempotency-Key reused with different execution command payload.",
+                request_id=request_id,
+            )
+        return cached
+
+    def _save_idempotent(
+        self,
+        *,
+        scope: str,
+        key: str,
+        payload: dict[str, Any],
+        response: dict[str, Any],
+    ) -> None:
+        if self._store is None:
+            return
+        self._store.save_idempotent_response(
+            scope=scope,
+            key=key,
+            payload=payload,
+            response=response,
         )

--- a/backend/src/platform_api/services/execution_service.py
+++ b/backend/src/platform_api/services/execution_service.py
@@ -61,7 +61,8 @@ class ExecutionService:
         self._store = store
         self._execution_adapter = execution_adapter
         self._execution_command_service = execution_command_service or ExecutionCommandService(
-            execution_adapter=execution_adapter
+            execution_adapter=execution_adapter,
+            store=store,
         )
         self._reconciliation_service = reconciliation_service
         self._knowledge_ingestion_pipeline = knowledge_ingestion_pipeline
@@ -128,6 +129,7 @@ class ExecutionService:
                 tenant_id=context.tenant_id,
                 user_id=context.user_id,
                 idempotency_key=idempotency_key,
+                request_id=context.request_id,
             )
         )
 
@@ -323,6 +325,7 @@ class ExecutionService:
                 tenant_id=context.tenant_id,
                 user_id=context.user_id,
                 idempotency_key=idempotency_key,
+                request_id=context.request_id,
             )
         )
 

--- a/backend/src/platform_api/state_store.py
+++ b/backend/src/platform_api/state_store.py
@@ -339,6 +339,8 @@ class InMemoryStateStore:
         self._idempotency: dict[str, dict[str, tuple[str, dict[str, Any]]]] = {
             "deployments": {},
             "orders": {},
+            "execution_commands_deployments": {},
+            "execution_commands_orders": {},
         }
 
     def next_id(self, scope: str) -> str:

--- a/backend/tests/contracts/test_execution_command_idempotency.py
+++ b/backend/tests/contracts/test_execution_command_idempotency.py
@@ -1,0 +1,157 @@
+"""Contract tests for AG-EXE-03 execution command idempotency."""
+
+from __future__ import annotations
+
+import asyncio
+
+from src.platform_api.errors import PlatformAPIError
+from src.platform_api.services.execution_command_service import (
+    CreateDeploymentCommand,
+    ExecutionCommandService,
+    PlaceOrderCommand,
+)
+from src.platform_api.state_store import InMemoryStateStore
+
+
+class _CountingAdapter:
+    def __init__(self) -> None:
+        self.create_deployment_calls = 0
+        self.place_order_calls = 0
+
+    async def create_deployment(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        strategy_id: str,
+        mode: str,
+        capital: float,
+        tenant_id: str,
+        user_id: str,
+        idempotency_key: str,
+    ):
+        _ = (strategy_id, mode, capital, tenant_id, user_id, idempotency_key)
+        self.create_deployment_calls += 1
+        return {
+            "providerDeploymentId": "live-dep-idem-001",
+            "deploymentId": "dep-idem-001",
+            "status": "queued",
+        }
+
+    async def place_order(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        symbol: str,
+        side: str,
+        order_type: str,
+        quantity: float,
+        price: float | None,
+        deployment_id: str | None,
+        tenant_id: str,
+        user_id: str,
+        idempotency_key: str,
+    ):
+        _ = (symbol, side, order_type, quantity, price, deployment_id, tenant_id, user_id, idempotency_key)
+        self.place_order_calls += 1
+        return {
+            "providerOrderId": "live-order-idem-001",
+            "orderId": "ord-idem-001",
+            "status": "pending",
+        }
+
+    async def stop_deployment(self, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        return {"status": "stopping"}
+
+    async def cancel_order(self, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        return {"status": "cancelled"}
+
+
+def test_command_layer_replays_cached_deployment_response() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        adapter = _CountingAdapter()
+        service = ExecutionCommandService(execution_adapter=adapter, store=store)  # type: ignore[arg-type]
+
+        command = CreateDeploymentCommand(
+            strategy_id="strat-001",
+            mode="paper",
+            capital=20_000,
+            tenant_id="tenant-a",
+            user_id="user-a",
+            idempotency_key="idem-cmd-deployment-001",
+            request_id="req-cmd-idem-001",
+        )
+        first = await service.create_deployment(command=command)
+        second = await service.create_deployment(command=command)
+
+        assert first["deploymentId"] == "dep-idem-001"
+        assert second["deploymentId"] == "dep-idem-001"
+        assert adapter.create_deployment_calls == 1
+
+    asyncio.run(_run())
+
+
+def test_command_layer_replays_cached_order_response() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        adapter = _CountingAdapter()
+        service = ExecutionCommandService(execution_adapter=adapter, store=store)  # type: ignore[arg-type]
+
+        command = PlaceOrderCommand(
+            symbol="BTCUSDT",
+            side="buy",
+            order_type="limit",
+            quantity=0.1,
+            price=64000,
+            deployment_id="dep-001",
+            tenant_id="tenant-a",
+            user_id="user-a",
+            idempotency_key="idem-cmd-order-001",
+            request_id="req-cmd-idem-002",
+        )
+        first = await service.place_order(command=command)
+        second = await service.place_order(command=command)
+
+        assert first["orderId"] == "ord-idem-001"
+        assert second["orderId"] == "ord-idem-001"
+        assert adapter.place_order_calls == 1
+
+    asyncio.run(_run())
+
+
+def test_command_layer_rejects_key_reuse_with_different_payload() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        adapter = _CountingAdapter()
+        service = ExecutionCommandService(execution_adapter=adapter, store=store)  # type: ignore[arg-type]
+
+        first = CreateDeploymentCommand(
+            strategy_id="strat-001",
+            mode="paper",
+            capital=20_000,
+            tenant_id="tenant-a",
+            user_id="user-a",
+            idempotency_key="idem-cmd-deployment-002",
+            request_id="req-cmd-idem-003",
+        )
+        await service.create_deployment(command=first)
+
+        conflicting = CreateDeploymentCommand(
+            strategy_id="strat-001",
+            mode="paper",
+            capital=21_000,
+            tenant_id="tenant-a",
+            user_id="user-a",
+            idempotency_key="idem-cmd-deployment-002",
+            request_id="req-cmd-idem-003",
+        )
+        try:
+            await service.create_deployment(command=conflicting)
+            raise AssertionError("Expected idempotency conflict for changed command payload.")
+        except PlatformAPIError as exc:
+            assert exc.status_code == 409
+            assert exc.code == "IDEMPOTENCY_KEY_CONFLICT"
+
+        assert adapter.create_deployment_calls == 1
+
+    asyncio.run(_run())

--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -345,6 +345,8 @@ Required rules:
 2. The command layer is the only component that can call side-effecting adapter operations.
 3. Read-only status/snapshot calls can use adapter read methods directly.
 4. Risk gating remains mandatory before command execution for side-effecting actions.
+5. Command-layer idempotency is mandatory for deployment creation and order placement; duplicate keys replay prior response.
+6. Reusing an idempotency key with different command payload must fail with conflict (`IDEMPOTENCY_KEY_CONFLICT`).
 
 ## 8) Compatibility Rules
 

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -351,6 +351,8 @@ Required rules:
 2. The command layer is the only component that can call side-effecting adapter operations.
 3. Read-only status/snapshot calls can use adapter read methods directly.
 4. Risk gating remains mandatory before command execution for side-effecting actions.
+5. Command-layer idempotency is mandatory for deployment creation and order placement; duplicate keys replay prior response.
+6. Reusing an idempotency key with different command payload must fail with conflict (`IDEMPOTENCY_KEY_CONFLICT`).
 
 ## 8) Compatibility Rules
 

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "015ef2ed7e0bffe2340d054b4a10dd143d4dabecfb314d89c477aab41a4bd5f5",
+    "chunk_hash": "384908cdad1a0763aac6dacd884f0223812c03eb5278f8567a97b91b620740b4",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "0d28f1b069502fa37c95bd8098af91fefe2788ce077cebf9da6998a65cff467a",
+    "source_hash": "b27260364a1808a920cd21bd12afddb7c02d2e98c715417abac653dbf1132b3a",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "015ef2ed7e0bffe2340d054b4a10dd143d4dabecfb314d89c477aab41a4bd5f5",
+    "chunk_hash": "384908cdad1a0763aac6dacd884f0223812c03eb5278f8567a97b91b620740b4",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "0d28f1b069502fa37c95bd8098af91fefe2788ce077cebf9da6998a65cff467a"
+    "source_hash": "b27260364a1808a920cd21bd12afddb7c02d2e98c715417abac653dbf1132b3a"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",

--- a/docs/portal/operations/gate4-orchestrator-controls.md
+++ b/docs/portal/operations/gate4-orchestrator-controls.md
@@ -48,6 +48,7 @@ Execution side-effect operations are routed through internal command handlers be
 2. Order place/cancel commands are emitted via command layer abstractions.
 3. Command layer delegates side effects to `ExecutionAdapter`; provider APIs remain adapter-only.
 4. Read paths (list/get) remain non-command adapter reads.
+5. Deployment create and order place commands enforce idempotency replay semantics; key/payload conflicts fail deterministically.
 
 ## Traceability
 
@@ -56,4 +57,5 @@ Execution side-effect operations are routed through internal command handlers be
 - Execution command runtime: `/backend/src/platform_api/services/execution_command_service.py`
 - Contract tests: `/backend/tests/contracts/test_orchestrator_state_machine.py`
 - Contract tests: `/backend/tests/contracts/test_execution_command_layer.py`
+- Contract tests: `/backend/tests/contracts/test_execution_command_idempotency.py`
 - Related epics/issues: `#77`, `#138`, `#106`


### PR DESCRIPTION
## Summary
- enforce idempotency inside `ExecutionCommandService` for deployment create and order place commands
- replay cached command responses for duplicate key+payload invocations
- reject idempotency key reuse with payload drift using `IDEMPOTENCY_KEY_CONFLICT`
- propagate request IDs into command-level conflict errors
- add command-layer idempotency contract tests
- update interfaces/operations docs and regenerate LLM artifacts

## Validation
- `uv run --directory backend --with pytest python -m pytest tests/contracts/test_execution_command_idempotency.py tests/contracts/test_execution_command_layer.py tests/contracts/test_idempotency_contract_runtime.py tests/contracts/test_platform_api_v1_handlers.py tests/contracts/test_risk_pretrade_checks.py tests/contracts/test_risk_killswitch_drawdown.py tests/contracts/test_risk_audit_trail.py -q`
- `npm --prefix docs/portal-site run ci`
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`

Fixes #60
Refs #77
Refs #138
Refs #106
Refs #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order/deployment side-effect execution paths and introduces a new caching layer for adapter responses; mistakes could cause stale replays or unexpected 409 conflicts, but changes are scoped and covered by contract tests.
> 
> **Overview**
> Adds **command-layer idempotency enforcement** in `ExecutionCommandService` for `create_deployment` and `place_order` by caching adapter responses in `InMemoryStateStore` and replaying them on duplicate `Idempotency-Key` + payload calls.
> 
> Reusing an idempotency key with a different command payload now fails deterministically with `409` `IDEMPOTENCY_KEY_CONFLICT` (including `request_id`), and `ExecutionService` wires the store + propagates `request_id` into command objects. Updates state-store scopes, adds contract tests for replay/conflict behavior, and refreshes architecture/ops docs + generated LLM artifact hashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df548ddea95b7d344af92f31e421307f90e14f8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces idempotency at the command layer for deployment creation and order placement operations. The implementation caches command responses keyed by idempotency key and payload fingerprint, replaying cached responses for duplicate requests and rejecting key reuse with payload drift using `IDEMPOTENCY_KEY_CONFLICT` 409 errors.

Key changes:
- Added `_load_idempotent` and `_save_idempotent` helper methods in `ExecutionCommandService` that check/store responses before delegating to the adapter
- Wired `InMemoryStateStore` into the command service and added separate idempotency scopes (`execution_commands_deployments`, `execution_commands_orders`)
- Propagated `request_id` through command objects to include it in conflict error responses
- Added comprehensive contract tests verifying cache replay behavior and payload conflict detection
- Updated architecture documentation (INTERFACES.md) to mandate command-layer idempotency rules
- Regenerated LLM artifacts and updated operations documentation with traceability references

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns from the codebase, includes thorough contract tests covering all three scenarios (cache hit, cache miss, conflict), properly integrates with existing state store idempotency infrastructure, and maintains backward compatibility by making the store parameter optional
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/services/execution_command_service.py | added command-layer idempotency enforcement for deployment and order commands with cache replay and conflict detection |
| backend/src/platform_api/services/execution_service.py | wired command service with state store and propagated request_id to command objects |
| backend/src/platform_api/state_store.py | added separate idempotency scopes for execution commands (deployments and orders) |
| backend/tests/contracts/test_execution_command_idempotency.py | comprehensive contract tests verifying cache replay and payload conflict detection |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ExecutionService
    participant ExecutionCommandService
    participant StateStore
    participant ExecutionAdapter

    Note over Client,ExecutionAdapter: First Request with new idempotency key
    Client->>ExecutionService: create_deployment with idempotency-key-001
    ExecutionService->>ExecutionCommandService: create_deployment(command)
    ExecutionCommandService->>StateStore: get_idempotent_response(key, payload)
    StateStore-->>ExecutionCommandService: conflict=false, cached=None
    ExecutionCommandService->>ExecutionAdapter: create_deployment(params)
    ExecutionAdapter-->>ExecutionCommandService: response
    ExecutionCommandService->>StateStore: save_idempotent_response(key, payload, response)
    ExecutionCommandService-->>ExecutionService: response
    ExecutionService-->>Client: DeploymentResponse

    Note over Client,ExecutionAdapter: Duplicate Request with same key and payload
    Client->>ExecutionService: create_deployment with same key and payload
    ExecutionService->>ExecutionCommandService: create_deployment(command)
    ExecutionCommandService->>StateStore: get_idempotent_response(key, payload)
    StateStore-->>ExecutionCommandService: conflict=false, cached=response
    ExecutionCommandService-->>ExecutionService: cached response (no adapter call)
    ExecutionService-->>Client: DeploymentResponse

    Note over Client,ExecutionAdapter: Conflict Request with same key but different payload
    Client->>ExecutionService: create_deployment with same key, different payload
    ExecutionService->>ExecutionCommandService: create_deployment(command)
    ExecutionCommandService->>StateStore: get_idempotent_response(key, different_payload)
    StateStore-->>ExecutionCommandService: conflict=true, cached=None
    ExecutionCommandService-->>ExecutionService: raise PlatformAPIError 409
    ExecutionService-->>Client: 409 Conflict IDEMPOTENCY_KEY_CONFLICT
```

<sub>Last reviewed commit: df548dd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->