### PR TITLE
docs: DOC-16 regenerate Gate4 LLM package and traceability

### DIFF
--- a/docs/llm/chunks/portal_gate4_conversation_contract_v1.md
+++ b/docs/llm/chunks/portal_gate4_conversation_contract_v1.md
@@ -1,0 +1,99 @@
+# Gate4 Conversation Contract
+
+Source: `docs/portal/platform/gate4-conversation-contract.md`
+Topic: `platform`
+Stable ID: `portal_gate4_conversation_contract_v1`
+
+# Gate4 Conversation Contract
+
+## Objective
+
+Define one conversation contract shared by CLI, Web, and OpenClaw, with additive `/v2` API semantics.
+
+## Endpoints
+
+- `POST /v2/conversations/sessions`
+- `GET /v2/conversations/sessions/{sessionId}`
+- `POST /v2/conversations/sessions/{sessionId}/turns`
+
+## Core Semantics
+
+1. Session creation requires explicit `channel` value.
+2. Channel enum is normalized: `cli | web | openclaw`.
+3. Turn creation appends immutable turn records and updates session timestamps.
+4. Missing session IDs return canonical `ErrorResponse` with `404`.
+5. Conversation contract is additive under `/v2`; `/v1` remains unchanged.
+
+## Context Memory Semantics (CONV-02)
+
+1. Memory is scoped per `tenant_id:user_id` and reused across that user's conversation sessions.
+2. Each turn updates bounded context memory:
+  - recent messages (bounded by retention policy),
+  - inferred intent (`deploy | backtest | order | risk | portfolio`),
+  - linked trading artifacts (`strat-*`, `dep-*`, `ord-*`, `portfolio-*`, `bt-*`, `dataset-*`),
+  - symbol references (for example `BTCUSDT`).
+3. Session metadata exposes current memory under `contextMemory`.
+4. Turn metadata includes `contextMemorySnapshot` so clients can render deterministic multi-turn context.
+5. Memory is isolated by user identity and does not leak across users.
+
+## Proactive Suggestions and Notifications (CONV-03)
+
+1. Turn processing emits proactive suggestions based on message intent and context-memory state.
+2. Notification delivery is controlled by session-level opt-in (`metadata.notificationsOptIn`).
+3. Opted-in sessions receive structured notification payloads in turn metadata.
+4. Every emitted notification writes an audit record with session/turn identity and severity/category metadata.
+5. Opted-out sessions still receive suggestions but no notification emission.
+
+## Sequence: Multi-Turn Contract Flow
+
+```mermaid
+sequenceDiagram
+    participant C as "Client (CLI/Web/OpenClaw)"
+    participant API as "Platform API /v2/conversations"
+    participant SVC as "ConversationService"
+    participant MEM as "Context Memory"
+    participant AUD as "Notification Audit"
+
+    C->>API: POST /sessions (channel, topic, metadata)
+    API->>SVC: create_session()
+    SVC->>MEM: initialize/load per-user memory
+    SVC-->>C: session(id, metadata.contextMemory)
+
+    C->>API: POST /sessions/{id}/turns (message)
+    API->>SVC: create_turn()
+    SVC->>MEM: update memory (intent, artifacts, symbols, retention)
+    SVC->>SVC: derive suggestions + proactive notifications
+    alt notificationsOptIn=true
+        SVC->>AUD: persist notification records
+    end
+    SVC-->>C: turn(suggestions, metadata.contextMemorySnapshot, metadata.notifications)
+```
+
+## Failure and Fallback Behavior
+
+| Condition | Expected Response | Client Handling |
+| --- | --- | --- |
+| Unknown session ID | `404 CONVERSATION_SESSION_NOT_FOUND` | Surface error with `requestId`; do not synthesize a replacement session |
+| Invalid turn payload | `422` validation error | Prompt user to correct payload; keep existing session state |
+| Notification opt-out | `notifications=[]` and no audit writes | Continue with suggestions-only UX |
+| Internal error | canonical `ErrorResponse` with `requestId` | Preserve correlation ID and retry through same Platform API route only |
+
+## Client Compatibility Notes
+
+1. OpenClaw must create sessions with `channel=openclaw`.
+2. CLI/Web/OpenClaw all consume identical `/v2/conversations/*` schemas.
+3. Clients should treat `contextMemory` and `contextMemorySnapshot` as additive metadata fields.
+4. Clients should not assume notification presence; respect opt-in behavior.
+
+## Boundary Alignment
+
+- Conversation is a public contract concern, not a provider integration.
+- Conversation routes remain inside Platform API.
+- Provider boundaries are unchanged: adapter-only integrations.
+
+## Traceability
+
+- OpenAPI: `/docs/architecture/specs/platform-api.openapi.yaml`
+- Interface definition: `/docs/architecture/INTERFACES.md`
+- Parent epics: `#80`, `#106`, `#81`
+- Gate4 docs issue: `#137`

