### PR TITLE
docs(g5-149): regenerate final LLM package traceability

### DIFF
--- a/docs/llm/chunks/portal_gate5_consumer_mock_contracts_v1.md
+++ b/docs/llm/chunks/portal_gate5_consumer_mock_contracts_v1.md
@@ -1,0 +1,40 @@
+# Gate5 Consumer-Driven Mock Contract Checks
+
+Source: `docs/portal/operations/gate5-consumer-mock-contracts.md`
+Topic: `operations`
+Stable ID: `portal_gate5_consumer_mock_contracts_v1`
+
+# Gate5 Consumer-Driven Mock Contract Checks
+
+## Objective
+
+Ensure client-facing payload contracts remain compatible before release by validating generated mock responses from the authoritative Platform API OpenAPI spec.
+
+## CI Gates
+
+`contracts-governance` must run both:
+
+1. `bash contracts/scripts/mock-smoke-test.sh`
+2. `bash contracts/scripts/mock-consumer-contract-test.sh`
+
+## Consumer Scope
+
+Current consumer-driven assertions include:
+
+1. Trading CLI lane expectations on `/v1/research/market-scan` and `/v1/strategies`.
+2. OpenClaw lane expectations on `/v2/conversations/sessions` and `/v2/conversations/sessions/{sessionId}/turns`.
+
+## Failure Semantics
+
+Merge is blocked when either check fails for any of:
+
+1. route/routing breakage,
+2. missing required client envelope fields,
+3. non-conforming session/turn shape for OpenClaw lane flows.
+
+## Traceability
+
+- `contracts/scripts/mock-smoke-test.sh`
+- `contracts/scripts/mock-consumer-contract-test.sh`
+- `.github/workflows/contracts-governance.yml`
+- `docs/architecture/INTERFACES.md`

--- a/docs/llm/chunks/portal_gate5_deployment_profile_v1.md
+++ b/docs/llm/chunks/portal_gate5_deployment_profile_v1.md
@@ -1,0 +1,39 @@
+# Gate5 Deployment Profile
+
+Source: `docs/portal/operations/gate5-deployment-profile.md`
+Topic: `operations`
+Stable ID: `portal_gate5_deployment_profile_v1`
+
+# Gate5 Deployment Profile
+
+## Objective
+
+Gate5 enforces one active deployment target profile with no contradictory runtime paths.
+
+## Active Path
+
+1. Azure Container Apps in resource group `trade-nexus` (West Europe).
+2. Backend runtime in `trade-nexus-backend`.
+3. Images sourced from `tradenexusacr`.
+4. Deployment automation via `backend-deploy.yml`.
+
+## Explicitly Inactive Paths
+
+1. AKS multi-cluster profile is not active for Gate5 release.
+2. Any client-side provider direct path is disallowed.
+3. Any mixed dual-active deployment profile is disallowed.
+
+## Release Readiness Checklist
+
+1. Contract governance checks are green.
+2. `contracts-governance` includes full backend contract behavior suite (`backend/tests/contracts` with OpenAPI baseline/freeze + behavior tests).
+3. Docs governance checks are green.
+4. Deployment documentation and runbooks reference a single active profile.
+5. Parent `#81` status is updated with deployment evidence links.
+
+## Traceability
+
+- Deployment architecture source: `/docs/architecture/DEPLOYMENT.md`
+- Gate workflow process: `/docs/portal/operations/gate-workflow.md`
+- Reliability/deployment closure evidence: `/docs/portal/operations/gate5-reliability-deployment-closure.md`
+- Reliability parent epic: `#81`

