### PR TITLE
feat: AG-ORCH-02 queue and cancellation controls

### DIFF
--- a/backend/src/platform_api/services/orchestrator_queue_service.py
+++ b/backend/src/platform_api/services/orchestrator_queue_service.py
@@ -1,0 +1,120 @@
+"""Orchestrator queue, prioritization, and cancellation controls (AG-ORCH-02)."""
+
+from __future__ import annotations
+
+import heapq
+from dataclasses import dataclass, field
+from itertools import count
+from typing import Any
+
+from src.platform_api.services.orchestrator_state_machine import (
+    INITIAL_ORCHESTRATOR_STATE,
+    OrchestratorTransitionError,
+    transition_state,
+)
+from src.platform_api.state_store import utc_now
+
+
+@dataclass
+class OrchestratorWorkItem:
+    id: str
+    priority: int
+    state: str = INITIAL_ORCHESTRATOR_STATE
+    payload: dict[str, Any] = field(default_factory=dict)
+    cancellation_reason: str | None = None
+    created_at: str = field(default_factory=utc_now)
+    updated_at: str = field(default_factory=utc_now)
+
+
+class OrchestratorQueueService:
+    """Deterministic queue with priority ordering and safe cancellation semantics."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, OrchestratorWorkItem] = {}
+        self._queue: list[tuple[int, int, str]] = []
+        self._sequence = count(1)
+
+    def enqueue(
+        self,
+        *,
+        item_id: str,
+        priority: int = 100,
+        payload: dict[str, Any] | None = None,
+    ) -> OrchestratorWorkItem:
+        if item_id in self._items:
+            raise ValueError(f"Orchestrator item already exists: {item_id}")
+
+        item = OrchestratorWorkItem(
+            id=item_id,
+            priority=priority,
+            payload=dict(payload or {}),
+        )
+        item.state = transition_state(item.state, "queued")
+        item.updated_at = utc_now()
+        self._items[item_id] = item
+        heapq.heappush(self._queue, (priority, next(self._sequence), item_id))
+        return item
+
+    def dequeue_next(self) -> OrchestratorWorkItem | None:
+        while self._queue:
+            _, _, item_id = heapq.heappop(self._queue)
+            item = self._items[item_id]
+            if item.state != "queued":
+                continue
+            item.state = transition_state(item.state, "executing")
+            item.updated_at = utc_now()
+            return item
+        return None
+
+    def cancel(self, *, item_id: str, reason: str) -> OrchestratorWorkItem:
+        item = self._require(item_id)
+        item.state = transition_state(item.state, "cancelled")
+        item.cancellation_reason = reason
+        item.updated_at = utc_now()
+        return item
+
+    def mark_awaiting_tool(self, *, item_id: str) -> OrchestratorWorkItem:
+        item = self._require(item_id)
+        item.state = transition_state(item.state, "awaiting_tool")
+        item.updated_at = utc_now()
+        return item
+
+    def mark_awaiting_user_confirmation(self, *, item_id: str) -> OrchestratorWorkItem:
+        item = self._require(item_id)
+        item.state = transition_state(item.state, "awaiting_user_confirmation")
+        item.updated_at = utc_now()
+        return item
+
+    def resume(self, *, item_id: str) -> OrchestratorWorkItem:
+        item = self._require(item_id)
+        item.state = transition_state(item.state, "executing")
+        item.updated_at = utc_now()
+        return item
+
+    def complete(self, *, item_id: str) -> OrchestratorWorkItem:
+        item = self._require(item_id)
+        item.state = transition_state(item.state, "completed")
+        item.updated_at = utc_now()
+        return item
+
+    def fail(self, *, item_id: str) -> OrchestratorWorkItem:
+        item = self._require(item_id)
+        item.state = transition_state(item.state, "failed")
+        item.updated_at = utc_now()
+        return item
+
+    def get(self, *, item_id: str) -> OrchestratorWorkItem:
+        return self._require(item_id)
+
+    def _require(self, item_id: str) -> OrchestratorWorkItem:
+        item = self._items.get(item_id)
+        if item is None:
+            raise KeyError(f"Orchestrator item not found: {item_id}")
+        return item
+
+
+__all__ = [
+    "OrchestratorQueueService",
+    "OrchestratorTransitionError",
+    "OrchestratorWorkItem",
+]

--- a/backend/tests/contracts/test_orchestrator_queue_cancellation.py
+++ b/backend/tests/contracts/test_orchestrator_queue_cancellation.py
@@ -1,0 +1,84 @@
+"""Contract tests for AG-ORCH-02 queue prioritization and cancellation semantics."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.platform_api.services.orchestrator_queue_service import (
+    OrchestratorQueueService,
+    OrchestratorTransitionError,
+)
+
+
+def test_priority_queue_dequeues_highest_priority_first() -> None:
+    service = OrchestratorQueueService()
+
+    service.enqueue(item_id="orch-low", priority=50)
+    service.enqueue(item_id="orch-high", priority=10)
+    service.enqueue(item_id="orch-mid", priority=20)
+
+    first = service.dequeue_next()
+    second = service.dequeue_next()
+    third = service.dequeue_next()
+
+    assert first is not None and first.id == "orch-high"
+    assert second is not None and second.id == "orch-mid"
+    assert third is not None and third.id == "orch-low"
+    assert service.dequeue_next() is None
+
+
+def test_fifo_order_for_same_priority() -> None:
+    service = OrchestratorQueueService()
+
+    service.enqueue(item_id="orch-a", priority=20)
+    service.enqueue(item_id="orch-b", priority=20)
+    service.enqueue(item_id="orch-c", priority=20)
+
+    assert service.dequeue_next().id == "orch-a"  # type: ignore[union-attr]
+    assert service.dequeue_next().id == "orch-b"  # type: ignore[union-attr]
+    assert service.dequeue_next().id == "orch-c"  # type: ignore[union-attr]
+
+
+def test_cancelling_queued_item_prevents_execution() -> None:
+    service = OrchestratorQueueService()
+
+    service.enqueue(item_id="orch-queued", priority=5)
+    cancelled = service.cancel(item_id="orch-queued", reason="superseded")
+    assert cancelled.state == "cancelled"
+    assert cancelled.cancellation_reason == "superseded"
+    assert service.dequeue_next() is None
+
+
+def test_cancelling_executing_item_is_allowed() -> None:
+    service = OrchestratorQueueService()
+
+    service.enqueue(item_id="orch-exec", priority=5)
+    executing = service.dequeue_next()
+    assert executing is not None and executing.state == "executing"
+
+    cancelled = service.cancel(item_id="orch-exec", reason="manual override")
+    assert cancelled.state == "cancelled"
+    assert cancelled.cancellation_reason == "manual override"
+
+
+def test_terminal_item_cannot_be_cancelled() -> None:
+    service = OrchestratorQueueService()
+
+    service.enqueue(item_id="orch-done", priority=10)
+    service.dequeue_next()
+    service.complete(item_id="orch-done")
+
+    with pytest.raises(OrchestratorTransitionError):
+        service.cancel(item_id="orch-done", reason="should fail")
+
+
+def test_queue_skips_cancelled_items_and_continues() -> None:
+    service = OrchestratorQueueService()
+
+    service.enqueue(item_id="orch-a", priority=10)
+    service.enqueue(item_id="orch-b", priority=20)
+    service.cancel(item_id="orch-a", reason="duplicate")
+
+    next_item = service.dequeue_next()
+    assert next_item is not None
+    assert next_item.id == "orch-b"

