### PR TITLE
feat: AG-ORCH-03 retry and failure budget policy

### DIFF
--- a/backend/src/platform_api/services/orchestrator_retry_policy.py
+++ b/backend/src/platform_api/services/orchestrator_retry_policy.py
@@ -1,0 +1,120 @@
+"""Deterministic orchestrator retry and failure-budget controls (AG-ORCH-03)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RetryBudgetPolicy:
+    max_attempts: int = 3
+    max_failures: int = 3
+    base_backoff_seconds: int = 1
+    max_backoff_seconds: int = 30
+
+
+@dataclass
+class RetryRuntimeState:
+    attempts: int = 0
+    failures: int = 0
+    terminal: bool = False
+
+
+@dataclass(frozen=True)
+class RetryDecision:
+    retry_allowed: bool
+    terminal: bool
+    next_state: str
+    reason: str
+    retry_after_seconds: int | None
+    attempts: int
+    failures: int
+    remaining_attempts: int
+    remaining_failures: int
+
+
+class OrchestratorRetryPolicyService:
+    """Tracks attempts/failures and emits deterministic bounded retry decisions."""
+
+    def __init__(self, *, policy: RetryBudgetPolicy | None = None) -> None:
+        self._policy = policy or RetryBudgetPolicy()
+        self._state_by_item: dict[str, RetryRuntimeState] = {}
+
+    def begin_attempt(self, *, item_id: str) -> RetryRuntimeState:
+        state = self._state_for(item_id)
+        if state.terminal:
+            raise ValueError(f"Retry state is terminal for item: {item_id}")
+        state.attempts += 1
+        return state
+
+    def record_failure(self, *, item_id: str) -> RetryDecision:
+        state = self._state_for(item_id)
+        if state.terminal:
+            return self._terminal_decision(state=state, reason="failure_budget_exhausted")
+        if state.attempts == 0:
+            state.attempts = 1
+        state.failures += 1
+
+        attempts_exhausted = state.attempts >= self._policy.max_attempts
+        failures_exhausted = state.failures >= self._policy.max_failures
+        if attempts_exhausted or failures_exhausted:
+            state.terminal = True
+            reason = "attempt_budget_exhausted" if attempts_exhausted else "failure_budget_exhausted"
+            return self._terminal_decision(state=state, reason=reason)
+
+        retry_after_seconds = min(
+            self._policy.base_backoff_seconds * (2 ** max(state.failures - 1, 0)),
+            self._policy.max_backoff_seconds,
+        )
+        return RetryDecision(
+            retry_allowed=True,
+            terminal=False,
+            next_state="awaiting_tool",
+            reason="retry_scheduled",
+            retry_after_seconds=retry_after_seconds,
+            attempts=state.attempts,
+            failures=state.failures,
+            remaining_attempts=max(self._policy.max_attempts - state.attempts, 0),
+            remaining_failures=max(self._policy.max_failures - state.failures, 0),
+        )
+
+    def record_success(self, *, item_id: str) -> RetryRuntimeState:
+        state = self._state_for(item_id)
+        state.terminal = True
+        return state
+
+    def snapshot(self, *, item_id: str) -> RetryRuntimeState:
+        state = self._state_for(item_id)
+        return RetryRuntimeState(
+            attempts=state.attempts,
+            failures=state.failures,
+            terminal=state.terminal,
+        )
+
+    def _state_for(self, item_id: str) -> RetryRuntimeState:
+        state = self._state_by_item.get(item_id)
+        if state is None:
+            state = RetryRuntimeState()
+            self._state_by_item[item_id] = state
+        return state
+
+    def _terminal_decision(self, *, state: RetryRuntimeState, reason: str) -> RetryDecision:
+        return RetryDecision(
+            retry_allowed=False,
+            terminal=True,
+            next_state="failed",
+            reason=reason,
+            retry_after_seconds=None,
+            attempts=state.attempts,
+            failures=state.failures,
+            remaining_attempts=max(self._policy.max_attempts - state.attempts, 0),
+            remaining_failures=max(self._policy.max_failures - state.failures, 0),
+        )
+
+
+__all__ = [
+    "OrchestratorRetryPolicyService",
+    "RetryBudgetPolicy",
+    "RetryDecision",
+    "RetryRuntimeState",
+]

--- a/backend/tests/contracts/test_orchestrator_retry_policy.py
+++ b/backend/tests/contracts/test_orchestrator_retry_policy.py
@@ -1,0 +1,89 @@
+"""Contract tests for AG-ORCH-03 retry/failure budget policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.platform_api.services.orchestrator_retry_policy import (
+    OrchestratorRetryPolicyService,
+    RetryBudgetPolicy,
+)
+
+
+def test_retry_policy_is_deterministic_and_bounded() -> None:
+    service = OrchestratorRetryPolicyService(
+        policy=RetryBudgetPolicy(
+            max_attempts=3,
+            max_failures=3,
+            base_backoff_seconds=2,
+            max_backoff_seconds=30,
+        )
+    )
+
+    service.begin_attempt(item_id="orch-001")
+    first = service.record_failure(item_id="orch-001")
+    assert first.retry_allowed is True
+    assert first.next_state == "awaiting_tool"
+    assert first.retry_after_seconds == 2
+
+    service.begin_attempt(item_id="orch-001")
+    second = service.record_failure(item_id="orch-001")
+    assert second.retry_allowed is True
+    assert second.next_state == "awaiting_tool"
+    assert second.retry_after_seconds == 4
+
+    service.begin_attempt(item_id="orch-001")
+    third = service.record_failure(item_id="orch-001")
+    assert third.retry_allowed is False
+    assert third.terminal is True
+    assert third.next_state == "failed"
+    assert third.reason == "attempt_budget_exhausted"
+
+
+def test_failure_budget_exhaustion_precedes_attempt_budget() -> None:
+    service = OrchestratorRetryPolicyService(
+        policy=RetryBudgetPolicy(
+            max_attempts=5,
+            max_failures=2,
+            base_backoff_seconds=1,
+            max_backoff_seconds=30,
+        )
+    )
+
+    service.begin_attempt(item_id="orch-002")
+    first = service.record_failure(item_id="orch-002")
+    assert first.retry_allowed is True
+
+    service.begin_attempt(item_id="orch-002")
+    second = service.record_failure(item_id="orch-002")
+    assert second.retry_allowed is False
+    assert second.terminal is True
+    assert second.reason == "failure_budget_exhausted"
+
+
+def test_begin_attempt_fails_after_terminal_state() -> None:
+    service = OrchestratorRetryPolicyService(
+        policy=RetryBudgetPolicy(
+            max_attempts=1,
+            max_failures=1,
+        )
+    )
+
+    service.begin_attempt(item_id="orch-003")
+    decision = service.record_failure(item_id="orch-003")
+    assert decision.terminal is True
+
+    with pytest.raises(ValueError):
+        service.begin_attempt(item_id="orch-003")
+
+
+def test_success_marks_retry_state_terminal() -> None:
+    service = OrchestratorRetryPolicyService()
+    service.begin_attempt(item_id="orch-004")
+    state = service.record_success(item_id="orch-004")
+    assert state.terminal is True
+
+    snapshot = service.snapshot(item_id="orch-004")
+    assert snapshot.attempts == 1
+    assert snapshot.failures == 0
+    assert snapshot.terminal is True