--- a/docs/llm/chunks/portal_gate5_ml_signal_integration_v1.md
+++ b/docs/llm/chunks/portal_gate5_ml_signal_integration_v1.md
@@ -1,0 +1,97 @@
+# Gate5 ML Signal Integration and Safety
+
+Source: `docs/portal/platform/gate5-ml-signal-integration.md`
+Topic: `platform`
+Stable ID: `portal_gate5_ml_signal_integration_v1`
+
+# Gate5 ML Signal Integration and Safety
+
+## Objective
+
+Document the Gate5 ML wiring that augments research and risk paths without allowing opaque model output to drive side effects.
+
+## Signal Contract Matrix
+
+| Signal | Input Fields | Validation Rules | Deterministic Fallback | Runtime Usage | Audit Surface |
+| --- | --- | --- | --- | --- | --- |
+| `prediction` | `direction`, `confidence` | `direction` in `bullish/bearish/neutral`; confidence normalized to `0..1` | direction -> `neutral`; confidence -> `0.0` | Research idea ranking bias only | `dataContextSummary`, `fallbackReasons` |
+| `sentiment` | `score`, `confidence`, optional source metadata | score normalized to `0..1`; confidence normalized to `0..1`; top-level `sentiment` merged into `mlSignals.sentiment` | score -> `0.5`; confidence -> `0.0` | Research scoring/context summary only | `dataContextSummary` includes score/confidence/source/lookback and fallback markers |
+| `volatility` | `predictedPct`, `confidence` | `predictedPct >= 0`; confidence in `0..1`; high-confidence tiers map to fixed sizing multipliers | multiplier -> `1.0`; source -> `fallback`; explicit reason recorded | Risk pretrade sizing only | Risk audit metadata (`volatilityForecast*`, `volatilityFallback*`) |
+| `anomaly` | `isAnomaly`, `score`, `confidence` | score and confidence coerced to `0..1`; breach requires `isAnomaly=true`, `score>=0.8`, `confidence>=0.7` | clear anomaly state with explicit fallback reason | Research risk flags + Risk fail-closed gate | `dataContextSummary`, `mlAnomaly*` audit fields |
+| `regime` | `label/regime/state`, `confidence` | alias normalization to `risk_on/neutral/risk_off`; confidence threshold `>=0.55` | `neutral` regime and multiplier `1.0` with fallback reason | Research context + Risk sizing multiplier | `dataContextSummary`, `mlRegime*` audit fields |
+
+## Validation and Fallback Rules
+
+1. ML signals are optional inputs; missing payloads never crash the request path.
+2. Confidence values above `1.0` are normalized as percentages (`x / 100`) where applicable.
+3. Out-of-range values become deterministic fallback defaults and append explicit fallback reason codes.
+4. Regime confidence below `0.55` forces `neutral` regime behavior.
+5. Volatility confidence below `0.55` forces multiplier `1.0`.
+6. Anomaly breach thresholds (`isAnomaly=true`, `score>=0.8`, `confidence>=0.7`) block execution side effects.
+7. Research path uses ML only for ranking/context enrichment; it does not execute trades.
+8. Execution side effects remain gated by risk checks and adapter boundaries.
+
+## Fallback Matrix
+
+| Condition | Research Outcome | Risk Outcome | Evidence |
+| --- | --- | --- | --- |
+| `mlSignals` missing | baseline ranking + fallback summary text | neutral regime, no anomaly breach, volatility multiplier `1.0` | `fallbackReasons`, `mlSignalFallbackReason` |
+| Sentiment malformed | score `0.5`, confidence `0.0` | no direct risk side-effect | sentiment fallback reasons in context summary |
+| Volatility missing/invalid/low-confidence | no ranking failure | multiplier `1.0` fail-open | `volatilityFallbackReason`, `volatilityFallbackUsed=true` |
+| Regime low confidence | neutral regime in summary | neutral regime multiplier `1.0` | `regime_confidence_low`, `mlRegimeSizingMultiplier=1.0` |
+| Anomaly breach active | research risk flag `anomaly_breach` | pretrade fail-closed (`ML_ANOMALY_BREACH`) | `mlAnomalyBreach=true` and blocked audit event |
+
+## Decision Loop Wiring
+
+```mermaid
+flowchart TD
+  A["POST /v2/research/market-scan"] --> B["DataKnowledgeAdapter.get_market_context"]
+  B --> C["Normalize top-level sentiment into mlSignals.sentiment"]
+  C --> D["MLSignalValidationService.validate"]
+  D --> E["Research ranking and dataContextSummary (audit text)"]
+  E --> F["Persist market ML snapshot (__market__)"]
+  F --> G["Risk pretrade checks resolve ML snapshot"]
+  G --> H{"Anomaly breach?"}
+  H -->|Yes| I["Fail-closed block before adapter side effects"]
+  H -->|No| J["Apply regime and volatility sizing multipliers"]
+  J --> K["Risk audit trail metadata persisted"]
+```
+
+## Auditability Contract
+
+Research path auditability:
+
+1. `dataContextSummary` contains normalized ML summary and fallback reason list.
+2. `riskFlags` surface `anomaly_breach` and `regime_risk_off` states for downstream consumers.
+3. `mlSignalSummary` and `mlSignals` snapshots are persisted in state store for risk gating.
+
+Risk path auditability:
+
+1. Volatility metadata: `volatilityForecastPct`, `volatilityForecastConfidence`, `volatilitySizingMultiplier`, `volatilityForecastSource`, `volatilityFallbackReason`, `volatilityFallbackUsed`.
+2. Regime/anomaly metadata: `mlSignalSource`, `mlSignalFallbackReason`, `mlSignalFallbackUsed`, `mlRegime`, `mlRegimeConfidence`, `mlRegimeSizingMultiplier`, `mlAnomalyScore`, `mlAnomalyConfidence`, `mlAnomalyFlag`, `mlAnomalyBreach`.
+3. Breach blocks write explicit outcome code (`ML_ANOMALY_BREACH`) in risk audit records.
+
+## Runtime and Test Traceability
+
+Runtime modules:
+
+1. `/backend/src/platform_api/services/ml_signal_service.py`
+2. `/backend/src/platform_api/services/v2_services.py`
+3. `/backend/src/platform_api/services/risk_pretrade_service.py`
+4. `/backend/src/platform_api/adapters/data_knowledge_adapter.py`
+
+Contract tests:
+
+1. `/backend/tests/contracts/test_ml_signal_validation_service.py`
+2. `/backend/tests/contracts/test_platform_api_v2_handlers.py`
+3. `/backend/tests/contracts/test_data_knowledge_adapter_cache_policy.py`
+4. `/backend/tests/contracts/test_risk_pretrade_checks.py`
+5. `/backend/tests/contracts/test_risk_audit_trail.py`
+
+Issue coverage:
+
+1. `#85` ML prediction wiring
+2. `#86` sentiment integration
+3. `#87` volatility-risk integration
+4. `#88` anomaly/regime integration
+5. `#53` research provider budget fail-closed controls

--- a/docs/llm/chunks/portal_gate5_orchestrator_execution_traces_v1.md
+++ b/docs/llm/chunks/portal_gate5_orchestrator_execution_traces_v1.md
@@ -1,0 +1,67 @@
+# Gate5 Orchestrator Execution Traces
+
+Source: `docs/portal/operations/gate5-orchestrator-execution-traces.md`
+Topic: `operations`
+Stable ID: `portal_gate5_orchestrator_execution_traces_v1`
+
+# Gate5 Orchestrator Execution Traces
+
+## Objective
+
+Persist deterministic orchestrator traces for run lifecycle transitions and retry decisions so runtime behavior is auditable.
+
+## Runtime Contract
+
+1. State store record type: `OrchestratorExecutionTraceRecord`.
+2. Storage location: `InMemoryStateStore.orchestrator_execution_traces`.
+3. Trace identity fields are required on every record:
+   - `request_id`
+   - `tenant_id`
+   - `user_id`
+4. Trace records are append-only and chronological for each `run_id`.
+
+## Emitted Events
+
+### Queue lifecycle
+
+- `run_received`
+- `state_transition`
+
+Transitions covered by step labels:
+
+- `enqueue`
+- `dequeue`
+- `await_tool`
+- `await_user_confirmation`
+- `resume`
+- `cancel`
+- `complete`
+- `fail`
+
+### Retry policy
+
+- `retry_attempt_started`
+- `retry_failure_recorded`
+- `retry_scheduled`
+- `retry_terminal_decision`
+- `retry_success`
+
+## Validation Coverage
+
+Contract tests verify:
+
+1. Lifecycle state transitions are traced end-to-end.
+2. Retry schedule and terminal decisions are traced with metadata.
+3. Trace identity propagation is preserved for auditability.
+
+Relevant tests:
+
+- `backend/tests/contracts/test_orchestrator_execution_traces.py`
+- `backend/tests/contracts/test_orchestrator_queue_cancellation.py`
+- `backend/tests/contracts/test_orchestrator_retry_policy.py`
+
+## Traceability
+
+- Child issue: `#49`
+- Parent epics: `#77`, `#81`
+- Interface contract: `docs/architecture/INTERFACES.md`