--- a/docs/llm/chunks/portal_gate4_incident_runbooks_v1.md
+++ b/docs/llm/chunks/portal_gate4_incident_runbooks_v1.md
@@ -1,0 +1,211 @@
+# Gate4 Incident Runbooks
+
+Source: `docs/portal/operations/gate4-incident-runbooks.md`
+Topic: `operations`
+Stable ID: `portal_gate4_incident_runbooks_v1`
+
+# Gate4 Incident Runbooks
+
+## Scope
+
+This runbook covers:
+
+- conversation and OpenClaw incident response,
+- risk rejection and kill-switch incident response,
+- audit evidence capture and review handoff.
+
+## Guardrails
+
+1. Clients must use Platform API routes only.
+2. No runbook step may call provider APIs directly from clients.
+3. Side-effecting commands remain blocked when risk controls fail.
+4. Every incident update must include correlation IDs and issue links.
+
+## Severity Levels
+
+| Severity | Trigger | SLA Target |
+| --- | --- | --- |
+| `SEV-1` | Side effects blocked across tenants or wrong-side execution risk | Immediate containment, 30-minute review handoff |
+| `SEV-2` | Single-tenant contract failures, degraded suggestions, repeated kill-switch false positives | 2-hour mitigation |
+| `SEV-3` | Isolated payload/client defects with known workaround | Next planned release |
+
+## Runbook A: Conversation and OpenClaw
+
+### Trigger Signals
+
+- Elevated `4xx/5xx` for:
+  - `POST /v2/conversations/sessions`
+  - `GET /v2/conversations/sessions/{sessionId}`
+  - `POST /v2/conversations/sessions/{sessionId}/turns`
+- OpenClaw workflow breakage in contract/e2e checks.
+- Missing `contextMemorySnapshot` or notification metadata in turn responses.
+
+### Triage Checklist
+
+1. Capture correlation: `requestId`, `sessionId`, `tenant_id`, `user_id`, `channel`.
+2. Verify API contract path and auth headers with a minimal repro:
+
+```bash
+curl -sS -X POST "$PLATFORM_API_BASE/v2/conversations/sessions" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-API-Key: $API_KEY" \
+  -H "X-Tenant-Id: $TENANT_ID" \
+  -H "X-User-Id: $USER_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"openclaw","topic":"incident-triage","metadata":{"notificationsOptIn":true}}'
+```
+
+3. Re-run deterministic contract coverage:
+
+```bash
+uv run --directory backend --with pytest python -m pytest \
+  backend/tests/contracts/test_platform_api_v2_handlers.py \
+  backend/tests/contracts/test_conversation_context_memory.py \
+  backend/tests/contracts/test_conversation_proactive_notifications.py \
+  backend/tests/contracts/test_openclaw_client_integration.py \
+  backend/tests/contracts/test_openclaw_e2e_flow.py -q
+```
+
+4. Validate boundary invariants:
+  - OpenClaw lane uses `channel=openclaw`.
+  - No provider-direct client calls.
+  - Errors are canonical contract errors with `requestId`.
+
+### Decision Tree
+
+```mermaid
+flowchart TD
+    A["Conversation/OpenClaw incident detected"] --> B{"Platform API contract routes healthy?"}
+    B -->|No| C["Escalate API availability incident and contain client traffic"]
+    B -->|Yes| D{"Contract payload/headers valid?"}
+    D -->|No| E["Fix client payload/header contract mismatch and retest"]
+    D -->|Yes| F{"Runtime memory/notification semantics valid?"}
+    F -->|No| G["Contain by disabling proactive notifications and patch conversation runtime"]
+    F -->|Yes| H["Escalate downstream platform dependency issue with request IDs"]
+```
+
+### Containment Actions
+
+1. Keep traffic on Platform API paths; do not introduce provider-direct fallback.
+2. For unstable notification behavior, force `notificationsOptIn=false` at client feature flag until recovery.
+3. If OpenClaw skill lane is degraded, fail over to CLI-mediated lane (still Platform API only).
+
+### Recovery Checklist
+
+1. Contract tests pass for v2 conversation handlers and OpenClaw e2e flow.
+2. Repro requests return canonical success/error shapes with correlation IDs.
+3. `contextMemory` and `contextMemorySnapshot` fields are deterministic across retries.
+4. Incident summary is posted with root cause and prevention action.
+
+## Runbook B: Risk Runtime and Kill-Switch
+
+### Trigger Signals
+
+- Sudden spikes in `422` risk limit rejections on:
+  - `POST /v1/deployments`
+  - `POST /v1/orders`
+- `423` kill-switch rejections on side-effecting commands.
+- Drawdown-triggered stop behavior firing unexpectedly or not firing when expected.
+
+### Triage Checklist
+
+1. Collect evidence: `requestId`, `deploymentId`/`orderId`, policy `version`, outcome code, and breach reason.
+2. Validate risk controls with contract checks:
+
+```bash
+uv run --directory backend --with pytest python -m pytest \
+  backend/tests/contracts/test_risk_policy_schema.py \
+  backend/tests/contracts/test_risk_pretrade_checks.py \
+  backend/tests/contracts/test_risk_killswitch_drawdown.py \
+  backend/tests/contracts/test_risk_audit_trail.py \
+  backend/tests/contracts/test_execution_command_layer.py \
+  backend/tests/contracts/test_execution_command_idempotency.py -q
+```
+
+3. Verify stop and rejection behavior through Platform API only:
+  - `GET /v1/deployments/{deploymentId}`
+  - `POST /v1/deployments/{deploymentId}/actions/stop`
+  - `POST /v1/orders`
+
+4. Confirm policy compatibility:
+  - accepted schema version is `risk-policy.v1`,
+  - invalid schema/version must fail closed.
+
+### Decision Tree
+
+```mermaid
+flowchart TD
+    A["Risk incident detected"] --> B{"Kill-switch currently triggered?"}
+    B -->|Yes| C{"Drawdown breach evidence valid?"}
+    C -->|Yes| D["Maintain block and execute controlled recovery plan"]
+    C -->|No| E["Treat as false positive, roll back invalid policy input, revalidate"]
+    B -->|No| F{"Pre-trade rejections increasing?"}
+    F -->|Yes| G["Inspect policy limits and audit outcomes, fix policy/config drift"]
+    F -->|No| H["Investigate execution/orchestrator path and retry budget handling"]
+```
+
+### Containment Actions
+
+1. Preserve fail-closed behavior; do not bypass risk gates to force execution.
+2. Keep side-effecting operations blocked while policy validity is uncertain.
+3. Limit blast radius by tenant/account where configuration isolation is available.
+
+### Recovery Checklist
+
+1. Policy validation passes (`risk-policy.v1`, limits coherent, enums valid).
+2. Drawdown breach and kill-switch transitions are reproducible and deterministic.
+3. Risk audit trail contains both blocked and approved decisions with outcome codes.
+4. Execution command layer remains idempotent after incident patch deployment.
+
+## Evidence Capture
+
+Collect and attach all of the following to the incident ticket:
+
+1. Reproduction command(s) and responses with redacted secrets.
+2. Correlation IDs (`requestId`) and timeline.
+3. Relevant policy snapshot and schema/version validation result.
+4. Contract test output used for verification.
+5. Mitigation, rollback, and follow-up action items.
+
+## Escalation Matrix
+
+| Condition | Primary Team | Secondary Team | Escalate To |
+| --- | --- | --- | --- |
+| Conversation/OpenClaw contract drift | Team E | Team G | Parent `#80`, docs parent `#106` |
+| Runtime state/retry anomalies | Team B | Team F | Parent `#77`, reliability `#81` |
+| Risk rejection/kill-switch uncertainty | Team B | Team F | Parent `#77`, reliability `#81` |
+| Audit evidence gap | Team F | Team G | Docs parent `#106`, reliability `#81` |
+
+## On-Call Handoff Template
+
+```md
+Gate4 Incident Handoff
+
+- Incident ID:
+- Severity:
+- Affected lane: conversation | openclaw | risk | runtime
+- Start time (UTC):
+- Current status: triage | contained | recovering | resolved
+- Correlation IDs:
+- Impact summary:
+- Guardrails confirmed:
+  - Platform API only: yes/no
+  - No provider-direct client calls: yes/no
+  - Risk fail-closed preserved: yes/no
+- Verification commands executed:
+- Remaining risks:
+- Owner team:
+- Review handoff target issue(s):
+- Next decision checkpoint time (UTC):
+```
+
+## Traceability
+
+- Conversation/OpenClaw docs:
+  - `/docs/portal/platform/gate4-conversation-contract.md`
+  - `/docs/portal/platform/gate4-openclaw-client-lane.md`
+- Runtime/risk docs:
+  - `/docs/portal/operations/gate4-orchestrator-controls.md`
+  - `/docs/portal/operations/gate4-risk-policy-controls.md`
+- Public API source: `/docs/architecture/specs/platform-api.openapi.yaml`
+- Related issues: `#139`, `#81`, `#106`