--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -325,6 +325,9 @@ Transition rules:
 3. `executing` can move to `awaiting_tool`, `awaiting_user_confirmation`, `completed`, `failed`, or `cancelled`.
 4. `awaiting_tool` and `awaiting_user_confirmation` can return only to `executing`, or end in `failed`/`cancelled`.
 5. Terminal states are immutable: `completed`, `failed`, and `cancelled` cannot transition to any different state.
+6. Queue scheduling is deterministic: lower numeric priority executes first; same priority preserves FIFO order.
+7. Cancelling a queued item removes it from execution eligibility and keeps state immutable at `cancelled`.
+8. Cancelling an executing or awaiting item transitions directly to `cancelled` with explicit cancellation reason.
 
 ## 6) Risk Policy Schema Contract (AG-RISK-01)
 

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -331,6 +331,9 @@ Transition rules:
 3. `executing` can move to `awaiting_tool`, `awaiting_user_confirmation`, `completed`, `failed`, or `cancelled`.
 4. `awaiting_tool` and `awaiting_user_confirmation` can return only to `executing`, or end in `failed`/`cancelled`.
 5. Terminal states are immutable: `completed`, `failed`, and `cancelled` cannot transition to any different state.
+6. Queue scheduling is deterministic: lower numeric priority executes first; same priority preserves FIFO order.
+7. Cancelling a queued item removes it from execution eligibility and keeps state immutable at `cancelled`.
+8. Cancelling an executing or awaiting item transitions directly to `cancelled` with explicit cancellation reason.
 
 ## 6) Risk Policy Schema Contract (AG-RISK-01)
 

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "b12a9de2aebbbbc4e3b16bd46e6021fa796c8b0de837cdea69a898a929922a60",
+    "chunk_hash": "973c5ee86ca194d5fa64384d8c8ce58dadb4585eb7f06f8b3eaf02827f4fcc8d",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "cff05595edab60085a2700f506c74996edc8e4e7147cc80432778af1bf8274df",
+    "source_hash": "14243e423ac1021f2c3586462ae4901f10a41ae61f95d8765a1ddb091faaeb24",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "b12a9de2aebbbbc4e3b16bd46e6021fa796c8b0de837cdea69a898a929922a60",
+    "chunk_hash": "973c5ee86ca194d5fa64384d8c8ce58dadb4585eb7f06f8b3eaf02827f4fcc8d",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "cff05595edab60085a2700f506c74996edc8e4e7147cc80432778af1bf8274df"
+    "source_hash": "14243e423ac1021f2c3586462ae4901f10a41ae61f95d8765a1ddb091faaeb24"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",


