### PR TITLE
fix: align risk rejection OpenAPI statuses with runtime

### DIFF
--- a/backend/tests/contracts/test_openapi_contract_baseline.py
+++ b/backend/tests/contracts/test_openapi_contract_baseline.py
@@ -59,6 +59,26 @@ def test_error_envelope_is_defined() -> None:
     assert "error:" in spec
 
 
+def test_risk_rejection_responses_are_declared_for_write_routes() -> None:
+    spec = _spec_text()
+    error422_ref = "$ref: '#/components/responses/Error422'"
+    error423_ref = "$ref: '#/components/responses/Error423'"
+
+    deployment_post_block = spec.split("operationId: createDeploymentV1", maxsplit=1)[1].split(
+        "  /v1/deployments/{deploymentId}:",
+        maxsplit=1,
+    )[0]
+    order_post_block = spec.split("operationId: createOrderV1", maxsplit=1)[1].split(
+        "  /v1/orders/{orderId}:",
+        maxsplit=1,
+    )[0]
+
+    assert error422_ref in deployment_post_block
+    assert error423_ref in deployment_post_block
+    assert error422_ref in order_post_block
+    assert error423_ref in order_post_block
+
+
 def test_public_tags_are_declared() -> None:
     spec = _spec_text()
     for tag in (

--- a/backend/tests/contracts/test_openapi_contract_freeze.py
+++ b/backend/tests/contracts/test_openapi_contract_freeze.py
@@ -87,6 +87,6 @@ def test_all_operations_define_unique_operation_ids() -> None:
 
 def test_error_component_responses_reference_error_envelope() -> None:
     spec = _spec_text()
-    for error_name in ("Error400", "Error401", "Error404", "Error409", "Error429"):
+    for error_name in ("Error400", "Error401", "Error404", "Error409", "Error422", "Error423", "Error429"):
         pattern = rf"{error_name}:\n(?:[ \t].*\n)*?[ \t]+\$ref: '#/components/schemas/ErrorResponse'"
         assert re.search(pattern, spec), f"{error_name} must reference ErrorResponse."

--- a/docs/architecture/specs/platform-api.openapi.yaml
+++ b/docs/architecture/specs/platform-api.openapi.yaml
@@ -409,6 +409,10 @@ paths:
           $ref: '#/components/responses/Error400'
         '401':
           $ref: '#/components/responses/Error401'
+        '422':
+          $ref: '#/components/responses/Error422'
+        '423':
+          $ref: '#/components/responses/Error423'
         '409':
           $ref: '#/components/responses/Error409'
 
@@ -634,6 +638,10 @@ paths:
           $ref: '#/components/responses/Error400'
         '401':
           $ref: '#/components/responses/Error401'
+        '422':
+          $ref: '#/components/responses/Error422'
+        '423':
+          $ref: '#/components/responses/Error423'
         '409':
           $ref: '#/components/responses/Error409'
 
@@ -1365,6 +1373,18 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
     Error409:
       description: Conflict
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error422:
+      description: Unprocessable entity
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error423:
+      description: Locked
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Summary
- add `422` and `423` error responses to `POST /v1/deployments` and `POST /v1/orders` in OpenAPI
- add reusable `Error422` and `Error423` response components mapped to canonical `ErrorResponse`
- add API-level v1 handler contract tests for risk rejections on deployment/order writes (`RISK_LIMIT_BREACH`, `RISK_KILL_SWITCH_ACTIVE`)
- add OpenAPI contract tests to lock risk rejection response declarations on write routes

## Why
Reviewer flagged contract drift: runtime emits `422/423` for risk gates, but OpenAPI + handler-level contract tests did not reflect this behavior.

## Validation
- npx --yes @redocly/cli@1.34.5 lint docs/architecture/specs/platform-api.openapi.yaml
- uv run --directory backend --with pytest python -m pytest backend/tests/contracts/test_openapi_contract_baseline.py backend/tests/contracts/test_openapi_contract_freeze.py backend/tests/contracts/test_platform_api_v1_handlers.py backend/tests/contracts/test_runtime_openapi_contract.py -q
- bash contracts/scripts/generate-sdk.sh
- bash contracts/scripts/verify-sdk-drift.sh
- bash contracts/scripts/mock-smoke-test.sh
- npm --prefix docs/portal-site run ci

Refs #141
Refs #81
Refs #106

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec/test-only changes that don’t alter runtime behavior; main risk is over-constraining the contract if status codes or error codes change.
> 
> **Overview**
> Aligns the public OpenAPI contract with runtime risk-gating behavior by documenting `422` (risk limit breach) and `423` (kill switch active) responses on `POST /v1/deployments` and `POST /v1/orders`, and adding reusable `Error422`/`Error423` response components.
> 
> Adds contract tests that (1) lock these responses into the OpenAPI spec and (2) assert the v1 handlers actually return `422/423` with `RISK_LIMIT_BREACH` and `RISK_KILL_SWITCH_ACTIVE` error codes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efb4b9f99ef394bd764242732b42c68aea6fc775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documented `422` (Unprocessable Entity) and `423` (Locked) risk rejection responses in the OpenAPI specification for `POST /v1/deployments` and `POST /v1/orders` endpoints.

**Changes:**
- Added reusable `Error422` and `Error423` response components that map to the canonical `ErrorResponse` schema
- Referenced these components in deployment and order creation endpoints to document `RISK_LIMIT_BREACH` (422) and `RISK_KILL_SWITCH_ACTIVE` (423) error codes
- Added OpenAPI contract tests to lock these response declarations in the spec
- Added handler-level contract tests to verify the v1 API actually returns these status codes with the correct error codes

**Purpose:**
Closes contract drift between runtime behavior (which already emits `422/423` for risk gates) and the public API specification, ensuring SDK consumers and integrators have accurate documentation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Spec and test-only changes that document existing runtime behavior without modifying application logic; comprehensive test coverage ensures contract alignment
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/architecture/specs/platform-api.openapi.yaml | Adds `Error422` and `Error423` response components and references them in `POST /v1/deployments` and `POST /v1/orders` to document risk rejection statuses |
| backend/tests/contracts/test_openapi_contract_baseline.py | Adds test `test_risk_rejection_responses_are_declared_for_write_routes` to lock `422/423` responses in OpenAPI spec for deployment and order creation endpoints |
| backend/tests/contracts/test_openapi_contract_freeze.py | Extends `test_error_component_responses_reference_error_envelope` to verify `Error422` and `Error423` components reference `ErrorResponse` schema |
| backend/tests/contracts/test_platform_api_v1_handlers.py | Adds four handler-level tests for risk rejections: deployment/order creation returning `422` for limit breach and `423` for kill switch, verifying status codes and error codes |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Platform API
    participant Risk as Risk Service
    participant Store as State Store

    Note over Client,Store: Risk Limit Breach Flow (422)
    Client->>API: POST /v1/deployments (capital: 1,000,001)
    API->>Risk: Pre-trade check
    Risk->>Risk: Validate capital limit
    Risk-->>API: RISK_LIMIT_BREACH
    API-->>Client: 422 Unprocessable Entity<br/>{code: "RISK_LIMIT_BREACH"}

    Note over Client,Store: Kill Switch Active Flow (423)
    Client->>API: POST /v1/orders (quantity: 0.1)
    API->>Store: Get risk policy
    Store-->>API: killSwitch.triggered = true
    API->>Risk: Pre-trade check
    Risk-->>API: RISK_KILL_SWITCH_ACTIVE
    API-->>Client: 423 Locked<br/>{code: "RISK_KILL_SWITCH_ACTIVE"}

    Note over Client,Store: Successful Flow (no risk rejection)
    Client->>API: POST /v1/deployments (capital: 20,000)
    API->>Risk: Pre-trade check
    Risk-->>API: OK
    API->>Store: Create deployment
    API-->>Client: 202 Accepted
```

<sub>Last reviewed commit: efb4b9f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->