### PR TITLE
feat: CONV-03 proactive suggestions and notifications

### DIFF
--- a/backend/src/platform_api/state_store.py
+++ b/backend/src/platform_api/state_store.py
@@ -185,6 +185,21 @@ class ConversationTurnRecord:
     created_at: str = field(default_factory=utc_now)
 
 
+@dataclass
+class ConversationNotificationRecord:
+    id: str
+    session_id: str
+    turn_id: str
+    category: str
+    severity: str
+    message: str
+    request_id: str
+    tenant_id: str
+    user_id: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str = field(default_factory=utc_now)
+
+
 class InMemoryStateStore:
     """Simple in-process persistence for Gate2 thin-slice behavior."""
 
@@ -299,6 +314,7 @@ class InMemoryStateStore:
         self.conversation_sessions: dict[str, ConversationSessionRecord] = {}
         self.conversation_turns: dict[str, list[ConversationTurnRecord]] = {}
         self.conversation_user_memory: dict[str, dict[str, Any]] = {}
+        self.conversation_notifications: dict[str, ConversationNotificationRecord] = {}
         self.risk_policy: dict[str, Any] = {
             "version": "risk-policy.v1",
             "mode": "enforced",
@@ -336,6 +352,7 @@ class InMemoryStateStore:
             "risk_audit": 1,
             "conversation_session": 1,
             "conversation_turn": 1,
+            "conversation_notification": 1,
         }
         self._idempotency: dict[str, dict[str, tuple[str, dict[str, Any]]]] = {
             "deployments": {},
@@ -377,6 +394,8 @@ class InMemoryStateStore:
             return f"conv-{idx:04d}"
         if scope == "conversation_turn":
             return f"turn-{idx:04d}"
+        if scope == "conversation_notification":
+            return f"note-{idx:04d}"
         return f"{scope}-{idx:03d}"
 
     @staticmethod

--- a/backend/tests/contracts/test_conversation_proactive_notifications.py
+++ b/backend/tests/contracts/test_conversation_proactive_notifications.py
@@ -1,0 +1,114 @@
+"""Contract tests for CONV-03 proactive suggestion and notification pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+
+from src.platform_api.schemas_v1 import RequestContext
+from src.platform_api.schemas_v2 import CreateConversationSessionRequest, CreateConversationTurnRequest
+from src.platform_api.services.conversation_service import ConversationService
+from src.platform_api.state_store import InMemoryStateStore
+
+
+def _context(*, user_id: str = "user-a") -> RequestContext:
+    return RequestContext(
+        request_id="req-conv-notify-001",
+        tenant_id="tenant-a",
+        user_id=user_id,
+    )
+
+
+def test_notifications_emitted_when_opted_in_and_audited() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        service = ConversationService(store=store)
+        context = _context()
+
+        session = await service.create_session(
+            request=CreateConversationSessionRequest(
+                channel="openclaw",
+                topic="proactive",
+                metadata={"notificationsOptIn": True},
+            ),
+            context=context,
+        )
+        response = await service.create_turn(
+            session_id=session.session.id,
+            request=CreateConversationTurnRequest(
+                role="user",
+                message="deploy strat-001 and place a buy order on BTCUSDT",
+            ),
+            context=context,
+        )
+
+        notifications = response.turn.metadata["notifications"]
+        assert len(notifications) >= 2
+        assert response.turn.metadata["notificationsOptIn"] is True
+        assert "notificationIds" in response.turn.metadata
+        assert len(store.conversation_notifications) == len(response.turn.metadata["notificationIds"])
+
+        refreshed = await service.get_session(session_id=session.session.id, context=context)
+        assert refreshed.session.metadata["notificationAuditCount"] == len(store.conversation_notifications)
+
+    asyncio.run(_run())
+
+
+def test_notifications_suppressed_when_opt_out_disabled() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        service = ConversationService(store=store)
+        context = _context()
+
+        session = await service.create_session(
+            request=CreateConversationSessionRequest(channel="web", topic="opt-out"),
+            context=context,
+        )
+        response = await service.create_turn(
+            session_id=session.session.id,
+            request=CreateConversationTurnRequest(
+                role="user",
+                message="deploy and place order",
+            ),
+            context=context,
+        )
+
+        assert len(response.turn.suggestions) >= 1
+        assert response.turn.metadata["notificationsOptIn"] is False
+        assert response.turn.metadata["notifications"] == []
+        assert len(store.conversation_notifications) == 0
+
+    asyncio.run(_run())
+
+
+def test_kill_switch_drives_critical_notification() -> None:
+    async def _run() -> None:
+        store = InMemoryStateStore()
+        store.risk_policy["killSwitch"] = {
+            "enabled": True,
+            "triggered": True,
+            "reason": "drawdown",
+        }
+        service = ConversationService(store=store)
+        context = _context()
+
+        session = await service.create_session(
+            request=CreateConversationSessionRequest(
+                channel="cli",
+                topic="risk",
+                metadata={"notificationsOptIn": True},
+            ),
+            context=context,
+        )
+        response = await service.create_turn(
+            session_id=session.session.id,
+            request=CreateConversationTurnRequest(
+                role="user",
+                message="place an order now",
+            ),
+            context=context,
+        )
+
+        notifications = response.turn.metadata["notifications"]
+        assert any(note["category"] == "risk" and note["severity"] == "critical" for note in notifications)
+
+    asyncio.run(_run())

--- a/backend/tests/contracts/test_platform_api_v2_handlers.py
+++ b/backend/tests/contracts/test_platform_api_v2_handlers.py
@@ -76,7 +76,11 @@ def test_conversation_v2_routes() -> None:
     create_session = client.post(
         "/v2/conversations/sessions",
         headers=HEADERS,
-        json={"channel": "openclaw", "topic": "risk-aware deployment"},
+        json={
+            "channel": "openclaw",
+            "topic": "risk-aware deployment",
+            "metadata": {"notificationsOptIn": True},
+        },
     )
     assert create_session.status_code == 201
     session_payload = create_session.json()["session"]
@@ -99,6 +103,7 @@ def test_conversation_v2_routes() -> None:
     assert turn_payload["sessionId"] == session_id
     assert len(turn_payload["suggestions"]) >= 1
     assert "contextMemorySnapshot" in turn_payload["metadata"]
+    assert len(turn_payload["metadata"]["notifications"]) >= 1
 
     missing = client.post(
         "/v2/conversations/sessions/conv-missing/turns",

--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -84,6 +84,13 @@ Context memory rules (CONV-02):
 3. Retention is explicit and bounded by memory policy (`maxRecentMessages`).
 4. Turn responses carry a `contextMemorySnapshot` in metadata for deterministic client behavior.
 
+Proactive pipeline rules (CONV-03):
+
+1. Proactive suggestions are derived from turn intent and context memory signals.
+2. Proactive notifications require explicit session opt-in (`notificationsOptIn`).
+3. Emitted notifications are auditable with persisted records (session, turn, severity, category, request identity).
+4. Opt-out sessions continue receiving non-invasive suggestions without notification delivery.
+
 ## 2) Internal Adapter Contracts
 
 These interfaces are implementation contracts inside the platform.

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -90,6 +90,13 @@ Context memory rules (CONV-02):
 3. Retention is explicit and bounded by memory policy (`maxRecentMessages`).
 4. Turn responses carry a `contextMemorySnapshot` in metadata for deterministic client behavior.
 
+Proactive pipeline rules (CONV-03):
+
+1. Proactive suggestions are derived from turn intent and context memory signals.
+2. Proactive notifications require explicit session opt-in (`notificationsOptIn`).
+3. Emitted notifications are auditable with persisted records (session, turn, severity, category, request identity).
+4. Opt-out sessions continue receiving non-invasive suggestions without notification delivery.
+
 ## 2) Internal Adapter Contracts
 
 These interfaces are implementation contracts inside the platform.

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "5e0f3aa000caab7fec2aae0f7e0860ebc6d34ab64795d99e449417dc402e17b8",
+    "chunk_hash": "a5b7e90a00586ecfca01c5cd2a9b3dd92fd7220e6a86816f250aacf568d87a3a",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "fa3facb3bdec6a816f3b794e0104f7176d8d1d313465c7d9105a62cf78b5b2e7",
+    "source_hash": "a1d06cb2864e105ce3c92f1178cea0bc562c58b2e997f3d32193e0aa48ca0c06",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "5e0f3aa000caab7fec2aae0f7e0860ebc6d34ab64795d99e449417dc402e17b8",
+    "chunk_hash": "a5b7e90a00586ecfca01c5cd2a9b3dd92fd7220e6a86816f250aacf568d87a3a",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "fa3facb3bdec6a816f3b794e0104f7176d8d1d313465c7d9105a62cf78b5b2e7"
+    "source_hash": "a1d06cb2864e105ce3c92f1178cea0bc562c58b2e997f3d32193e0aa48ca0c06"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",

--- a/docs/portal/platform/gate4-conversation-contract.md
+++ b/docs/portal/platform/gate4-conversation-contract.md
@@ -40,6 +40,14 @@ Define one conversation contract shared by CLI, Web, and OpenClaw, with additive
 4. Turn metadata includes `contextMemorySnapshot` so clients can render deterministic multi-turn context.
 5. Memory is isolated by user identity and does not leak across users.
 
+## Proactive Suggestions and Notifications (CONV-03)
+
+1. Turn processing emits proactive suggestions based on message intent and context-memory state.
+2. Notification delivery is controlled by session-level opt-in (`metadata.notificationsOptIn`).
+3. Opted-in sessions receive structured notification payloads in turn metadata.
+4. Every emitted notification writes an audit record with session/turn identity and severity/category metadata.
+5. Opted-out sessions still receive suggestions but no notification emission.
+
 ## Boundary Alignment
 
 - Conversation is a public contract concern, not a provider integration.


### PR DESCRIPTION
## Summary
- implement proactive suggestion and notification pipeline on conversation turns
- enforce session-level notification opt-in (`metadata.notificationsOptIn`)
- persist notification audit records (session/turn/category/severity/request identity)
- keep suggestion generation active even when notification delivery is opted out
- include emitted notifications and audit IDs in turn metadata
- add contract tests for opt-in delivery, opt-out suppression, and kill-switch critical notifications
- update interface + conversation docs and regenerate LLM artifacts

## Validation
- `uv run --directory backend --with pytest python -m pytest tests/contracts/test_conversation_context_memory.py tests/contracts/test_conversation_proactive_notifications.py tests/contracts/test_platform_api_v2_handlers.py tests/contracts/test_openapi_contract_v2_baseline.py tests/contracts/test_runtime_openapi_contract_v2.py tests/contracts/test_openapi_contract_baseline.py tests/contracts/test_openapi_contract_freeze.py -q`
- `npm --prefix docs/portal-site run ci`
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`

Fixes #84
Refs #80
Refs #137
Refs #106
Refs #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `/v2` conversation response shape and adds new persistence/audit side effects on turn creation, which may impact clients and test expectations despite being gated by an opt-in flag.
> 
> **Overview**
> Adds a CONV-03 proactive pipeline on `/v2` conversation turns: turn `suggestions` are now augmented with intent/context-driven proactive messages and capped per turn, and turn metadata gains `notificationsOptIn` plus a structured `notifications` list.
> 
> Introduces session-level notification opt-in (`metadata.notificationsOptIn`) and notification auditing: opted-in turns persist `ConversationNotificationRecord` entries in the `InMemoryStateStore` (with request/tenant/user identity) and increment `notificationAuditCount` on the session, returning `notificationIds` in turn metadata. Updates contract tests and docs/LLM artifacts to cover opt-in delivery, opt-out suppression, and kill-switch critical notifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e987762dd53fdb6c80dff294de19b387b3e5515c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements CONV-03 proactive suggestion and notification pipeline for the conversation service. The change introduces a context-aware notification system that generates suggestions based on user message intent (deploy, order, risk) and conversation memory, while respecting session-level opt-in preferences.

**Key Changes:**
- Proactive notification generation driven by message keywords and `lastIntent` from context memory
- Session-level opt-in control via `metadata.notificationsOptIn` flag
- Audit trail persistence with `ConversationNotificationRecord` storing session, turn, severity, category, and request identity
- Kill-switch detection emits critical notifications regardless of intent
- Suggestions always generated; notifications only delivered when opted in
- Notification deduplication by message content with order preservation
- Session metadata tracks `notificationAuditCount` for monitoring

**Implementation Quality:**
- Clean separation between suggestion generation and notification delivery
- Proper audit trail with full context preservation
- Comprehensive contract tests covering opt-in, opt-out, and critical scenarios
- Documentation updated across architecture, portal, and LLM artifacts

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk, requiring only minor verification of edge cases.
- Score reflects well-structured implementation with proper opt-in controls, comprehensive test coverage, and clean data modeling. The notification pipeline correctly separates suggestion generation from delivery, implements proper deduplication, and maintains a complete audit trail. Documentation is thorough across all required artifacts. One minor area for attention is ensuring the `_append_unique` method behavior is understood when merging suggestions and notifications.
- Pay close attention to `backend/src/platform_api/services/conversation_service.py` to verify the notification merging logic in `_append_unique` behaves as expected when combining derived suggestions with proactive notifications.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/services/conversation_service.py | Implements proactive notification pipeline with opt-in delivery, suggestion generation, and audit trail persistence. Logic is solid with proper deduplication and context-aware notifications. |
| backend/src/platform_api/state_store.py | Adds `ConversationNotificationRecord` dataclass and storage dictionary. Clean data model addition with proper field definitions. |
| backend/tests/contracts/test_conversation_proactive_notifications.py | Comprehensive contract tests covering opt-in delivery, opt-out suppression, and kill-switch critical notifications. Well-structured test coverage. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[User creates conversation turn] --> B{Check role}
    B -->|role == user| C[Derive proactive notifications]
    B -->|role != user| D[Skip notification generation]
    
    C --> E{Check kill-switch}
    E -->|triggered| F[Add critical risk notification]
    E -->|not triggered| G[Continue]
    
    F --> G
    G --> H{Check message intent}
    H -->|deploy| I[Add deployment notification]
    H -->|order/buy/sell| J[Add risk limit notification]
    H -->|drawdown/risk| K[Add drawdown notification]
    
    I --> L[Deduplicate notifications]
    J --> L
    K --> L
    
    L --> M[Convert to proactive suggestions]
    M --> N[Merge with derived suggestions]
    N --> O{Session notificationsOptIn?}
    
    O -->|true| P[Record notification audit trail]
    O -->|false| Q[Skip audit recording]
    
    P --> R[Add notifications to turn metadata]
    P --> S[Increment session notificationAuditCount]
    
    Q --> T[Set notifications to empty array]
    
    R --> U[Return turn response]
    S --> U
    T --> U
    D --> U
```

<sub>Last reviewed commit: e987762</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->