### PR TITLE
feat: CONV-02 multi-turn conversation context memory

### DIFF
--- a/backend/src/platform_api/services/conversation_service.py
+++ b/backend/src/platform_api/services/conversation_service.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import copy
+import re
+from typing import Any
+
 from src.platform_api.errors import PlatformAPIError
 from src.platform_api.schemas_v1 import RequestContext
 from src.platform_api.schemas_v2 import (
@@ -19,6 +23,11 @@ from src.platform_api.state_store import (
     utc_now,
 )
 
+_MEMORY_VERSION = "conv-memory.v1"
+_MEMORY_MAX_RECENT_MESSAGES = 5
+_MEMORY_MAX_LINKED_ARTIFACTS = 25
+_MEMORY_MAX_SYMBOLS = 25
+
 
 class ConversationService:
     """Stateful in-memory conversation service for contract validation."""
@@ -34,12 +43,14 @@ class ConversationService:
     ) -> ConversationSessionResponse:
         session_id = self._store.next_id("conversation_session")
         now = utc_now()
+        metadata = dict(request.metadata)
+        metadata["contextMemory"] = self._load_context_memory(context=context)
         record = ConversationSessionRecord(
             id=session_id,
             channel=request.channel,
             status="active",
             topic=request.topic,
-            metadata=request.metadata,
+            metadata=metadata,
             created_at=now,
             updated_at=now,
             last_turn_at=None,
@@ -75,17 +86,27 @@ class ConversationService:
                 request_id=context.request_id,
             )
 
+        now = utc_now()
+        context_memory = self._update_context_memory(
+            session=session,
+            role=request.role,
+            message=request.message,
+            created_at=now,
+            context=context,
+        )
+        turn_metadata = dict(request.metadata)
+        turn_metadata["contextMemorySnapshot"] = context_memory
         turn = ConversationTurnRecord(
             id=self._store.next_id("conversation_turn"),
             session_id=session_id,
             role=request.role,
             message=request.message,
             suggestions=self._derive_suggestions(role=request.role, message=request.message),
-            metadata=request.metadata,
+            metadata=turn_metadata,
+            created_at=now,
         )
         self._store.conversation_turns.setdefault(session_id, []).append(turn)
 
-        now = utc_now()
         session.updated_at = now
         session.last_turn_at = now
 
@@ -136,3 +157,161 @@ class ConversationService:
             suggestions.append("Review latest backtest metrics and drawdown before deployment.")
 
         return suggestions