--- a/docs/llm/chunks/portal_gate5_release_runbooks_client_validation_v1.md
+++ b/docs/llm/chunks/portal_gate5_release_runbooks_client_validation_v1.md
@@ -1,0 +1,101 @@
+# Gate5 Release Runbooks And Client Validation
+
+Source: `docs/portal/operations/gate5-release-runbooks-and-client-validation.md`
+Topic: `operations`
+Stable ID: `portal_gate5_release_runbooks_client_validation_v1`
+
+# Gate5 Release Runbooks And Client Validation
+
+## Objective
+
+Define one operational playbook for Gate5 release validation and incident handling across CLI, Web, OpenClaw, and agent-runtime client lanes.
+
+## Entry Criteria
+
+Run this playbook only when foundational dependencies are complete:
+
+1. `#44` consumer-driven mock contract checks merged.
+2. `#45` SLO and alert baseline merged.
+3. `#75` deployment profile reconciled to one active path.
+4. `#80` pre-release readiness dependency closed.
+
+## Release Validation Sequence
+
+1. Confirm required governance checks are green on release PRs:
+   - `contract-governance`
+   - `review-governance`
+   - `docs-governance`
+   - `llm-package-governance`
+2. Confirm deployment profile remains singular:
+   - `/docs/portal/operations/gate5-deployment-profile.md`
+3. Confirm reliability closure evidence is current:
+   - `/docs/portal/operations/gate5-reliability-deployment-closure.md`
+4. Execute lane-by-lane compatibility checks (below).
+
+## Cross-Client Compatibility Matrix
+
+| Lane | Validation Surface | Primary Commands | Pass Criteria |
+| --- | --- | --- | --- |
+| CLI | Platform boundary + mock consumer checks | `cd trading-cli && bun run ci` | contract tests pass, no boundary drift |
+| Web | OpenAPI + SDK contract compatibility | `cd trade-nexus && bash contracts/scripts/verify-sdk-drift.sh` | SDK in sync with OpenAPI contract |
+| OpenClaw | Platform API lane contract + end-to-end flow | `cd trade-nexus/backend && uv run --with pytest python -m pytest tests/contracts/test_openclaw_client_lane_contract.py tests/contracts/test_openclaw_e2e_flow.py` | both suites pass |
+| Agent runtime | risk/research/reconciliation/orchestrator contracts | `cd trade-nexus/backend && uv run --with pytest python -m pytest tests/contracts` | full contract suite passes |
+
+## Deployment Promotion And Rollback
+
+Promotion and rollback follow the existing operational runbooks:
+
+1. Promotion guide: `/.ops/runbooks/release-promotion.md`
+2. Smoke validation: `/.ops/scripts/smoke-check.sh`
+3. Rollback automation: `/.ops/scripts/rollback.sh`
+4. SLO reference: `/.ops/runbooks/slo-definitions.md`
+
+## Incident Handling Playbook
+
+### Scenario A: Contract Regression
+
+1. Contain: block merge and hold deployment promotion.
+2. Verify with:
+   - `pytest backend/tests/contracts/test_openapi_contract_baseline.py`
+   - `pytest backend/tests/contracts/test_openapi_contract_freeze.py`
+   - `bash contracts/scripts/check-breaking-changes.sh`
+3. Recover: patch contract/runtime mismatch, rerun gates, and repost evidence on the release issue.
+
+### Scenario B: Reliability/SLO Breach
+
+1. Contain: halt release progression, run smoke checks, and assess active revision health.
+2. Verify with:
+   - `/.ops/scripts/smoke-check.sh`
+   - SLO baseline at `contracts/config/slo-alert-baseline.v1.json`
+3. Recover: execute rollback (`/.ops/scripts/rollback.sh`) if breach criteria are met.
+
+### Scenario C: Cross-Client Compatibility Failure
+
+1. Contain: freeze release and identify affected lane(s).
+2. Reproduce using lane-specific commands from the compatibility matrix.
+3. Recover: fix contract drift or client expectation mismatch, then rerun lane and governance checks.
+
+## Evidence Recording
+
+For each release candidate, capture:
+
+1. CI run URLs for required governance checks.
+2. Command output summaries per lane.
+3. Deployment revision and smoke-check outcome.
+4. Any rollback/incident actions executed.
+
+Use:
+
+- `/.ops/templates/release-evidence.md`
+- `/.ops/templates/drill-report.md`
+
+## Traceability
+
+- Child issue: `#147`
+- Parent epics: `#81`, `#106`
+- Signoff: `#150`
+- Related docs:
+  - `/docs/portal/operations/gate5-deployment-profile.md`
+  - `/docs/portal/operations/gate5-reliability-deployment-closure.md`
+  - `/docs/portal/operations/gate5-consumer-mock-contracts.md`
+  - `/docs/portal/operations/gate5-slo-alerting-baseline.md`