--- a/docs/llm/chunks/portal_gate4_openclaw_client_lane_v1.md
+++ b/docs/llm/chunks/portal_gate4_openclaw_client_lane_v1.md
@@ -1,0 +1,109 @@
+# Gate4 OpenClaw Client Lane
+
+Source: `docs/portal/platform/gate4-openclaw-client-lane.md`
+Topic: `platform`
+Stable ID: `portal_gate4_openclaw_client_lane_v1`
+
+# Gate4 OpenClaw Client Lane
+
+## Objective
+
+Define OpenClaw as a first-class client lane without changing provider boundaries.
+
+## Boundary Contract
+
+1. OpenClaw is a client lane only.
+2. OpenClaw calls Platform API contracts only.
+3. OpenClaw must never call provider APIs directly.
+4. Provider integrations remain adapter-only inside `trade-nexus` backend.
+5. OpenClaw-specific backend behavior must be contract-first in OpenAPI.
+
+## Allowed Call Paths
+
+- OpenClaw skill -> SDK/API client -> Platform API
+- OpenClaw skill -> `trading-cli` -> Platform API
+
+Both paths are valid if they preserve auth, request correlation, and idempotency semantics defined in OpenAPI.
+
+## Sequence: OpenClaw Request Path
+
+```mermaid
+sequenceDiagram
+    participant OC as "OpenClaw Skill"
+    participant CLI as "trading-cli (optional)"
+    participant API as "Platform API"
+    participant ADP as "Platform Adapters"
+    participant PRV as "Providers"
+
+    alt SDK/API-first lane
+        OC->>API: Call /v1 and /v2 contracts
+    else CLI-mediated lane
+        OC->>CLI: Run CLI command
+        CLI->>API: Call /v1 and /v2 contracts
+    end
+    API->>ADP: Internal adapter call
+    ADP->>PRV: Provider API
+    PRV-->>ADP: Provider response
+    ADP-->>API: Normalized response
+    API-->>OC: Contract response + requestId
+```
+
+## OC-02 Client Integration
+
+Reference OpenClaw client integration is implemented in:
+
+- `/backend/src/platform_api/clients/openclaw_client.py`
+
+Behavior constraints:
+
+1. Calls only canonical Platform API endpoints (`/v1/*`, `/v2/*`).
+2. Initializes conversation sessions with `channel=openclaw`.
+3. Preserves `Authorization`, `X-API-Key`, `X-Request-Id`, `X-Tenant-Id`, `X-User-Id`.
+4. Includes `Idempotency-Key` for side-effecting operations that require it.
+5. Performs no provider-direct calls.
+
+## OC-03 End-to-End Flow Verification
+
+OpenClaw flow tests validate the client path across core lifecycle operations:
+
+1. Conversation session/turn bootstrap (`/v2/conversations/*`).
+2. Research and strategy/backtest path (`/v1/research/*`, `/v1/strategies/*`, `/v1/backtests/*`).
+3. Deployment/order execution path (`/v1/deployments/*`, `/v1/orders/*`).
+4. Reporting path (`/v1/portfolios/*`).
+
+Reference test:
+
+- `/backend/tests/contracts/test_openclaw_e2e_flow.py`
+
+## Explicitly Forbidden
+
+- OpenClaw -> Lona API direct calls
+- OpenClaw -> live-engine direct calls
+- OpenClaw -> data provider direct calls
+- Introducing undocumented `/v1/openclaw/*` endpoints
+
+## Failure and Fallback Behavior
+
+| Condition | Expected Behavior | Required Guardrail |
+| --- | --- | --- |
+| Platform API returns contract error | Return canonical error to OpenClaw | Preserve `requestId` for triage |
+| Missing auth/idempotency headers | Reject request per API contract | Do not bypass to provider-direct calls |
+| CLI wrapper failure | Retry via Platform API path only | Keep boundary; no provider fallback |
+| Provider incident behind adapter | Platform API reports normalized error | OpenClaw remains client-only |
+
+## Client Compatibility Notes
+
+1. OpenClaw integrations can be implemented via SDK/API-first or CLI-mediated patterns.
+2. Both patterns must preserve `Authorization`/`X-API-Key`, tenant/user headers, and request correlation.
+3. Conversation bootstrapping must set `channel=openclaw`.
+4. Side-effecting writes must include idempotency keys where OpenAPI requires them.
+
+## Traceability
+
+- Architecture contract: `/docs/architecture/OPENCLAW_INTEGRATION.md`
+- Interface boundary: `/docs/architecture/INTERFACES.md`
+- Public API source: `/docs/architecture/specs/platform-api.openapi.yaml`
+- OC-02 contract tests: `/backend/tests/contracts/test_openclaw_client_integration.py`
+- OC-03 e2e tests: `/backend/tests/contracts/test_openclaw_e2e_flow.py`
+- Parent epics: `#80`, `#106`, `#81`
+- Gate4 docs issue: `#137`