+
+    @staticmethod
+    def _memory_key(*, context: RequestContext) -> str:
+        return f"{context.tenant_id}:{context.user_id}"
+
+    def _default_context_memory(self) -> dict[str, Any]:
+        return {
+            "version": _MEMORY_VERSION,
+            "retention": {"maxRecentMessages": _MEMORY_MAX_RECENT_MESSAGES},
+            "turnCount": 0,
+            "lastIntent": None,
+            "recentMessages": [],
+            "linkedArtifacts": {
+                "strategyIds": [],
+                "deploymentIds": [],
+                "orderIds": [],
+                "portfolioIds": [],
+                "backtestIds": [],
+                "datasetIds": [],
+            },
+            "symbols": [],
+        }
+
+    def _load_context_memory(self, *, context: RequestContext) -> dict[str, Any]:
+        key = self._memory_key(context=context)
+        existing = self._store.conversation_user_memory.get(key)
+        if isinstance(existing, dict):
+            return copy.deepcopy(existing)
+        return self._default_context_memory()
+
+    def _update_context_memory(
+        self,
+        *,
+        session: ConversationSessionRecord,
+        role: str,
+        message: str,
+        created_at: str,
+        context: RequestContext,
+    ) -> dict[str, Any]:
+        context_memory = session.metadata.get("contextMemory")
+        if not isinstance(context_memory, dict):
+            context_memory = self._load_context_memory(context=context)
+        else:
+            context_memory = copy.deepcopy(context_memory)
+
+        context_memory["version"] = _MEMORY_VERSION
+        retention = context_memory.get("retention")
+        if not isinstance(retention, dict):
+            retention = {}
+            context_memory["retention"] = retention
+        max_recent = int(retention.get("maxRecentMessages", _MEMORY_MAX_RECENT_MESSAGES))
+        if max_recent <= 0:
+            max_recent = _MEMORY_MAX_RECENT_MESSAGES
+        retention["maxRecentMessages"] = max_recent
+
+        context_memory["turnCount"] = int(context_memory.get("turnCount", 0)) + 1
+
+        recent_messages = context_memory.get("recentMessages")
+        if not isinstance(recent_messages, list):
+            recent_messages = []
+            context_memory["recentMessages"] = recent_messages
+        recent_messages.append({"role": role, "message": message, "createdAt": created_at})
+        if len(recent_messages) > max_recent:
+            del recent_messages[:-max_recent]
+
+        linked_artifacts = context_memory.get("linkedArtifacts")
+        if not isinstance(linked_artifacts, dict):
+            linked_artifacts = {}
+            context_memory["linkedArtifacts"] = linked_artifacts
+        for field in (
+            "strategyIds",
+            "deploymentIds",
+            "orderIds",
+            "portfolioIds",
+            "backtestIds",
+            "datasetIds",
+        ):
+            values = linked_artifacts.get(field)
+            if not isinstance(values, list):
+                linked_artifacts[field] = []
+
+        if role == "user":
+            intent = self._infer_intent(message=message)
+            if intent is not None:
+                context_memory["lastIntent"] = intent
+
+            linked_artifacts["strategyIds"] = self._append_unique(
+                linked_artifacts["strategyIds"],
+                self._find_ids(message=message, pattern=r"\bstrat-[a-z0-9]+\b"),
+                max_items=_MEMORY_MAX_LINKED_ARTIFACTS,
+            )
+            linked_artifacts["deploymentIds"] = self._append_unique(
+                linked_artifacts["deploymentIds"],
+                self._find_ids(message=message, pattern=r"\bdep-[a-z0-9]+\b"),
+                max_items=_MEMORY_MAX_LINKED_ARTIFACTS,
+            )
+            linked_artifacts["orderIds"] = self._append_unique(
+                linked_artifacts["orderIds"],
+                self._find_ids(message=message, pattern=r"\bord-[a-z0-9]+\b"),
+                max_items=_MEMORY_MAX_LINKED_ARTIFACTS,
+            )
+            linked_artifacts["portfolioIds"] = self._append_unique(
+                linked_artifacts["portfolioIds"],
+                self._find_ids(message=message, pattern=r"\bportfolio-[a-z0-9-]+\b"),
+                max_items=_MEMORY_MAX_LINKED_ARTIFACTS,
+            )
+            linked_artifacts["backtestIds"] = self._append_unique(
+                linked_artifacts["backtestIds"],
+                self._find_ids(message=message, pattern=r"\bbt-[a-z0-9]+\b"),
+                max_items=_MEMORY_MAX_LINKED_ARTIFACTS,
+            )
+            linked_artifacts["datasetIds"] = self._append_unique(
+                linked_artifacts["datasetIds"],
+                self._find_ids(message=message, pattern=r"\bdataset-[a-z0-9-]+\b"),
+                max_items=_MEMORY_MAX_LINKED_ARTIFACTS,
+            )
+            symbols = context_memory.get("symbols")
+            if not isinstance(symbols, list):
+                symbols = []
+            context_memory["symbols"] = self._append_unique(
+                symbols,
+                self._find_ids(message=message, pattern=r"\b[A-Z]{2,10}(?:USDT|USD)\b"),
+                max_items=_MEMORY_MAX_SYMBOLS,
+            )
+
+        session.metadata["contextMemory"] = context_memory
+        self._store.conversation_user_memory[self._memory_key(context=context)] = copy.deepcopy(context_memory)
+        return context_memory
+
+    @staticmethod
+    def _find_ids(*, message: str, pattern: str) -> list[str]:
+        return [match.group(0) for match in re.finditer(pattern, message, flags=re.IGNORECASE)]
+
+    @staticmethod
+    def _append_unique(existing: list[Any], new_values: list[Any], *, max_items: int) -> list[Any]:
+        normalized = [str(value) for value in existing]
+        for value in new_values:
+            item = str(value)
+            if item not in normalized:
+                normalized.append(item)
+        if len(normalized) > max_items:
+            normalized = normalized[-max_items:]
+        return normalized
+
+    @staticmethod
+    def _infer_intent(*, message: str) -> str | None:
+        lowered = message.lower()
+        if "deploy" in lowered:
+            return "deploy"
+        if "backtest" in lowered:
+            return "backtest"
+        if "order" in lowered or "buy" in lowered or "sell" in lowered:
+            return "order"
+        if "risk" in lowered or "drawdown" in lowered:
+            return "risk"
+        if "portfolio" in lowered:
+            return "portfolio"
+        return None