--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -328,6 +328,9 @@ Transition rules:
 6. Queue scheduling is deterministic: lower numeric priority executes first; same priority preserves FIFO order.
 7. Cancelling a queued item removes it from execution eligibility and keeps state immutable at `cancelled`.
 8. Cancelling an executing or awaiting item transitions directly to `cancelled` with explicit cancellation reason.
+9. Retry policy must be deterministic and budgeted by `max_attempts` and `max_failures`.
+10. Retry-eligible failures transition to retry-wait semantics (`awaiting_tool`) with bounded backoff metadata.
+11. Budget exhaustion transitions to terminal `failed` with explicit exhaustion reason.
 
 ## 6) Risk Policy Schema Contract (AG-RISK-01)
 

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -334,6 +334,9 @@ Transition rules:
 6. Queue scheduling is deterministic: lower numeric priority executes first; same priority preserves FIFO order.
 7. Cancelling a queued item removes it from execution eligibility and keeps state immutable at `cancelled`.
 8. Cancelling an executing or awaiting item transitions directly to `cancelled` with explicit cancellation reason.
+9. Retry policy must be deterministic and budgeted by `max_attempts` and `max_failures`.
+10. Retry-eligible failures transition to retry-wait semantics (`awaiting_tool`) with bounded backoff metadata.
+11. Budget exhaustion transitions to terminal `failed` with explicit exhaustion reason.
 
 ## 6) Risk Policy Schema Contract (AG-RISK-01)
 

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "973c5ee86ca194d5fa64384d8c8ce58dadb4585eb7f06f8b3eaf02827f4fcc8d",
+    "chunk_hash": "253e386d78f68d405a918d7d86c7a342bfd69dc3e171ed28e94604619cf3f349",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "14243e423ac1021f2c3586462ae4901f10a41ae61f95d8765a1ddb091faaeb24",
+    "source_hash": "e15f41e090d8a35ee3656dd06e00972a477025d09223a7161143dc54adecdd2e",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "973c5ee86ca194d5fa64384d8c8ce58dadb4585eb7f06f8b3eaf02827f4fcc8d",
+    "chunk_hash": "253e386d78f68d405a918d7d86c7a342bfd69dc3e171ed28e94604619cf3f349",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "14243e423ac1021f2c3586462ae4901f10a41ae61f95d8765a1ddb091faaeb24"
+    "source_hash": "e15f41e090d8a35ee3656dd06e00972a477025d09223a7161143dc54adecdd2e"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",