--- a/docs/llm/chunks/portal_gate4_orchestrator_controls_v1.md
+++ b/docs/llm/chunks/portal_gate4_orchestrator_controls_v1.md
@@ -1,0 +1,108 @@
+# Gate4 Orchestrator Controls
+
+Source: `docs/portal/operations/gate4-orchestrator-controls.md`
+Topic: `operations`
+Stable ID: `portal_gate4_orchestrator_controls_v1`
+
+# Gate4 Orchestrator Controls
+
+## Objective
+
+Define a deterministic orchestrator lifecycle, queue/cancellation controls, retry/failure-budget policy, and execution command boundary so runtime behavior can be tested, audited, and safely hardened.
+
+## State Contract
+
+States:
+
+- `received`
+- `queued`
+- `executing`
+- `awaiting_tool`
+- `awaiting_user_confirmation`
+- `completed`
+- `failed`
+- `cancelled`
+
+## Transition Boundaries
+
+1. Requests start in `received` and move to `queued` before execution work begins.
+2. Execution can pause only in `awaiting_tool` or `awaiting_user_confirmation`.
+3. Terminal states are immutable: once `completed`, `failed`, or `cancelled`, no further transition is accepted.
+4. Invalid transitions must fail deterministically with explicit errors.
+
+## Deterministic Transition Matrix
+
+| Current State | Allowed Targets |
+| --- | --- |
+| `received` | `received`, `queued`, `failed`, `cancelled` |
+| `queued` | `queued`, `executing`, `failed`, `cancelled` |
+| `executing` | `executing`, `awaiting_tool`, `awaiting_user_confirmation`, `completed`, `failed`, `cancelled` |
+| `awaiting_tool` | `awaiting_tool`, `executing`, `failed`, `cancelled` |
+| `awaiting_user_confirmation` | `awaiting_user_confirmation`, `executing`, `failed`, `cancelled` |
+| `completed` | `completed` |
+| `failed` | `failed` |
+| `cancelled` | `cancelled` |
+
+## Queue and Cancellation Controls (AG-ORCH-02)
+
+Queue/cancellation runtime semantics are active:
+
+1. Work items enter queue from `received -> queued`.
+2. Queue scheduling is deterministic: lower numeric priority executes first; same priority is FIFO.
+3. `dequeue` transitions `queued -> executing`.
+4. Cancelling queued work prevents execution and records cancellation reason.
+5. Cancelling executing/awaiting work transitions directly to `cancelled`.
+6. Terminal states remain immutable under cancellation attempts.
+
+## Retry and Failure Budget Policy (AG-ORCH-03)
+
+Retry runtime semantics are deterministic and bounded:
+
+1. Retry decisions are constrained by explicit `max_attempts` and `max_failures`.
+2. Retry-eligible failures emit bounded exponential backoff delay metadata.
+3. Retry path remains non-terminal and maps to retry-wait execution state (`awaiting_tool`).
+4. Attempt/failure budget exhaustion emits terminal `failed` decision with deterministic reason codes.
+5. Terminal retry states are immutable for further attempt scheduling.
+
+### Retry Decision Matrix
+
+| Condition | Decision | Next Runtime State |
+| --- | --- | --- |
+| Attempts and failures within budget | Retry allowed with bounded backoff | `awaiting_tool` |
+| `max_attempts` exhausted | Retry denied | `failed` |
+| `max_failures` exhausted | Retry denied | `failed` |
+| Retry state already terminal | New attempts denied | `failed` (immutable) |
+
+## Gate4 Scope Boundary
+
+- AG-ORCH-01 transition contract, AG-ORCH-02 queue/cancellation controls, and AG-ORCH-03 retry/failure budget policy are active.
+
+## Execution Command Boundary (AG-EXE-01)
+
+Execution side-effect operations are routed through internal command handlers before adapter calls:
+
+1. Deployment create/stop commands are emitted via command layer abstractions.
+2. Order place/cancel commands are emitted via command layer abstractions.
+3. Command layer delegates side effects to `ExecutionAdapter`; provider APIs remain adapter-only.
+4. Read paths (list/get) remain non-command adapter reads.
+5. Deployment create and order place commands enforce idempotency replay semantics; key/payload conflicts fail deterministically.
+
+## Migration Notes
+
+1. Runtime components should consume queue/retry outcomes via deterministic service calls, not ad-hoc state mutation.
+2. New orchestrator features must extend contract tests before runtime behavior changes are merged.
+3. Side-effecting execution retries remain gated by AG-RISK controls and execution command idempotency semantics.
+
+## Traceability
+
+- Architecture interface contract: `/docs/architecture/INTERFACES.md`
+- Runtime implementation: `/backend/src/platform_api/services/orchestrator_state_machine.py`
+- Queue/cancellation runtime: `/backend/src/platform_api/services/orchestrator_queue_service.py`
+- Retry policy runtime: `/backend/src/platform_api/services/orchestrator_retry_policy.py`
+- Execution command runtime: `/backend/src/platform_api/services/execution_command_service.py`
+- Contract tests: `/backend/tests/contracts/test_orchestrator_state_machine.py`
+- Contract tests: `/backend/tests/contracts/test_orchestrator_queue_cancellation.py`
+- Contract tests: `/backend/tests/contracts/test_orchestrator_retry_policy.py`
+- Contract tests: `/backend/tests/contracts/test_execution_command_layer.py`
+- Contract tests: `/backend/tests/contracts/test_execution_command_idempotency.py`
+- Related epics/issues: `#77`, `#138`, `#106`

