### PR TITLE
docs(g5-150): align traceability endpoint and #80 waiver criteria

### DIFF
--- a/docs/llm/chunks/portal_gate5_release_runbooks_client_validation_v1.md
+++ b/docs/llm/chunks/portal_gate5_release_runbooks_client_validation_v1.md
@@ -17,7 +17,9 @@ Run this playbook only when foundational dependencies are complete:
 1. `#44` consumer-driven mock contract checks merged.
 2. `#45` SLO and alert baseline merged.
 3. `#75` deployment profile reconciled to one active path.
-4. `#80` pre-release readiness dependency closed.
+4. `#80` pre-release readiness dependency is either:
+   - closed, or
+   - explicitly waived with rationale and approver reference recorded on `#150`.
 
 ## Release Validation Sequence
 

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -438,14 +438,13 @@
   },
   {
     "chunk": "docs/llm/chunks/portal_gate5_release_runbooks_client_validation_v1.md",
-    "chunk_hash": "a5937679cdd8baf662c3e21ec23d065a9732ced4a96720bebf30318a8299c835",
+    "chunk_hash": "678584f25b014bf270509460e556b0b43074aeed9fef259a12b2fba58a99122b",
     "concepts": [
       "release_runbook",
       "cross_client_validation",
       "incident_handling"
     ],
     "endpoints": [
-      "/health",
       "/v1/health",
       "/v2/conversations/sessions",
       "/v2/conversations/sessions/{sessionId}/turns"
@@ -458,7 +457,7 @@
       "Team G"
     ],
     "source": "docs/portal/operations/gate5-release-runbooks-and-client-validation.md",
-    "source_hash": "8390c5222ef461f518c8c9caf7661239c4e50c75f30cd7979c45cc4b1288d283",
+    "source_hash": "170fe1836679a66b3ef7328a51ddc9dab97fc5ae25549d24f6289858a3a2b750",
     "title": "Gate5 Release Runbooks And Client Validation",
     "topic": "operations",
     "workflows": [

--- a/docs/llm/manifest.json
+++ b/docs/llm/manifest.json
@@ -2,5 +2,5 @@
   "entry_count": 20,
   "schema_version": "1.0",
   "source_map": "docs/llm/source-map.json",
-  "source_map_hash": "5de88406aa92a1b0e0bc0d19e8f3f60a3244d8168c787594ee75658f74062264"
+  "source_map_hash": "3d00e8a00fbfe515671ffd4c4f7d574d8bb57b3a551c437dce2e07d0320f0df2"
 }

--- a/docs/llm/source-map.json
+++ b/docs/llm/source-map.json
@@ -216,7 +216,7 @@
       "source": "docs/portal/operations/gate5-release-runbooks-and-client-validation.md",
       "topic": "operations",
       "concepts": ["release_runbook", "cross_client_validation", "incident_handling"],
-      "endpoints": ["/health", "/v1/health", "/v2/conversations/sessions", "/v2/conversations/sessions/{sessionId}/turns"],
+      "endpoints": ["/v1/health", "/v2/conversations/sessions", "/v2/conversations/sessions/{sessionId}/turns"],
       "workflows": ["release_validation_sequence", "client_lane_compatibility"],
       "owners": ["Team E", "Team F", "Team G"],
       "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/106"

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -113,10 +113,10 @@
   },
   {
     "chunk": "docs/llm/chunks/portal_gate5_release_runbooks_client_validation_v1.md",
-    "chunk_hash": "a5937679cdd8baf662c3e21ec23d065a9732ced4a96720bebf30318a8299c835",
+    "chunk_hash": "678584f25b014bf270509460e556b0b43074aeed9fef259a12b2fba58a99122b",
     "id": "portal_gate5_release_runbooks_client_validation_v1",
     "source": "docs/portal/operations/gate5-release-runbooks-and-client-validation.md",
-    "source_hash": "8390c5222ef461f518c8c9caf7661239c4e50c75f30cd7979c45cc4b1288d283"
+    "source_hash": "170fe1836679a66b3ef7328a51ddc9dab97fc5ae25549d24f6289858a3a2b750"
   },
   {
     "chunk": "docs/llm/chunks/portal_gate5_reliability_deployment_closure_v1.md",

--- a/docs/portal/operations/gate5-release-runbooks-and-client-validation.md
+++ b/docs/portal/operations/gate5-release-runbooks-and-client-validation.md
@@ -21,7 +21,9 @@ Run this playbook only when foundational dependencies are complete:
 1. `#44` consumer-driven mock contract checks merged.
 2. `#45` SLO and alert baseline merged.
 3. `#75` deployment profile reconciled to one active path.
-4. `#80` pre-release readiness dependency closed.
+4. `#80` pre-release readiness dependency is either:
+   - closed, or
+   - explicitly waived with rationale and approver reference recorded on `#150`.
 
 ## Release Validation Sequence
 


### PR DESCRIPTION
## Summary
- remove non-canonical `/health` entry from Gate5 traceability source map and keep `/v1/health` only
- update Gate5 release runbook entry criteria so `#80` can be satisfied by closure **or** explicit waiver with rationale + approver on `#150`
- regenerate/validate LLM package artifacts for traceability consistency

## Why
Gate5 review flagged two residual closure gaps on `#150`:
1. endpoint drift in traceability metadata
2. unconditional dependency text on `#80` despite signoff waiver path

## Validation
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`
- `npm --prefix docs/portal-site run ci`

## Links
- Refs #150
- Refs #80
- Parent status updates will be posted on #77 #78 #81 #106 after merge readiness

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only and generated-metadata updates; risk is limited to potential traceability/index inconsistencies if regeneration was incorrect.
> 
> **Overview**
> **Gate5 release validation criteria is relaxed with a controlled waiver path.** The runbook now treats `#80` as satisfied either by closure *or* by an explicitly approved waiver recorded on `#150`.
> 
> **LLM package traceability metadata is corrected and regenerated.** Removes the stray `/health` endpoint entry (keeping `/v1/health`), and updates the generated `docs/llm` artifacts (`index.json`, `source-map.json`, `traceability.json`, `manifest.json`) with refreshed hashes/source hashes to match the updated docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 628b9b9b0742a6776b34b224f74d851bfe4d2de7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrected Gate5 release validation criteria and LLM package traceability metadata to resolve two signoff blockers identified during final Gate5 review.

**Key Changes:**
- Relaxed entry criteria for `#80` to allow explicit waiver path with documented rationale and approver reference on `#150`, providing controlled flexibility for release signoff
- Removed non-canonical `/health` endpoint from traceability metadata, retaining only the versioned `/v1/health` endpoint to align with API contract standards
- Regenerated all LLM package artifacts (`index.json`, `source-map.json`, `traceability.json`, `manifest.json`) with updated hashes reflecting the corrected source documentation

**Validation:**
- Changes were validated using `generate_llm_package.py` and `check_llm_package.py` scripts
- Portal site CI validation confirms documentation build integrity

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only changes that correct traceability metadata and relax release criteria with a controlled waiver path. The changes are well-scoped, validated by the LLM package scripts, and do not affect runtime behavior. The endpoint correction aligns with existing API contract standards where `/v1/health` is the canonical versioned endpoint.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/portal/operations/gate5-release-runbooks-and-client-validation.md | Relaxed entry criteria for `#80` to allow explicit waiver path via `#150` |
| docs/llm/source-map.json | Removed non-canonical `/health` endpoint, keeping only `/v1/health` |
| docs/llm/index.json | Updated hashes and removed `/health` endpoint from traceability index |

</details>


</details>


<sub>Last reviewed commit: 628b9b9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->