--- a/backend/src/platform_api/state_store.py
+++ b/backend/src/platform_api/state_store.py
@@ -298,6 +298,7 @@ class InMemoryStateStore:
         self.risk_audit_trail: dict[str, RiskAuditRecord] = {}
         self.conversation_sessions: dict[str, ConversationSessionRecord] = {}
         self.conversation_turns: dict[str, list[ConversationTurnRecord]] = {}
+        self.conversation_user_memory: dict[str, dict[str, Any]] = {}
         self.risk_policy: dict[str, Any] = {
             "version": "risk-policy.v1",
             "mode": "enforced",

--- a/backend/tests/contracts/test_conversation_context_memory.py
+++ b/backend/tests/contracts/test_conversation_context_memory.py
@@ -1,0 +1,129 @@
+"""Contract tests for CONV-02 multi-turn conversation context memory."""
+
+from __future__ import annotations
+
+import asyncio
+
+from src.platform_api.schemas_v1 import RequestContext
+from src.platform_api.schemas_v2 import CreateConversationSessionRequest, CreateConversationTurnRequest
+from src.platform_api.services.conversation_service import ConversationService
+from src.platform_api.state_store import InMemoryStateStore
+
+
+def _context(*, user_id: str = "user-a") -> RequestContext:
+    return RequestContext(
+        request_id="req-conv-memory-001",
+        tenant_id="tenant-a",
+        user_id=user_id,
+    )
+
+
+def test_context_memory_links_artifacts_across_turns() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        service = ConversationService(store=store)
+        context = _context(user_id="user-a")
+
+        session = await service.create_session(
+            request=CreateConversationSessionRequest(channel="openclaw", topic="execution"),
+            context=context,
+        )
+        session_id = session.session.id
+
+        await service.create_turn(
+            session_id=session_id,
+            request=CreateConversationTurnRequest(
+                role="user",
+                message="deploy strat-001 on dep-001 and watch portfolio-paper-001",
+            ),
+            context=context,
+        )
+        await service.create_turn(
+            session_id=session_id,
+            request=CreateConversationTurnRequest(
+                role="user",
+                message="place a buy order for BTCUSDT",
+            ),
+            context=context,
+        )
+
+        refreshed = await service.get_session(session_id=session_id, context=context)
+        memory = refreshed.session.metadata["contextMemory"]
+        assert memory["lastIntent"] == "order"
+        assert "strat-001" in memory["linkedArtifacts"]["strategyIds"]
+        assert "dep-001" in memory["linkedArtifacts"]["deploymentIds"]
+        assert "portfolio-paper-001" in memory["linkedArtifacts"]["portfolioIds"]
+        assert "BTCUSDT" in memory["symbols"]
+        assert memory["turnCount"] == 2
+
+    asyncio.run(_run())
+
+
+def test_context_memory_applies_recent_message_retention_limit() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        service = ConversationService(store=store)
+        context = _context(user_id="user-a")
+
+        session = await service.create_session(
+            request=CreateConversationSessionRequest(channel="web", topic="retention"),
+            context=context,
+        )
+        session_id = session.session.id
+
+        for idx in range(7):
+            await service.create_turn(
+                session_id=session_id,
+                request=CreateConversationTurnRequest(role="user", message=f"turn {idx}"),
+                context=context,
+            )
+
+        refreshed = await service.get_session(session_id=session_id, context=context)
+        memory = refreshed.session.metadata["contextMemory"]
+        recent_messages = memory["recentMessages"]
+        assert len(recent_messages) == 5
+        assert recent_messages[0]["message"] == "turn 2"
+        assert recent_messages[-1]["message"] == "turn 6"
+
+    asyncio.run(_run())
+
+
+def test_context_memory_isolated_per_user() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        service = ConversationService(store=store)
+
+        user_a = _context(user_id="user-a")
+        user_b = _context(user_id="user-b")
+
+        session_a = await service.create_session(
+            request=CreateConversationSessionRequest(channel="cli", topic="user-a"),
+            context=user_a,
+        )
+        session_b = await service.create_session(
+            request=CreateConversationSessionRequest(channel="cli", topic="user-b"),
+            context=user_b,
+        )
+
+        await service.create_turn(
+            session_id=session_a.session.id,
+            request=CreateConversationTurnRequest(role="user", message="deploy strat-001"),
+            context=user_a,
+        )
+        await service.create_turn(
+            session_id=session_b.session.id,
+            request=CreateConversationTurnRequest(role="user", message="deploy strat-002"),
+            context=user_b,
+        )
+
+        refreshed_a = await service.get_session(session_id=session_a.session.id, context=user_a)
+        refreshed_b = await service.get_session(session_id=session_b.session.id, context=user_b)
+        memory_a = refreshed_a.session.metadata["contextMemory"]
+        memory_b = refreshed_b.session.metadata["contextMemory"]
+
+        assert "strat-001" in memory_a["linkedArtifacts"]["strategyIds"]
+        assert "strat-002" not in memory_a["linkedArtifacts"]["strategyIds"]
+        assert "strat-002" in memory_b["linkedArtifacts"]["strategyIds"]
+        assert "strat-001" not in memory_b["linkedArtifacts"]["strategyIds"]
+
+    asyncio.run(_run())

--- a/backend/tests/contracts/test_platform_api_v2_handlers.py
+++ b/backend/tests/contracts/test_platform_api_v2_handlers.py
@@ -87,6 +87,7 @@ def test_conversation_v2_routes() -> None:
     get_session = client.get(f"/v2/conversations/sessions/{session_id}", headers=HEADERS)
     assert get_session.status_code == 200
     assert get_session.json()["session"]["id"] == session_id
+    assert "contextMemory" in get_session.json()["session"]["metadata"]
 
     create_turn = client.post(
         f"/v2/conversations/sessions/{session_id}/turns",
@@ -97,6 +98,7 @@ def test_conversation_v2_routes() -> None:
     turn_payload = create_turn.json()["turn"]
     assert turn_payload["sessionId"] == session_id
     assert len(turn_payload["suggestions"]) >= 1
+    assert "contextMemorySnapshot" in turn_payload["metadata"]
 
     missing = client.post(
         "/v2/conversations/sessions/conv-missing/turns",

--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -77,6 +77,13 @@ Conversation channel is explicit and normalized by schema enum:
 - `web`
 - `openclaw`
 
+Context memory rules (CONV-02):
+
+1. Conversation context memory is maintained per `tenant_id:user_id` and synchronized into session metadata.
+2. Multi-turn memory tracks recent messages, inferred intent, linked artifacts (strategy/deployment/order/portfolio/backtest/dataset), and symbols.
+3. Retention is explicit and bounded by memory policy (`maxRecentMessages`).
+4. Turn responses carry a `contextMemorySnapshot` in metadata for deterministic client behavior.
+
 ## 2) Internal Adapter Contracts
 
 These interfaces are implementation contracts inside the platform.

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -83,6 +83,13 @@ Conversation channel is explicit and normalized by schema enum:
 - `web`
 - `openclaw`
 
+Context memory rules (CONV-02):
+
+1. Conversation context memory is maintained per `tenant_id:user_id` and synchronized into session metadata.
+2. Multi-turn memory tracks recent messages, inferred intent, linked artifacts (strategy/deployment/order/portfolio/backtest/dataset), and symbols.
+3. Retention is explicit and bounded by memory policy (`maxRecentMessages`).
+4. Turn responses carry a `contextMemorySnapshot` in metadata for deterministic client behavior.
+
 ## 2) Internal Adapter Contracts
 
 These interfaces are implementation contracts inside the platform.

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "384908cdad1a0763aac6dacd884f0223812c03eb5278f8567a97b91b620740b4",
+    "chunk_hash": "5e0f3aa000caab7fec2aae0f7e0860ebc6d34ab64795d99e449417dc402e17b8",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "b27260364a1808a920cd21bd12afddb7c02d2e98c715417abac653dbf1132b3a",
+    "source_hash": "fa3facb3bdec6a816f3b794e0104f7176d8d1d313465c7d9105a62cf78b5b2e7",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "384908cdad1a0763aac6dacd884f0223812c03eb5278f8567a97b91b620740b4",
+    "chunk_hash": "5e0f3aa000caab7fec2aae0f7e0860ebc6d34ab64795d99e449417dc402e17b8",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "b27260364a1808a920cd21bd12afddb7c02d2e98c715417abac653dbf1132b3a"
+    "source_hash": "fa3facb3bdec6a816f3b794e0104f7176d8d1d313465c7d9105a62cf78b5b2e7"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",

--- a/docs/portal/platform/gate4-conversation-contract.md
+++ b/docs/portal/platform/gate4-conversation-contract.md
@@ -1,6 +1,6 @@
 ---
 title: Gate4 Conversation Contract
-summary: Contract-defined conversation API semantics across CLI, Web, and OpenClaw client lanes.
+summary: Contract-defined conversation API semantics across CLI, Web, and OpenClaw client lanes, including context-memory behavior.
 owners:
   - Team E
   - Team B
@@ -27,6 +27,18 @@ Define one conversation contract shared by CLI, Web, and OpenClaw, with additive
 3. Turn creation appends immutable turn records and updates session timestamps.
 4. Missing session IDs return canonical `ErrorResponse` with `404`.
 5. Conversation contract is additive under `/v2`; `/v1` remains unchanged.
+
+## Context Memory Semantics (CONV-02)
+
+1. Memory is scoped per `tenant_id:user_id` and reused across that user's conversation sessions.
+2. Each turn updates bounded context memory:
+  - recent messages (bounded by retention policy),
+  - inferred intent (`deploy | backtest | order | risk | portfolio`),
+  - linked trading artifacts (`strat-*`, `dep-*`, `ord-*`, `portfolio-*`, `bt-*`, `dataset-*`),
+  - symbol references (for example `BTCUSDT`).
+3. Session metadata exposes current memory under `contextMemory`.
+4. Turn metadata includes `contextMemorySnapshot` so clients can render deterministic multi-turn context.
+5. Memory is isolated by user identity and does not leak across users.
 
 ## Boundary Alignment
 


### PR DESCRIPTION
## Summary
- add per-user multi-turn context memory in conversation service (scoped by `tenant_id:user_id`)
- persist and synchronize memory into conversation session metadata (`contextMemory`)
- include deterministic `contextMemorySnapshot` in turn metadata
- track bounded recent messages, inferred intent, linked artifacts (`strat/dep/ord/portfolio/bt/dataset`), and symbol references
- enforce bounded retention policy for recent messages
- add contract tests for memory linking, retention behavior, and user isolation
- update interface + conversation docs and regenerate LLM artifacts

## Validation
- `uv run --directory backend --with pytest python -m pytest tests/contracts/test_conversation_context_memory.py tests/contracts/test_platform_api_v2_handlers.py tests/contracts/test_openapi_contract_v2_baseline.py tests/contracts/test_runtime_openapi_contract_v2.py tests/contracts/test_openapi_contract_baseline.py tests/contracts/test_openapi_contract_freeze.py -q`
- `npm --prefix docs/portal-site run ci`
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`

Fixes #83
Refs #80
Refs #137
Refs #106
Refs #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `/v2` conversation response metadata and introduces new in-memory persistence keyed by `tenant_id:user_id`, which could affect clients that assume opaque metadata or rely on prior session/turn shapes.
> 
> **Overview**
> Adds **CONV-02 per-user conversation context memory** to the `/v2` conversation contract: session creation now hydrates `session.metadata.contextMemory` from a `tenant_id:user_id` store, and each new turn updates that memory (bounded recent messages, inferred intent, linked artifact IDs, and symbols) while returning a deterministic `contextMemorySnapshot` in turn metadata.
> 
> Extends the in-memory state store with `conversation_user_memory`, adds contract tests for cross-turn linking/retention/user isolation, updates v2 handler smoke tests to assert the new metadata fields, and refreshes interface/docs plus regenerated LLM index/trace hashes to document the new semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a181810ba5fd5bdc798124a6bded92fc616f5943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements CONV-02 multi-turn conversation context memory that maintains per-user state across conversation sessions. Memory is scoped by `tenant_id:user_id` and tracks recent messages (bounded by retention policy), inferred intent, linked trading artifacts (strategies, deployments, orders, portfolios, backtests, datasets), and symbol references.

**Key Changes:**
- Session creation hydrates `contextMemory` from user-scoped store
- Each turn updates memory and returns `contextMemorySnapshot` in turn metadata
- Memory retention enforces configurable bounds (default 5 recent messages, 25 artifacts, 25 symbols)
- Regex patterns extract artifact IDs and symbols from user messages
- Contract tests validate cross-turn linking, retention limits, and user isolation

**Minor Issue:**
- Symbol regex pattern on line 291 uses `re.IGNORECASE` with `[A-Z]{2,10}`, which makes the uppercase requirement ineffective

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor regex flag inconsistency that should be clarified
- Well-tested implementation with comprehensive contract tests. The regex flag inconsistency is minor and doesn't break functionality, but should be clarified for intent. Memory isolation, bounded retention, and deterministic snapshots are correctly implemented.
- backend/src/platform_api/services/conversation_service.py (line 291 regex flag)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/services/conversation_service.py | Added multi-turn context memory with bounded retention, artifact linking, and user isolation. Regex patterns extract IDs and symbols from user messages. |
| backend/src/platform_api/state_store.py | Added `conversation_user_memory` dict to store per-user context memory keyed by `tenant_id:user_id`. |
| backend/tests/contracts/test_conversation_context_memory.py | Contract tests validating artifact linking, retention limits, and user isolation for context memory. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Client: Create Session] -->|POST /v2/conversations/sessions| B[ConversationService]
    B -->|Load memory for tenant_id:user_id| C[conversation_user_memory store]
    C -->|Hydrate contextMemory| D[Session metadata]
    D -->|Return session with contextMemory| A
    
    E[Client: Create Turn] -->|POST /v2/conversations/sessions/:id/turns| F[ConversationService]
    F -->|Get existing contextMemory| D
    F -->|Extract artifacts via regex| G[_find_ids]
    F -->|Infer intent from message| H[_infer_intent]
    F -->|Apply retention bounds| I[_append_unique]
    G --> J[Updated contextMemory]
    H --> J
    I --> J
    J -->|Write to session.metadata| D
    J -->|Persist to user memory store| C
    J -->|Return as contextMemorySnapshot| K[Turn metadata]
    K -->|Return turn| E
```

<sub>Last reviewed commit: a181810</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->