--- a/docs/llm/chunks/portal_gate4_risk_policy_controls_v1.md
+++ b/docs/llm/chunks/portal_gate4_risk_policy_controls_v1.md
@@ -1,0 +1,107 @@
+# Gate4 Risk Policy Controls
+
+Source: `docs/portal/operations/gate4-risk-policy-controls.md`
+Topic: `operations`
+Stable ID: `portal_gate4_risk_policy_controls_v1`
+
+# Gate4 Risk Policy Controls
+
+## Objective
+
+Define a machine-readable risk policy contract and enforce it before execution side effects, then halt runtime execution on drawdown breaches.
+
+## Schema Contract
+
+Schema artifact:
+
+- `/contracts/schemas/risk-policy.v1.schema.json`
+
+Required top-level fields:
+
+- `version`
+- `mode`
+- `limits`
+- `killSwitch`
+- `actionsOnBreach`
+
+## Validation Boundaries
+
+1. Only schema version `risk-policy.v1` is accepted in this wave.
+2. Unknown versions fail validation.
+3. Invalid enums, malformed limits, and incompatible notional bounds fail validation.
+4. Policy validation is deterministic and backed by contract tests.
+
+## Active Pre-Trade Enforcement (AG-RISK-02)
+
+Pre-trade checks are mandatory gates before side effects:
+
+1. Deployment creation is blocked when policy limits would be exceeded.
+2. Order placement is blocked on max-position/max-notional breaches.
+3. Triggered kill-switch blocks deployment/order side effects.
+4. Invalid or unsupported policy fails closed (no side effects).
+
+## Active Drawdown Kill-Switch Runtime Handling (AG-RISK-03)
+
+Runtime drawdown checks are enforced during deployment status refresh:
+
+1. `latestPnl` is evaluated against deployment capital and `limits.maxDrawdownPct`.
+2. Breach sets `killSwitch.triggered=true` with timestamp and breach reason.
+3. Active deployments are sent to adapter stop flow immediately after breach detection.
+4. Once triggered, pre-trade side-effecting commands remain blocked.
+
+## Active Risk Audit Trail (AG-RISK-04)
+
+Risk decisions now persist to runtime audit storage for both allow and block outcomes:
+
+1. Pre-trade deployment and order checks record `approved`/`blocked` decisions.
+2. Runtime drawdown checks record approval decisions and breach-triggered blocks.
+3. Records include request identity (`request_id`, `tenant_id`, `user_id`), policy version/mode, and outcome code.
+4. Invalid policy/version paths fail closed and emit blocked audit records.
+
+## Risk Control Point Matrix
+
+| Control Point | Behavior | Side-Effect Policy |
+| --- | --- | --- |
+| Deployment pre-trade check | Validate notional bounds + kill-switch state | Block on breach (`422/423`) before adapter call |
+| Order pre-trade check | Validate symbol/portfolio notional, daily loss, reference price | Block on breach (`422/423`) before adapter call |
+| Runtime drawdown monitor | Evaluate `latestPnl` vs drawdown limit | Trigger kill-switch and halt deployment path |
+| Policy validation | Enforce schema/version compatibility | Fail closed on invalid policy (`500`) |
+
+## Risk Decision and Audit Evidence Model
+
+Audit entries capture deterministic decision metadata:
+
+| Field | Description |
+| --- | --- |
+| `decision` | `approved` or `blocked` |
+| `check_type` | Risk control category (`pretrade_deployment`, `pretrade_order`, `runtime_drawdown`) |
+| `request_id` / `tenant_id` / `user_id` | Identity and correlation |
+| `policy_version` / `policy_mode` | Evaluated policy context |
+| `outcome_code` | Deterministic failure/signal code (`RISK_LIMIT_BREACH`, `RISK_KILL_SWITCH_ACTIVE`, etc.) |
+| `reason` | Human-readable rationale |
+| `metadata` | Structured context (notional, drawdown, symbol, deployment references) |
+
+## Gate4 Scope Boundary
+
+- AG-RISK-01 schema + validator, AG-RISK-02 pre-trade enforcement, AG-RISK-03 drawdown kill-switch handling, and AG-RISK-04 risk audit trail are active.
+
+## Migration Notes
+
+1. All new side-effecting execution paths must call risk gates before command dispatch.
+2. Runtime additions should extend risk audit coverage rather than introducing non-audited checks.
+3. Policy schema changes must be versioned and validated before rollout.
+
+## Traceability
+
+- Schema: `/contracts/schemas/risk-policy.v1.schema.json`
+- Runtime validator: `/backend/src/platform_api/services/risk_policy.py`
+- Pre-trade gate runtime: `/backend/src/platform_api/services/risk_pretrade_service.py`
+- Drawdown kill-switch runtime: `/backend/src/platform_api/services/risk_killswitch_service.py`
+- Risk audit runtime: `/backend/src/platform_api/services/risk_audit_service.py`
+- Contract tests:
+  - `/backend/tests/contracts/test_risk_policy_schema.py`
+  - `/backend/tests/contracts/test_risk_pretrade_checks.py`
+  - `/backend/tests/contracts/test_risk_killswitch_drawdown.py`
+  - `/backend/tests/contracts/test_risk_audit_trail.py`
+- Interface definition: `/docs/architecture/INTERFACES.md`
+- Related epics/issues: `#77`, `#138`, `#106`

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -174,5 +174,157 @@
     "workflows": [
       "research_enrichment"
     ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_conversation_contract_v1.md",
+    "chunk_hash": "d26c605e4216b9ff635d9b062cdd847bfa5452b636abd553a389195702094d0e",
+    "concepts": [
+      "conversation_contract",
+      "context_memory",
+      "proactive_notifications",
+      "channel_enum"
+    ],
+    "endpoints": [
+      "/v2/conversations/sessions",
+      "/v2/conversations/sessions/{sessionId}",
+      "/v2/conversations/sessions/{sessionId}/turns"
+    ],
+    "id": "portal_gate4_conversation_contract_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/80",
+    "owners": [
+      "Team E",
+      "Team B",
+      "Team G"
+    ],
+    "source": "docs/portal/platform/gate4-conversation-contract.md",
+    "source_hash": "b96f221e761a544079dbf7c7a024193b639ff5150325bad41fd2f92fbd46e86b",
+    "title": "Gate4 Conversation Contract",
+    "topic": "platform",
+    "workflows": [
+      "multiturn_conversation",
+      "proactive_suggestion_pipeline"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_incident_runbooks_v1.md",
+    "chunk_hash": "b9feb3275063c5cc8ad844e9971425d32a37586c13be5022bb047053a5fa417d",
+    "concepts": [
+      "incident_triage",
+      "kill_switch_recovery",
+      "audit_evidence",
+      "oncall_handoff"
+    ],
+    "endpoints": [
+      "/v2/conversations/sessions",
+      "/v2/conversations/sessions/{sessionId}/turns",
+      "/v1/deployments",
+      "/v1/orders"
+    ],
+    "id": "portal_gate4_incident_runbooks_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81",
+    "owners": [
+      "Team F",
+      "Team G",
+      "Team E",
+      "Team B"
+    ],
+    "source": "docs/portal/operations/gate4-incident-runbooks.md",
+    "source_hash": "dfc1f3c96efaf7fd545f68597c3036a02963146d7ca32b43894b08bda735b5aa",
+    "title": "Gate4 Incident Runbooks",
+    "topic": "operations",
+    "workflows": [
+      "incident_response",
+      "gate4_docs_review"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_openclaw_client_lane_v1.md",
+    "chunk_hash": "1f590a280d7c427e347d5460993e1f3297f143f6b42522dec8c71778feea68d1",
+    "concepts": [
+      "openclaw_lane",
+      "client_boundary",
+      "platform_api_only",
+      "adapter_boundary"
+    ],
+    "endpoints": [
+      "/v2/conversations/sessions",
+      "/v2/conversations/sessions/{sessionId}/turns",
+      "/v1/deployments",
+      "/v1/orders"
+    ],
+    "id": "portal_gate4_openclaw_client_lane_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/80",
+    "owners": [
+      "Team E",
+      "Team G"
+    ],
+    "source": "docs/portal/platform/gate4-openclaw-client-lane.md",
+    "source_hash": "7b1a30713ce6d1465b87371f2952c84f478a046c23920bdb1601e937c5546808",
+    "title": "Gate4 OpenClaw Client Lane",
+    "topic": "platform",
+    "workflows": [
+      "openclaw_sdk_lane",
+      "openclaw_cli_lane",
+      "client_boundary_enforcement"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_orchestrator_controls_v1.md",
+    "chunk_hash": "ee86a2360c8a4611df359ffaf29d27d9bd8e961d9927e07588bfe323084f5660",
+    "concepts": [
+      "orchestrator_state_machine",
+      "queue_cancellation",
+      "retry_budget",
+      "execution_command_layer"
+    ],
+    "endpoints": [
+      "/v1/deployments",
+      "/v1/orders"
+    ],
+    "id": "portal_gate4_orchestrator_controls_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/77",
+    "owners": [
+      "Team B",
+      "Team F",
+      "Team G"
+    ],
+    "source": "docs/portal/operations/gate4-orchestrator-controls.md",
+    "source_hash": "5b25d16f4f550757648b020a095592ef2fc44c21cfb1255f7815d0062e5ae841",
+    "title": "Gate4 Orchestrator Controls",
+    "topic": "operations",
+    "workflows": [
+      "orchestrator_state_transitions",
+      "runtime_retry_control"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_risk_policy_controls_v1.md",
+    "chunk_hash": "84db0ab2cf37d1d23e0646ef2dc04c0ca06cc2d92f38a36ce14e8929032d806e",
+    "concepts": [
+      "risk_policy_schema",
+      "pretrade_checks",
+      "drawdown_killswitch",
+      "risk_audit_trail"
+    ],
+    "endpoints": [
+      "/v1/deployments",
+      "/v1/orders",
+      "/v1/deployments/{deploymentId}/actions/stop"
+    ],
+    "id": "portal_gate4_risk_policy_controls_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/77",
+    "owners": [
+      "Team B",
+      "Team F",
+      "Team G"
+    ],
+    "source": "docs/portal/operations/gate4-risk-policy-controls.md",
+    "source_hash": "c011a25bfd10805e08aada6dfbfc519810dc38aab4c567070d45c73507206833",
+    "title": "Gate4 Risk Policy Controls",
+    "topic": "operations",
+    "workflows": [
+      "risk_gate_enforcement",
+      "drawdown_containment"
+    ]
   }
 ]

--- a/docs/llm/manifest.json
+++ b/docs/llm/manifest.json
@@ -1,6 +1,6 @@
 {
-  "entry_count": 7,
+  "entry_count": 12,
   "schema_version": "1.0",
   "source_map": "docs/llm/source-map.json",
-  "source_map_hash": "7818389cb575828247353c0cddbdba9d6b8cacf1563e164d32c05e1fab7de56a"
+  "source_map_hash": "f13aa6690cd34050a32e105ba7ab75f257a0ef188426f1f1f2b11df0bd9eee9b"
 }

--- a/docs/llm/source-map.json
+++ b/docs/llm/source-map.json
@@ -77,6 +77,61 @@
       "workflows": ["research_enrichment"],
       "owners": ["Team B", "Team C", "Team G"],
       "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/77"
+    },
+    {
+      "id": "portal_gate4_openclaw_client_lane_v1",
+      "title": "Gate4 OpenClaw Client Lane",
+      "source": "docs/portal/platform/gate4-openclaw-client-lane.md",
+      "topic": "platform",
+      "concepts": ["openclaw_lane", "client_boundary", "platform_api_only", "adapter_boundary"],
+      "endpoints": ["/v2/conversations/sessions", "/v2/conversations/sessions/{sessionId}/turns", "/v1/deployments", "/v1/orders"],
+      "workflows": ["openclaw_sdk_lane", "openclaw_cli_lane", "client_boundary_enforcement"],
+      "owners": ["Team E", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/80"
+    },
+    {
+      "id": "portal_gate4_conversation_contract_v1",
+      "title": "Gate4 Conversation Contract",
+      "source": "docs/portal/platform/gate4-conversation-contract.md",
+      "topic": "platform",
+      "concepts": ["conversation_contract", "context_memory", "proactive_notifications", "channel_enum"],
+      "endpoints": ["/v2/conversations/sessions", "/v2/conversations/sessions/{sessionId}", "/v2/conversations/sessions/{sessionId}/turns"],
+      "workflows": ["multiturn_conversation", "proactive_suggestion_pipeline"],
+      "owners": ["Team E", "Team B", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/80"
+    },
+    {
+      "id": "portal_gate4_orchestrator_controls_v1",
+      "title": "Gate4 Orchestrator Controls",
+      "source": "docs/portal/operations/gate4-orchestrator-controls.md",
+      "topic": "operations",
+      "concepts": ["orchestrator_state_machine", "queue_cancellation", "retry_budget", "execution_command_layer"],
+      "endpoints": ["/v1/deployments", "/v1/orders"],
+      "workflows": ["orchestrator_state_transitions", "runtime_retry_control"],
+      "owners": ["Team B", "Team F", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/77"
+    },
+    {
+      "id": "portal_gate4_risk_policy_controls_v1",
+      "title": "Gate4 Risk Policy Controls",
+      "source": "docs/portal/operations/gate4-risk-policy-controls.md",
+      "topic": "operations",
+      "concepts": ["risk_policy_schema", "pretrade_checks", "drawdown_killswitch", "risk_audit_trail"],
+      "endpoints": ["/v1/deployments", "/v1/orders", "/v1/deployments/{deploymentId}/actions/stop"],
+      "workflows": ["risk_gate_enforcement", "drawdown_containment"],
+      "owners": ["Team B", "Team F", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/77"
+    },
+    {
+      "id": "portal_gate4_incident_runbooks_v1",
+      "title": "Gate4 Incident Runbooks",
+      "source": "docs/portal/operations/gate4-incident-runbooks.md",
+      "topic": "operations",
+      "concepts": ["incident_triage", "kill_switch_recovery", "audit_evidence", "oncall_handoff"],
+      "endpoints": ["/v2/conversations/sessions", "/v2/conversations/sessions/{sessionId}/turns", "/v1/deployments", "/v1/orders"],
+      "workflows": ["incident_response", "gate4_docs_review"],
+      "owners": ["Team F", "Team G", "Team E", "Team B"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81"
     }
   ]
 }

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -47,5 +47,40 @@
     "id": "portal_gate3_research_loop_context_v1",
     "source": "docs/portal/platform/gate3-research-loop-context.md",
     "source_hash": "1178986aeb57c9e03210a2dab0fcb89b8889db430c1ac8f6cc316aaed06c5b28"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_conversation_contract_v1.md",
+    "chunk_hash": "d26c605e4216b9ff635d9b062cdd847bfa5452b636abd553a389195702094d0e",
+    "id": "portal_gate4_conversation_contract_v1",
+    "source": "docs/portal/platform/gate4-conversation-contract.md",
+    "source_hash": "b96f221e761a544079dbf7c7a024193b639ff5150325bad41fd2f92fbd46e86b"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_incident_runbooks_v1.md",
+    "chunk_hash": "b9feb3275063c5cc8ad844e9971425d32a37586c13be5022bb047053a5fa417d",
+    "id": "portal_gate4_incident_runbooks_v1",
+    "source": "docs/portal/operations/gate4-incident-runbooks.md",
+    "source_hash": "dfc1f3c96efaf7fd545f68597c3036a02963146d7ca32b43894b08bda735b5aa"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_openclaw_client_lane_v1.md",
+    "chunk_hash": "1f590a280d7c427e347d5460993e1f3297f143f6b42522dec8c71778feea68d1",
+    "id": "portal_gate4_openclaw_client_lane_v1",
+    "source": "docs/portal/platform/gate4-openclaw-client-lane.md",
+    "source_hash": "7b1a30713ce6d1465b87371f2952c84f478a046c23920bdb1601e937c5546808"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_orchestrator_controls_v1.md",
+    "chunk_hash": "ee86a2360c8a4611df359ffaf29d27d9bd8e961d9927e07588bfe323084f5660",
+    "id": "portal_gate4_orchestrator_controls_v1",
+    "source": "docs/portal/operations/gate4-orchestrator-controls.md",
+    "source_hash": "5b25d16f4f550757648b020a095592ef2fc44c21cfb1255f7815d0062e5ae841"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate4_risk_policy_controls_v1.md",
+    "chunk_hash": "84db0ab2cf37d1d23e0646ef2dc04c0ca06cc2d92f38a36ce14e8929032d806e",
+    "id": "portal_gate4_risk_policy_controls_v1",
+    "source": "docs/portal/operations/gate4-risk-policy-controls.md",
+    "source_hash": "c011a25bfd10805e08aada6dfbfc519810dc38aab4c567070d45c73507206833"
   }
 ]


### PR DESCRIPTION
## Summary\n- add Gate4 portal sources to LLM source map\n- regenerate chunk artifacts, index, traceability, and manifest\n- ensure Gate4 client/runtime docs are represented in machine-readable package\n\n## Validation\n- npm --prefix docs/portal-site run ci\n- python3 scripts/docs/generate_llm_package.py\n- python3 scripts/docs/check_llm_package.py\n\nFixes #140\nRefs #106\nRefs #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only changes plus regenerated metadata/hashes; no runtime or API behavior changes, with the main risk being stale/incorrect generated artifacts or traceability entries.
> 
> **Overview**
> Adds **Gate4 portal content** to the generated LLM documentation package by introducing five new chunk artifacts covering the `/v2` conversation contract (including `channel` normalization, context memory, and proactive notification semantics), the OpenClaw client lane boundary, orchestrator control semantics, risk policy controls, and incident runbooks.
> 
> Regenerates the LLM package metadata to include these sources: updates `docs/llm/index.json`, extends `docs/llm/source-map.json`, refreshes `docs/llm/traceability.json`, and bumps `docs/llm/manifest.json` `entry_count` from 7 to 12 with new hashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 705e194a304ab1a5de0a275a32b19ae32ac22625. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Gate4 portal documentation to the generated LLM package by incorporating five new chunk artifacts covering conversation contracts, OpenClaw client boundaries, orchestrator controls, risk policy enforcement, and incident runbooks.

- Regenerates all LLM package metadata (`index.json`, `source-map.json`, `traceability.json`, `manifest.json`) with updated hashes
- Updates entry count from 7 to 12 to reflect the new Gate4 documentation chunks
- All new chunks follow consistent structure with source attribution, stable IDs, topics, and traceability metadata
- The changes are machine-generated via `generate_llm_package.py` and verified with `check_llm_package.py`
- No runtime code changes; purely documentation and metadata updates
- All source files (`docs/portal/platform/gate4-*.md` and `docs/portal/operations/gate4-*.md`) exist in the repository

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only changes with machine-generated metadata artifacts; no runtime behavior, API, or code logic changes; validation scripts were run per PR description; all changes follow consistent patterns and structure
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/llm/chunks/portal_gate4_conversation_contract_v1.md | New chunk artifact documenting `/v2` conversation contract with channel normalization, context memory, and proactive notification semantics |
| docs/llm/chunks/portal_gate4_incident_runbooks_v1.md | New chunk artifact with incident response runbooks for conversation/OpenClaw and risk/kill-switch scenarios |
| docs/llm/chunks/portal_gate4_openclaw_client_lane_v1.md | New chunk artifact defining OpenClaw as client-only lane with Platform API boundary constraints |
| docs/llm/chunks/portal_gate4_orchestrator_controls_v1.md | New chunk artifact documenting orchestrator state machine, queue/cancellation, retry budget, and execution command semantics |
| docs/llm/chunks/portal_gate4_risk_policy_controls_v1.md | New chunk artifact defining risk policy schema contract, pre-trade enforcement, drawdown kill-switch, and audit trail |
| docs/llm/index.json | Adds 5 new entries with chunk paths, hashes, metadata (concepts, endpoints, workflows, owners) for Gate4 portal docs |
| docs/llm/manifest.json | Updates `entry_count` from 7 to 12 and refreshes `source_map_hash` to reflect new Gate4 entries |
| docs/llm/source-map.json | Extends sources array with 5 Gate4 entries (concepts, endpoints, workflows, owners, issues) for new portal docs |
| docs/llm/traceability.json | Adds traceability records linking 5 new chunks to source docs with `source_hash` and `chunk_hash` verification |

</details>


</details>


<sub>Last reviewed commit: 705e194</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->