--- a/docs/portal/operations/gate4-orchestrator-controls.md
+++ b/docs/portal/operations/gate4-orchestrator-controls.md
@@ -12,7 +12,7 @@ updated: 2026-02-14
 
 ## Objective
 
-Define a deterministic orchestrator lifecycle, queue/cancellation controls, and execution command boundary so runtime behavior can be tested, audited, and safely hardened.
+Define a deterministic orchestrator lifecycle, queue/cancellation controls, retry/failure-budget policy, and execution command boundary so runtime behavior can be tested, audited, and safely hardened.
 
 ## State Contract
 
@@ -45,10 +45,19 @@ Queue/cancellation runtime semantics are active:
 5. Cancelling executing/awaiting work transitions directly to `cancelled`.
 6. Terminal states remain immutable under cancellation attempts.
 
+## Retry and Failure Budget Policy (AG-ORCH-03)
+
+Retry runtime semantics are deterministic and bounded:
+
+1. Retry decisions are constrained by explicit `max_attempts` and `max_failures`.
+2. Retry-eligible failures emit bounded exponential backoff delay metadata.
+3. Retry path remains non-terminal and maps to retry-wait execution state (`awaiting_tool`).
+4. Attempt/failure budget exhaustion emits terminal `failed` decision with deterministic reason codes.
+5. Terminal retry states are immutable for further attempt scheduling.
+
 ## Gate4 Scope Boundary
 
-- AG-ORCH-01 transition contract and AG-ORCH-02 queue/cancellation controls are active.
-- Retry and failure budget policy lands in AG-ORCH-03 (`#48`).
+- AG-ORCH-01 transition contract, AG-ORCH-02 queue/cancellation controls, and AG-ORCH-03 retry/failure budget policy are active.
 
 ## Execution Command Boundary (AG-EXE-01)
 
@@ -65,9 +74,11 @@ Execution side-effect operations are routed through internal command handlers be
 - Architecture interface contract: `/docs/architecture/INTERFACES.md`
 - Runtime implementation: `/backend/src/platform_api/services/orchestrator_state_machine.py`
 - Queue/cancellation runtime: `/backend/src/platform_api/services/orchestrator_queue_service.py`
+- Retry policy runtime: `/backend/src/platform_api/services/orchestrator_retry_policy.py`
 - Execution command runtime: `/backend/src/platform_api/services/execution_command_service.py`
 - Contract tests: `/backend/tests/contracts/test_orchestrator_state_machine.py`
 - Contract tests: `/backend/tests/contracts/test_orchestrator_queue_cancellation.py`
+- Contract tests: `/backend/tests/contracts/test_orchestrator_retry_policy.py`
 - Contract tests: `/backend/tests/contracts/test_execution_command_layer.py`
 - Contract tests: `/backend/tests/contracts/test_execution_command_idempotency.py`
 - Related epics/issues: `#77`, `#138`, `#106`