--- a/docs/llm/chunks/portal_gate5_reliability_deployment_closure_v1.md
+++ b/docs/llm/chunks/portal_gate5_reliability_deployment_closure_v1.md
@@ -1,0 +1,61 @@
+# Gate5 Reliability And Deployment Closure
+
+Source: `docs/portal/operations/gate5-reliability-deployment-closure.md`
+Topic: `operations`
+Stable ID: `portal_gate5_reliability_deployment_closure_v1`
+
+# Gate5 Reliability And Deployment Closure
+
+## Objective
+
+Provide one release-facing reliability and deployment closure record with traceable evidence across the full Gate5 reliability scope.
+
+## Scope Matrix
+
+| Issue | Scope | Status | Evidence |
+| --- | --- | --- | --- |
+| `#75` | Deployment target profile reconciliation | merged | [PR #184](https://github.com/iamtxena/trade-nexus/pull/184), commit `0ec4f5d534fb40e4fc79b833d0518cc3b899ca15` |
+| `#42` | Structured observability fields | merged | [PR #197](https://github.com/iamtxena/trade-nexus/pull/197), commit `bf60845a25521c989d039c9b16c9bea808791a64` |
+| `#43` | Reliability baseline non-regression verification | verified in Gate5 wave | `contract-governance` remained green while #42/#44/#45/#49 landed |
+| `#44` | Consumer-driven tests with mock server | merged | [PR #198](https://github.com/iamtxena/trade-nexus/pull/198), commit `674fcdab62d52a5c2223b1b338949b48a885e65c` |
+| `#45` | SLO and alerting baseline definition | merged | [PR #201](https://github.com/iamtxena/trade-nexus/pull/201), commit `b6b3c4884865e5bb9e1f1392880e220ef89382f3` |
+| `#49` | Orchestrator execution traces | merged | [PR #200](https://github.com/iamtxena/trade-nexus/pull/200), commit `02470cf8fcacd8f3fc141b596cbddb8b860c2c8b` |
+
+## Mandatory Gate Checks
+
+Gate5 reliability closure is merge-gated by:
+
+1. `contract-governance` (OpenAPI baseline/freeze + full backend contract behavior + mock smoke + mock consumer + SDK drift + breaking-change checks)
+2. `review-governance` (resolved threads + Cursor/Greptile sequencing)
+3. `docs-governance` (portal build/link/schema/stale-ref checks)
+4. `llm-package-governance` (generated package validation and committed artifacts)
+
+## Deployment Closure Criteria
+
+1. Single active deployment path is explicit and documented.
+2. Contradictory active deployment paths are disallowed.
+3. Release checklist references reliability gates as blocking conditions.
+4. Reliability evidence is linked from parent operations tracking (`#81`).
+
+See:
+
+- `/docs/portal/operations/gate5-deployment-profile.md`
+- `/docs/architecture/DEPLOYMENT.md`
+
+## Reliability Coverage Snapshot
+
+1. Correlation-first observability fields are enforced across middleware and core runtime services.
+2. Consumer contract compatibility is validated against mock-server outputs for CLI and OpenClaw lanes.
+3. SLO/alert baseline is versioned and CI-validated for docs/config consistency.
+4. Orchestrator lifecycle and retry decisions emit append-only trace records for auditability.
+
+## Traceability
+
+- `/docs/portal/operations/gate5-structured-observability.md`
+- `/docs/portal/operations/gate5-consumer-mock-contracts.md`
+- `/docs/portal/operations/gate5-slo-alerting-baseline.md`
+- `/docs/portal/operations/gate5-orchestrator-execution-traces.md`
+- `/docs/portal/operations/gate5-release-runbooks-and-client-validation.md`
+- `/docs/architecture/INTERFACES.md`
+- `.github/workflows/contracts-governance.yml`
+- Parent epics: `#81`, `#106`

--- a/docs/llm/chunks/portal_gate5_slo_alerting_baseline_v1.md
+++ b/docs/llm/chunks/portal_gate5_slo_alerting_baseline_v1.md
@@ -1,0 +1,50 @@
+# Gate5 SLO And Alerting Baseline
+
+Source: `docs/portal/operations/gate5-slo-alerting-baseline.md`
+Topic: `operations`
+Stable ID: `portal_gate5_slo_alerting_baseline_v1`
+
+# Gate5 SLO And Alerting Baseline
+
+## Objective
+
+Define one explicit, versioned reliability baseline for critical Gate5 runtime paths and enforce it in CI.
+
+## Source Of Truth
+
+1. Baseline version: `gate5-slo-alert-baseline.v1`
+2. Versioned config: `contracts/config/slo-alert-baseline.v1.json`
+3. Verification gate: `contracts/scripts/check-slo-alert-baseline.py`
+4. CI enforcement path: `.github/workflows/contracts-governance.yml`
+
+## SLO Matrix
+
+| SLO ID | Service | Critical Path | SLI | Target | Window | Owner |
+| --- | --- | --- | --- | --- | --- | --- |
+| `platform_api_request_success_rate` | platform-api | execution,risk,research,reconciliation,conversation | 2xx_or_contractual_4xx_rate | `>=99.5%` | 30d | Team F |
+| `risk_pretrade_latency_p95_ms` | risk-pretrade | risk,execution | p95_latency_ms | `<=200` | 7d | Team F |
+| `research_market_scan_latency_p95_ms` | research | research | p95_latency_ms | `<=2500` | 7d | Team F |
+| `reconciliation_cycle_success_rate` | reconciliation | reconciliation | successful_cycle_rate | `>=99.0%` | 30d | Team F |
+| `conversation_turn_latency_p95_ms` | conversation | conversation | p95_latency_ms | `<=1200` | 7d | Team F |
+
+## Alert Matrix
+
+| Alert ID | SLO ID | Condition | Severity | Owner |
+| --- | --- | --- | --- | --- |
+| `alert_platform_api_success_rate_burn` | `platform_api_request_success_rate` | `error_budget_burn_2h>=5%` | SEV-2 | Team F |
+| `alert_risk_pretrade_latency` | `risk_pretrade_latency_p95_ms` | `p95_latency_ms>200_for_15m` | SEV-2 | Team F |
+| `alert_research_latency` | `research_market_scan_latency_p95_ms` | `p95_latency_ms>2500_for_15m` | SEV-3 | Team F |
+| `alert_reconciliation_success_rate` | `reconciliation_cycle_success_rate` | `successful_cycle_rate<99.0_for_15m` | SEV-2 | Team F |
+| `alert_conversation_turn_latency` | `conversation_turn_latency_p95_ms` | `p95_latency_ms>1200_for_15m` | SEV-3 | Team F |
+
+## Governance Rules
+
+1. Any SLO or alert semantics change must update both this portal page and `contracts/config/slo-alert-baseline.v1.json` in the same PR.
+2. `contracts/scripts/check-slo-alert-baseline.py` must pass in CI before merge.
+3. Missing owner, target, or ID alignment is a release-gating failure for Gate5.
+
+## Traceability
+
+- Reliability parent: `#81`
+- Gate5 reliability closure issue: `#45`
+- Gate workflow template: `docs/portal/operations/gate-workflow.md`

--- a/docs/llm/chunks/portal_gate5_structured_observability_v1.md
+++ b/docs/llm/chunks/portal_gate5_structured_observability_v1.md
@@ -1,0 +1,48 @@
+# Gate5 Structured Observability Fields
+
+Source: `docs/portal/operations/gate5-structured-observability.md`
+Topic: `operations`
+Stable ID: `portal_gate5_structured_observability_v1`
+
+# Gate5 Structured Observability Fields
+
+## Objective
+
+Make runtime logs queryable by request and actor identity so release stabilization and incident response can trace execution paths deterministically.
+
+## Required Structured Fields
+
+All Platform API request/service logs emit:
+
+1. `requestId`
+2. `tenantId`
+3. `userId`
+4. `component`
+5. `operation`
+6. `resourceType` (when applicable)
+7. `resourceId` (when applicable)
+
+## Runtime Coverage
+
+Structured observability is emitted across:
+
+1. request middleware (`request_started`, `request_completed`, unhandled failure path),
+2. research (`market_scan` enrichment events),
+3. risk pretrade decisions (`approved`/`blocked`),
+4. execution command orchestration (`create_deployment`, `create_order`),
+5. reconciliation drift checks,
+6. conversation session/turn lifecycle.
+
+## Validation Evidence
+
+Contract coverage asserts correlation fields are present and consistent:
+
+- `/backend/tests/contracts/test_observability_structured_fields.py`
+- `/backend/tests/contracts/test_error_envelope_runtime.py`
+
+## Traceability
+
+- Runtime helper: `/backend/src/platform_api/observability.py`
+- Middleware entrypoint: `/backend/src/main.py`
+- Interface contract: `/docs/architecture/INTERFACES.md`
+- Related issues: `#42`, `#81`, `#106`

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -326,5 +326,221 @@
       "risk_gate_enforcement",
       "drawdown_containment"
     ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_consumer_mock_contracts_v1.md",
+    "chunk_hash": "f34e780ede385920874eb135c9e4a746918ac7cef2fb89d8edd12a0ee71be890",
+    "concepts": [
+      "consumer_driven_contracts",
+      "mock_server",
+      "lane_compatibility"
+    ],
+    "endpoints": [
+      "/v1/research/market-scan",
+      "/v1/strategies",
+      "/v2/conversations/sessions",
+      "/v2/conversations/sessions/{sessionId}/turns"
+    ],
+    "id": "portal_gate5_consumer_mock_contracts_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81",
+    "owners": [
+      "Team F",
+      "Team E"
+    ],
+    "source": "docs/portal/operations/gate5-consumer-mock-contracts.md",
+    "source_hash": "72dd3c47e3abd84077c4c22e3f527576e78c0d9013eb64374102182f8745908b",
+    "title": "Gate5 Consumer-Driven Mock Contract Checks",
+    "topic": "operations",
+    "workflows": [
+      "mock_contract_validation",
+      "cross_client_contract_checks"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_deployment_profile_v1.md",
+    "chunk_hash": "b2a757d37dad24462b5f311396c2a17f89eba6c00b320862391115f298cf7525",
+    "concepts": [
+      "deployment_profile",
+      "single_active_path",
+      "release_gates"
+    ],
+    "endpoints": [],
+    "id": "portal_gate5_deployment_profile_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81",
+    "owners": [
+      "Team F",
+      "Team G"
+    ],
+    "source": "docs/portal/operations/gate5-deployment-profile.md",
+    "source_hash": "8c8fc4a076725f9ad42124f23750ebfbb5404bb6124bdbd066835b6881114bcd",
+    "title": "Gate5 Deployment Profile",
+    "topic": "operations",
+    "workflows": [
+      "deployment_reconciliation",
+      "release_readiness"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_ml_signal_integration_v1.md",
+    "chunk_hash": "3802fd51d84806927cca6d30dad75bae4b77052fd9b4b8dedd5ca781a38c68fe",
+    "concepts": [
+      "ml_signal_contracts",
+      "fallback_matrix",
+      "auditability"
+    ],
+    "endpoints": [
+      "/v2/research/market-scan",
+      "/v1/deployments",
+      "/v1/orders"
+    ],
+    "id": "portal_gate5_ml_signal_integration_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/77",
+    "owners": [
+      "Team C",
+      "Team B",
+      "Team G"
+    ],
+    "source": "docs/portal/platform/gate5-ml-signal-integration.md",
+    "source_hash": "53517d133f7114be8f4467222ea73b26c8745736b874e6fea99f290b53129f47",
+    "title": "Gate5 ML Signal Integration",
+    "topic": "platform",
+    "workflows": [
+      "research_scoring_with_ml",
+      "risk_safe_fallback"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_orchestrator_execution_traces_v1.md",
+    "chunk_hash": "13ac5ca023e77bd157b73ea1c8cbc76660a1f867d504bbbd14a4510ca4d1b14a",
+    "concepts": [
+      "orchestrator_traces",
+      "lifecycle_transitions",
+      "retry_auditability"
+    ],
+    "endpoints": [
+      "/v1/deployments",
+      "/v1/orders"
+    ],
+    "id": "portal_gate5_orchestrator_execution_traces_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81",
+    "owners": [
+      "Team F",
+      "Team G"
+    ],
+    "source": "docs/portal/operations/gate5-orchestrator-execution-traces.md",
+    "source_hash": "890cb2293b8f95e667e66a6b76f182d074ae758a584fe1a4c602e7e63f5c3496",
+    "title": "Gate5 Orchestrator Execution Traces",
+    "topic": "operations",
+    "workflows": [
+      "orchestrator_trace_capture",
+      "retry_trace_persistence"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_release_runbooks_client_validation_v1.md",
+    "chunk_hash": "a5937679cdd8baf662c3e21ec23d065a9732ced4a96720bebf30318a8299c835",
+    "concepts": [
+      "release_runbook",
+      "cross_client_validation",
+      "incident_handling"
+    ],
+    "endpoints": [
+      "/health",
+      "/v1/health",
+      "/v2/conversations/sessions",
+      "/v2/conversations/sessions/{sessionId}/turns"
+    ],
+    "id": "portal_gate5_release_runbooks_client_validation_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/106",
+    "owners": [
+      "Team E",
+      "Team F",
+      "Team G"
+    ],
+    "source": "docs/portal/operations/gate5-release-runbooks-and-client-validation.md",
+    "source_hash": "8390c5222ef461f518c8c9caf7661239c4e50c75f30cd7979c45cc4b1288d283",
+    "title": "Gate5 Release Runbooks And Client Validation",
+    "topic": "operations",
+    "workflows": [
+      "release_validation_sequence",
+      "client_lane_compatibility"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_reliability_deployment_closure_v1.md",
+    "chunk_hash": "ce6533f41022d7d558938295239f0f897ec6d0092422cf7ff9bb0657ebc9c274",
+    "concepts": [
+      "closure_evidence",
+      "reliability_scope",
+      "deployment_readiness"
+    ],
+    "endpoints": [],
+    "id": "portal_gate5_reliability_deployment_closure_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/106",
+    "owners": [
+      "Team F",
+      "Team G"
+    ],
+    "source": "docs/portal/operations/gate5-reliability-deployment-closure.md",
+    "source_hash": "b1c5e80c3780ffb0c201da0ee1bdf1992ba555b25a9e2bd3dbe426f54c922f86",
+    "title": "Gate5 Reliability And Deployment Closure",
+    "topic": "operations",
+    "workflows": [
+      "gate5_reliability_closeout",
+      "release_signoff_prep"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_slo_alerting_baseline_v1.md",
+    "chunk_hash": "999772c7a34bb86f09d34c84cdba0059c86d059cf2f93a96b9311af8f8750a7f",
+    "concepts": [
+      "slo_baseline",
+      "alert_thresholds",
+      "owner_accountability"
+    ],
+    "endpoints": [],
+    "id": "portal_gate5_slo_alerting_baseline_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81",
+    "owners": [
+      "Team F",
+      "Team G"
+    ],
+    "source": "docs/portal/operations/gate5-slo-alerting-baseline.md",
+    "source_hash": "377a3bfcab0d62c9c7bd07973c5bf19faf2f1a8a2eca1be94de558dd330bd201",
+    "title": "Gate5 SLO And Alerting Baseline",
+    "topic": "operations",
+    "workflows": [
+      "slo_governance",
+      "release_gate_enforcement"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_structured_observability_v1.md",
+    "chunk_hash": "9e326dad1896fce0582433f500f47ec5b9245e7284e34b80fe757e42b31073d4",
+    "concepts": [
+      "structured_logging",
+      "request_correlation",
+      "service_instrumentation"
+    ],
+    "endpoints": [
+      "/v1/research/market-scan",
+      "/v1/deployments",
+      "/v1/orders",
+      "/v2/conversations/sessions"
+    ],
+    "id": "portal_gate5_structured_observability_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81",
+    "owners": [
+      "Team F",
+      "Team G"
+    ],
+    "source": "docs/portal/operations/gate5-structured-observability.md",
+    "source_hash": "8ddfab927bcb3e472c645da2d7aff342e40e003ba0a3d56a034df21fb4a37369",
+    "title": "Gate5 Structured Observability Fields",
+    "topic": "operations",
+    "workflows": [
+      "runtime_observability",
+      "incident_traceability"
+    ]
   }
 ]

--- a/docs/llm/manifest.json
+++ b/docs/llm/manifest.json
@@ -1,6 +1,6 @@
 {
-  "entry_count": 12,
+  "entry_count": 20,
   "schema_version": "1.0",
   "source_map": "docs/llm/source-map.json",
-  "source_map_hash": "f13aa6690cd34050a32e105ba7ab75f257a0ef188426f1f1f2b11df0bd9eee9b"
+  "source_map_hash": "5de88406aa92a1b0e0bc0d19e8f3f60a3244d8168c787594ee75658f74062264"
 }

--- a/docs/llm/source-map.json
+++ b/docs/llm/source-map.json
@@ -132,6 +132,94 @@
       "workflows": ["incident_response", "gate4_docs_review"],
       "owners": ["Team F", "Team G", "Team E", "Team B"],
       "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81"
+    },
+    {
+      "id": "portal_gate5_ml_signal_integration_v1",
+      "title": "Gate5 ML Signal Integration",
+      "source": "docs/portal/platform/gate5-ml-signal-integration.md",
+      "topic": "platform",
+      "concepts": ["ml_signal_contracts", "fallback_matrix", "auditability"],
+      "endpoints": ["/v2/research/market-scan", "/v1/deployments", "/v1/orders"],
+      "workflows": ["research_scoring_with_ml", "risk_safe_fallback"],
+      "owners": ["Team C", "Team B", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/77"
+    },
+    {
+      "id": "portal_gate5_structured_observability_v1",
+      "title": "Gate5 Structured Observability Fields",
+      "source": "docs/portal/operations/gate5-structured-observability.md",
+      "topic": "operations",
+      "concepts": ["structured_logging", "request_correlation", "service_instrumentation"],
+      "endpoints": ["/v1/research/market-scan", "/v1/deployments", "/v1/orders", "/v2/conversations/sessions"],
+      "workflows": ["runtime_observability", "incident_traceability"],
+      "owners": ["Team F", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81"
+    },
+    {
+      "id": "portal_gate5_consumer_mock_contracts_v1",
+      "title": "Gate5 Consumer-Driven Mock Contract Checks",
+      "source": "docs/portal/operations/gate5-consumer-mock-contracts.md",
+      "topic": "operations",
+      "concepts": ["consumer_driven_contracts", "mock_server", "lane_compatibility"],
+      "endpoints": ["/v1/research/market-scan", "/v1/strategies", "/v2/conversations/sessions", "/v2/conversations/sessions/{sessionId}/turns"],
+      "workflows": ["mock_contract_validation", "cross_client_contract_checks"],
+      "owners": ["Team F", "Team E"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81"
+    },
+    {
+      "id": "portal_gate5_deployment_profile_v1",
+      "title": "Gate5 Deployment Profile",
+      "source": "docs/portal/operations/gate5-deployment-profile.md",
+      "topic": "operations",
+      "concepts": ["deployment_profile", "single_active_path", "release_gates"],
+      "endpoints": [],
+      "workflows": ["deployment_reconciliation", "release_readiness"],
+      "owners": ["Team F", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81"
+    },
+    {
+      "id": "portal_gate5_orchestrator_execution_traces_v1",
+      "title": "Gate5 Orchestrator Execution Traces",
+      "source": "docs/portal/operations/gate5-orchestrator-execution-traces.md",
+      "topic": "operations",
+      "concepts": ["orchestrator_traces", "lifecycle_transitions", "retry_auditability"],
+      "endpoints": ["/v1/deployments", "/v1/orders"],
+      "workflows": ["orchestrator_trace_capture", "retry_trace_persistence"],
+      "owners": ["Team F", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81"
+    },
+    {
+      "id": "portal_gate5_slo_alerting_baseline_v1",
+      "title": "Gate5 SLO And Alerting Baseline",
+      "source": "docs/portal/operations/gate5-slo-alerting-baseline.md",
+      "topic": "operations",
+      "concepts": ["slo_baseline", "alert_thresholds", "owner_accountability"],
+      "endpoints": [],
+      "workflows": ["slo_governance", "release_gate_enforcement"],
+      "owners": ["Team F", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/81"
+    },
+    {
+      "id": "portal_gate5_reliability_deployment_closure_v1",
+      "title": "Gate5 Reliability And Deployment Closure",
+      "source": "docs/portal/operations/gate5-reliability-deployment-closure.md",
+      "topic": "operations",
+      "concepts": ["closure_evidence", "reliability_scope", "deployment_readiness"],
+      "endpoints": [],
+      "workflows": ["gate5_reliability_closeout", "release_signoff_prep"],
+      "owners": ["Team F", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/106"
+    },
+    {
+      "id": "portal_gate5_release_runbooks_client_validation_v1",
+      "title": "Gate5 Release Runbooks And Client Validation",
+      "source": "docs/portal/operations/gate5-release-runbooks-and-client-validation.md",
+      "topic": "operations",
+      "concepts": ["release_runbook", "cross_client_validation", "incident_handling"],
+      "endpoints": ["/health", "/v1/health", "/v2/conversations/sessions", "/v2/conversations/sessions/{sessionId}/turns"],
+      "workflows": ["release_validation_sequence", "client_lane_compatibility"],
+      "owners": ["Team E", "Team F", "Team G"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/106"
     }
   ]
 }

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -82,5 +82,61 @@
     "id": "portal_gate4_risk_policy_controls_v1",
     "source": "docs/portal/operations/gate4-risk-policy-controls.md",
     "source_hash": "d1e553ac4d1850ef53a92be39baadcce07215a8b4ad06be0500a3af6989b7e72"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_consumer_mock_contracts_v1.md",
+    "chunk_hash": "f34e780ede385920874eb135c9e4a746918ac7cef2fb89d8edd12a0ee71be890",
+    "id": "portal_gate5_consumer_mock_contracts_v1",
+    "source": "docs/portal/operations/gate5-consumer-mock-contracts.md",
+    "source_hash": "72dd3c47e3abd84077c4c22e3f527576e78c0d9013eb64374102182f8745908b"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_deployment_profile_v1.md",
+    "chunk_hash": "b2a757d37dad24462b5f311396c2a17f89eba6c00b320862391115f298cf7525",
+    "id": "portal_gate5_deployment_profile_v1",
+    "source": "docs/portal/operations/gate5-deployment-profile.md",
+    "source_hash": "8c8fc4a076725f9ad42124f23750ebfbb5404bb6124bdbd066835b6881114bcd"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_ml_signal_integration_v1.md",
+    "chunk_hash": "3802fd51d84806927cca6d30dad75bae4b77052fd9b4b8dedd5ca781a38c68fe",
+    "id": "portal_gate5_ml_signal_integration_v1",
+    "source": "docs/portal/platform/gate5-ml-signal-integration.md",
+    "source_hash": "53517d133f7114be8f4467222ea73b26c8745736b874e6fea99f290b53129f47"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_orchestrator_execution_traces_v1.md",
+    "chunk_hash": "13ac5ca023e77bd157b73ea1c8cbc76660a1f867d504bbbd14a4510ca4d1b14a",
+    "id": "portal_gate5_orchestrator_execution_traces_v1",
+    "source": "docs/portal/operations/gate5-orchestrator-execution-traces.md",
+    "source_hash": "890cb2293b8f95e667e66a6b76f182d074ae758a584fe1a4c602e7e63f5c3496"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_release_runbooks_client_validation_v1.md",
+    "chunk_hash": "a5937679cdd8baf662c3e21ec23d065a9732ced4a96720bebf30318a8299c835",
+    "id": "portal_gate5_release_runbooks_client_validation_v1",
+    "source": "docs/portal/operations/gate5-release-runbooks-and-client-validation.md",
+    "source_hash": "8390c5222ef461f518c8c9caf7661239c4e50c75f30cd7979c45cc4b1288d283"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_reliability_deployment_closure_v1.md",
+    "chunk_hash": "ce6533f41022d7d558938295239f0f897ec6d0092422cf7ff9bb0657ebc9c274",
+    "id": "portal_gate5_reliability_deployment_closure_v1",
+    "source": "docs/portal/operations/gate5-reliability-deployment-closure.md",
+    "source_hash": "b1c5e80c3780ffb0c201da0ee1bdf1992ba555b25a9e2bd3dbe426f54c922f86"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_slo_alerting_baseline_v1.md",
+    "chunk_hash": "999772c7a34bb86f09d34c84cdba0059c86d059cf2f93a96b9311af8f8750a7f",
+    "id": "portal_gate5_slo_alerting_baseline_v1",
+    "source": "docs/portal/operations/gate5-slo-alerting-baseline.md",
+    "source_hash": "377a3bfcab0d62c9c7bd07973c5bf19faf2f1a8a2eca1be94de558dd330bd201"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_gate5_structured_observability_v1.md",
+    "chunk_hash": "9e326dad1896fce0582433f500f47ec5b9245e7284e34b80fe757e42b31073d4",
+    "id": "portal_gate5_structured_observability_v1",
+    "source": "docs/portal/operations/gate5-structured-observability.md",
+    "source_hash": "8ddfab927bcb3e472c645da2d7aff342e40e003ba0a3d56a034df21fb4a37369"
   }
 ]


### PR DESCRIPTION
## Summary\n- update docs/llm/source-map.json with Gate5 documentation entries\n- regenerate docs/llm chunks, index, manifest, and traceability artifacts\n- validate final package integrity for release-traceable docs delivery\n\n## Issue Links\n- Closes #149\n- Parent #106\n- Parent #81\n- Signoff #150\n\n## Validation\n- python3 scripts/docs/generate_llm_package.py\n- python3 scripts/docs/check_llm_package.py\n- npm --prefix docs/portal-site run ci\n\n## Notes\n- LLM package is generated from source docs only (no manual chunk editing).\n- No API contract or endpoint changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only regeneration of the `docs/llm` package (chunks/index/manifest/traceability) with no runtime or API behavior changes; risk is limited to broken LLM metadata/linkage if the generated artifacts are inconsistent.
> 
> **Overview**
> Adds eight new Gate5 documentation chunks to the generated `docs/llm` package (consumer mock contract checks, deployment profile, ML signal integration safety, orchestrator execution traces, release runbooks, reliability/deployment closure, SLO/alert baseline, structured observability).
> 
> Regenerates LLM package metadata to include these entries: updates `docs/llm/index.json`, `docs/llm/source-map.json`, `docs/llm/traceability.json`, and bumps `docs/llm/manifest.json` `entry_count` from 12 to 20 with a new `source_map_hash`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a16c27383b5c7380bd3af0ea669c6510300fd75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Regenerated LLM package artifacts to include 8 new Gate5 documentation entries (from 12 to 20 total entries), covering operations and platform topics for ML signal integration, observability, contract validation, deployment profiles, SLO/alerting, orchestrator traces, reliability closure, and release runbooks.

- Updated `source-map.json` with Gate5 documentation source references
- Generated 8 new chunk files with frontmatter stripped and metadata headers
- Regenerated `index.json` with complete entry metadata (concepts, endpoints, workflows, owners)
- Regenerated `traceability.json` with SHA256 hashes linking chunks to source files
- Updated `manifest.json` with correct entry count (20) and source-map hash

All changes are automated outputs from the LLM package generation script. Structure is consistent with existing entries - chunks properly reference source files, metadata is complete, and traceability hashes are present for integrity verification.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - automated documentation package regeneration with consistent structure
- All files are generated artifacts from scripts, counts are consistent (20 entries across all JSON files), chunk structure matches existing patterns with proper frontmatter stripping and metadata, traceability hashes present, and no code changes
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/llm/chunks/portal_gate5_ml_signal_integration_v1.md | Generated chunk documenting ML signal integration contracts and fallback matrix |
| docs/llm/chunks/portal_gate5_slo_alerting_baseline_v1.md | Generated chunk documenting SLO and alerting baseline with governance rules |
| docs/llm/index.json | Added 8 Gate5 entries with metadata (concepts, endpoints, workflows, owners) |
| docs/llm/manifest.json | Updated entry count from 12 to 20 and regenerated source-map hash |
| docs/llm/source-map.json | Added 8 Gate5 documentation source entries with topics, concepts, and owner links |
| docs/llm/traceability.json | Added 8 traceability records mapping chunks to source files with SHA256 hashes |

</details>


</details>


<sub>Last reviewed commit: 7a16c27</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->