### PR DESCRIPTION
## Summary
- add deterministic orchestrator queue service with priority and FIFO semantics
- implement safe cancellation for queued/executing/awaiting states with reason tracking
- keep terminal state immutability enforced by orchestrator state machine
- add AG-ORCH-02 contract tests for ordering, cancellation behavior, and invalid terminal cancellation
- update interfaces + operations docs and regenerate LLM artifacts

## Validation
- `uv run --directory backend --with pytest python -m pytest tests/contracts/test_orchestrator_state_machine.py tests/contracts/test_orchestrator_queue_cancellation.py tests/contracts/test_execution_command_layer.py tests/contracts/test_execution_command_idempotency.py -q`
- `npm --prefix docs/portal-site run ci`
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`

Fixes #47
Refs #77
Refs #138
Refs #106
Refs #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New queue/cancellation runtime semantics can affect orchestrator execution ordering and termination behavior; however changes are isolated, state transitions are contract-enforced, and covered by focused contract tests.
> 
> **Overview**
> Adds `OrchestratorQueueService`, an in-memory deterministic priority queue for orchestrator work items that enforces state transitions via the existing state machine, supports FIFO tie-breaking, and records cancellation reasons.
> 
> Introduces contract tests covering priority/FIFO dequeueing, cancellation behavior across `queued`/`executing`/terminal states, and skipping cancelled items. Updates architecture + Gate4 ops docs to formalize queue scheduling/cancellation rules and regenerates LLM artifact hashes (`docs/llm/*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e89da3a25e62ec81b0f088ae5c8c2624b482d5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements `OrchestratorQueueService` with deterministic priority-based scheduling (lower priority values execute first) and FIFO tie-breaking using Python's `heapq` and a monotonic sequence counter. Cancellation is supported for `queued`, `executing`, and `awaiting_*` states with explicit reason tracking, while terminal states (`completed`, `failed`, `cancelled`) remain immutable per the existing state machine contract.

- New 120-line queue service leverages `orchestrator_state_machine.transition_state` to enforce all state transitions, preventing invalid operations
- `dequeue_next` skips cancelled items automatically, ensuring only `queued` items transition to `executing`
- Contract tests validate priority ordering, FIFO semantics, cancellation prevention for terminal states, and queue skipping behavior
- Documentation updates formalize queue scheduling rules and cancellation semantics in architecture contracts and operations guides
- LLM artifact hashes regenerated to reflect updated interface documentation

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Implementation is well-isolated, leverages existing state machine contract for validation, includes comprehensive contract tests covering edge cases (priority, FIFO, cancellation, terminal state immutability), and updates are limited to new service module with no modifications to existing runtime logic
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/services/orchestrator_queue_service.py | New priority queue implementation with FIFO tie-breaking and state-machine-enforced transitions |
| backend/tests/contracts/test_orchestrator_queue_cancellation.py | Contract tests covering priority ordering, FIFO, cancellation semantics, and terminal state immutability |
| docs/architecture/INTERFACES.md | Added three queue/cancellation contract rules to orchestrator state machine section |
| docs/portal/operations/gate4-orchestrator-controls.md | Added AG-ORCH-02 queue/cancellation controls section with deterministic scheduling rules |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    Start([New Work Item]) --> Received[received]
    Received --> Enqueue{enqueue}
    Enqueue --> Queued[queued]
    
    Queued --> Dequeue{dequeue_next}
    Dequeue --> CheckState{state == queued?}
    CheckState -->|yes| Executing[executing]
    CheckState -->|no - skip| Dequeue
    
    Executing --> ExecuteOps{operation}
    ExecuteOps -->|tool needed| AwaitingTool[awaiting_tool]
    ExecuteOps -->|user input needed| AwaitingUser[awaiting_user_confirmation]
    ExecuteOps -->|success| Completed[completed]
    ExecuteOps -->|error| Failed[failed]
    
    AwaitingTool --> Resume1{resume}
    AwaitingUser --> Resume2{resume}
    Resume1 --> Executing
    Resume2 --> Executing
    
    Queued -.->|cancel| Cancelled[cancelled]
    Executing -.->|cancel| Cancelled
    AwaitingTool -.->|cancel| Cancelled
    AwaitingUser -.->|cancel| Cancelled
    
    Completed -.->|immutable| Completed
    Failed -.->|immutable| Failed
    Cancelled -.->|immutable| Cancelled
    
    style Completed fill:#4ade80
    style Failed fill:#f87171
    style Cancelled fill:#fbbf24
    style Queued fill:#60a5fa
    style Executing fill:#a78bfa
```

<sub>Last reviewed commit: 4e89da3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->