### PR DESCRIPTION
## Summary
- add deterministic orchestrator retry policy service with explicit attempt/failure budgets
- implement bounded retry decisions with deterministic backoff and explicit next-state outcomes
- enforce budget exhaustion behavior that transitions to terminal failure decisions
- add AG-ORCH-03 contract tests for deterministic retry paths, budget exhaustion, and terminal immutability
- update interfaces + operations docs and regenerate LLM artifacts

## Validation
- `uv run --directory backend --with pytest python -m pytest tests/contracts/test_orchestrator_state_machine.py tests/contracts/test_orchestrator_queue_cancellation.py tests/contracts/test_orchestrator_retry_policy.py tests/contracts/test_execution_command_layer.py tests/contracts/test_execution_command_idempotency.py -q`
- `npm --prefix docs/portal-site run ci`
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`

Fixes #48
Refs #77
Refs #138
Refs #106
Refs #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new orchestrator control logic that will influence how failures retry vs. become terminal; incorrect wiring or interpretation of budgets/reason codes could change runtime behavior. Changes are otherwise additive with focused contract tests.
> 
> **Overview**
> Adds a new `OrchestratorRetryPolicyService` that tracks per-item attempts/failures and produces deterministic retry decisions with **explicit attempt/failure budgets** and **bounded exponential backoff** (retrying via `awaiting_tool`, failing terminally with reason codes).
> 
> Introduces contract tests covering determinism/backoff, budget-exhaustion precedence, and terminal immutability, and updates orchestrator interface/operations docs (plus regenerated LLM doc index/traceability hashes) to codify the AG-ORCH-03 retry semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7a8791f189c9db891a8079dd2e06c2423296102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented deterministic retry policy service (AG-ORCH-03) with explicit attempt/failure budgets and bounded exponential backoff for orchestrator control flow.

- Added `OrchestratorRetryPolicyService` with mutable per-item retry state tracking
- Implemented bounded retry decisions with deterministic backoff calculation (base * 2^(failures-1), capped at max)
- Enforced budget exhaustion behavior transitioning to terminal `failed` state with explicit reason codes
- Added comprehensive contract tests covering deterministic paths, budget precedence, and terminal immutability
- Updated interface contracts and operations documentation with three new transition rules (9-11)
- Regenerated LLM artifacts with updated architecture documentation hashes

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor logical issue in terminal state reason reporting
- Implementation is deterministic and well-tested with comprehensive contract coverage, but `record_failure` on already-terminal states returns misleading "failure_budget_exhausted" reason regardless of how terminal state was reached (success vs. exhaustion)
- backend/src/platform_api/services/orchestrator_retry_policy.py - review terminal state reason logic at line 52-53

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/services/orchestrator_retry_policy.py | Added deterministic retry policy service with bounded exponential backoff; minor issue with terminal state reason reporting |
| backend/tests/contracts/test_orchestrator_retry_policy.py | Comprehensive contract tests for retry policy covering deterministic paths, budget exhaustion, and terminal state immutability |
| docs/architecture/INTERFACES.md | Added three transition rules (9-11) documenting retry policy contract: deterministic budgets, backoff metadata, and terminal failure states |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    Start([begin_attempt]) --> CheckTerminal{state.terminal?}
    CheckTerminal -->|true| RaiseError[Raise ValueError]
    CheckTerminal -->|false| IncrAttempts[attempts++]
    
    IncrAttempts --> Failure([record_failure])
    Failure --> CheckTerm2{state.terminal?}
    CheckTerm2 -->|true| ReturnTerminal[Return terminal decision]
    CheckTerm2 -->|false| AutoCorrect{attempts == 0?}
    AutoCorrect -->|true| SetAttempts[attempts = 1]
    AutoCorrect -->|false| IncrFailures[failures++]
    SetAttempts --> IncrFailures
    
    IncrFailures --> CheckBudgets{attempts >= max_attempts<br/>OR<br/>failures >= max_failures?}
    CheckBudgets -->|true| MarkTerminal[terminal = true]
    MarkTerminal --> TerminalDecision[Return terminal decision<br/>next_state: failed]
    
    CheckBudgets -->|false| CalcBackoff[Calculate backoff:<br/>min base * 2^failures-1, max]
    CalcBackoff --> RetryDecision[Return retry decision<br/>next_state: awaiting_tool]
    
    IncrAttempts --> Success([record_success])
    Success --> MarkSuccess[terminal = true]
```

<sub>Last reviewed commit: b7a8791</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->