### PR TITLE
fix(r1-207): forward tenant context on live-engine list adapters

### DIFF
--- a/backend/src/platform_api/services/execution_service.py
+++ b/backend/src/platform_api/services/execution_service.py
@@ -83,7 +83,11 @@ class ExecutionService:
         context: RequestContext,
     ) -> DeploymentListResponse:
         await self._run_drift_checks(context=context, scope="deployments")
-        records = await self._execution_adapter.list_deployments(status=status)
+        records = await self._execution_adapter.list_deployments(
+            status=status,
+            tenant_id=context.tenant_id,
+            user_id=context.user_id,
+        )
         return DeploymentListResponse(
             requestId=context.request_id,
             items=[Deployment(**deployment_to_dict(record)) for record in records],
@@ -276,7 +280,10 @@ class ExecutionService:
         return DeploymentResponse(requestId=context.request_id, deployment=Deployment(**deployment_to_dict(record)))
 
     async def list_portfolios(self, *, context: RequestContext) -> PortfolioListResponse:
-        records = await self._execution_adapter.list_portfolios()
+        records = await self._execution_adapter.list_portfolios(
+            tenant_id=context.tenant_id,
+            user_id=context.user_id,
+        )
         return PortfolioListResponse(
             requestId=context.request_id,
             items=[Portfolio(**portfolio_to_dict(record)) for record in records],
@@ -306,7 +313,11 @@ class ExecutionService:
         context: RequestContext,
     ) -> OrderListResponse:
         await self._run_drift_checks(context=context, scope="orders")
-        records = await self._execution_adapter.list_orders(status=status)
+        records = await self._execution_adapter.list_orders(
+            status=status,
+            tenant_id=context.tenant_id,
+            user_id=context.user_id,
+        )
         return OrderListResponse(
             requestId=context.request_id,
             items=[Order(**order_to_dict(record)) for record in records],

--- a/backend/tests/contracts/test_execution_adapter_boundary.py
+++ b/backend/tests/contracts/test_execution_adapter_boundary.py
@@ -64,7 +64,10 @@ async def _run_execution_adapter_portfolio_contracts() -> None:
     store = InMemoryStateStore()
     adapter = InMemoryExecutionAdapter(store)
 
-    portfolios = await adapter.list_portfolios()
+    portfolios = await adapter.list_portfolios(
+        tenant_id="tenant-a",
+        user_id="user-a",
+    )
     assert len(portfolios) >= 1
 
     snapshot = await adapter.get_portfolio_snapshot(

--- a/backend/tests/contracts/test_execution_command_layer.py
+++ b/backend/tests/contracts/test_execution_command_layer.py
@@ -43,12 +43,24 @@ class _NoSideEffectAdapter:
         _ = (provider_deployment_id, tenant_id, user_id)
         return {"status": "running", "latestPnl": self.latest_pnl}
 
-    async def list_deployments(self, *, status: str | None):  # type: ignore[no-untyped-def]
-        _ = status
+    async def list_deployments(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        status: str | None,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (status, tenant_id, user_id)
         return []
 
-    async def list_orders(self, *, status: str | None):  # type: ignore[no-untyped-def]
-        _ = status
+    async def list_orders(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        status: str | None,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (status, tenant_id, user_id)
         return []
 
     async def get_order(self, *, provider_order_id: str, tenant_id: str, user_id: str):  # type: ignore[no-untyped-def]
@@ -65,7 +77,8 @@ class _NoSideEffectAdapter:
         _ = (portfolio_id, tenant_id, user_id)
         return None
 
-    async def list_portfolios(self):  # type: ignore[no-untyped-def]
+    async def list_portfolios(self, *, tenant_id: str, user_id: str):  # type: ignore[no-untyped-def]
+        _ = (tenant_id, user_id)
         return []
 
 

--- a/backend/tests/contracts/test_execution_service_reconciliation_policy.py
+++ b/backend/tests/contracts/test_execution_service_reconciliation_policy.py
@@ -10,12 +10,24 @@ from src.platform_api.state_store import InMemoryStateStore
 
 
 class _StubExecutionAdapter:
-    async def list_deployments(self, *, status: str | None):  # type: ignore[no-untyped-def]
-        _ = status
+    async def list_deployments(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        status: str | None,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (status, tenant_id, user_id)
         return []
 
-    async def list_orders(self, *, status: str | None):  # type: ignore[no-untyped-def]
-        _ = status
+    async def list_orders(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        status: str | None,
+        tenant_id: str,
+        user_id: str,
+    ):
+        _ = (status, tenant_id, user_id)
         return []
 
 

--- a/docs/architecture/INTERFACES.md
+++ b/docs/architecture/INTERFACES.md
@@ -203,6 +203,22 @@ export interface ExecutionAdapter {
     latestPnl?: number;
   }>;
 
+  listDeployments(input: {
+    status?: string;
+    tenantId: string;
+    userId: string;
+  }): Promise<Array<{
+    id: string;
+    strategyId: string;
+    mode: 'paper' | 'live';
+    status: 'queued' | 'running' | 'paused' | 'stopping' | 'stopped' | 'failed';
+    capital: number;
+    providerRefId: string;
+    latestPnl?: number;
+    createdAt: string;
+    updatedAt: string;
+  }>>;
+
   placeOrder(input: {
     symbol: string;
     side: 'buy' | 'sell';
@@ -237,6 +253,41 @@ export interface ExecutionAdapter {
       unrealizedPnl: number;
     }>;
   }>;
+
+  listPortfolios(input: {
+    tenantId: string;
+    userId: string;
+  }): Promise<Array<{
+    id: string;
+    mode: 'paper' | 'live';
+    cash: number;
+    totalValue: number;
+    pnlTotal?: number;
+    positions: Array<{
+      symbol: string;
+      quantity: number;
+      avgPrice: number;
+      currentPrice: number;
+      unrealizedPnl: number;
+    }>;
+  }>>;
+
+  listOrders(input: {
+    status?: string;
+    tenantId: string;
+    userId: string;
+  }): Promise<Array<{
+    id: string;
+    symbol: string;
+    side: 'buy' | 'sell';
+    type: 'market' | 'limit';
+    quantity: number;
+    price?: number;
+    status: 'pending' | 'filled' | 'cancelled' | 'failed';
+    deploymentId?: string;
+    providerOrderId: string;
+    createdAt: string;
+  }>>;
 }
 ```
 

--- a/docs/llm/chunks/architecture_interfaces_v1.md
+++ b/docs/llm/chunks/architecture_interfaces_v1.md
@@ -209,6 +209,22 @@ export interface ExecutionAdapter {
     latestPnl?: number;
   }>;
 
+  listDeployments(input: {
+    status?: string;
+    tenantId: string;
+    userId: string;
+  }): Promise<Array<{
+    id: string;
+    strategyId: string;
+    mode: 'paper' | 'live';
+    status: 'queued' | 'running' | 'paused' | 'stopping' | 'stopped' | 'failed';
+    capital: number;
+    providerRefId: string;
+    latestPnl?: number;
+    createdAt: string;
+    updatedAt: string;
+  }>>;
+
   placeOrder(input: {
     symbol: string;
     side: 'buy' | 'sell';
@@ -243,6 +259,41 @@ export interface ExecutionAdapter {
       unrealizedPnl: number;
     }>;
   }>;
+
+  listPortfolios(input: {
+    tenantId: string;
+    userId: string;
+  }): Promise<Array<{
+    id: string;
+    mode: 'paper' | 'live';
+    cash: number;
+    totalValue: number;
+    pnlTotal?: number;
+    positions: Array<{
+      symbol: string;
+      quantity: number;
+      avgPrice: number;
+      currentPrice: number;
+      unrealizedPnl: number;
+    }>;
+  }>>;
+
+  listOrders(input: {
+    status?: string;
+    tenantId: string;
+    userId: string;
+  }): Promise<Array<{
+    id: string;
+    symbol: string;
+    side: 'buy' | 'sell';
+    type: 'market' | 'limit';
+    quantity: number;
+    price?: number;
+    status: 'pending' | 'filled' | 'cancelled' | 'failed';
+    deploymentId?: string;
+    providerOrderId: string;
+    createdAt: string;
+  }>>;
 }
 ```
 

--- a/docs/llm/chunks/portal_gate3_execution_hardening_v1.md
+++ b/docs/llm/chunks/portal_gate3_execution_hardening_v1.md
@@ -46,3 +46,8 @@ Drift event payloads include:
 - `resolution`
 
 Use these events to audit status corrections and detect recurring provider mismatches.
+
+## Post-GateX R1 Remediation
+
+- `#207`: list adapter paths (`deployments`, `orders`, `portfolios`) now forward caller `tenant_id` and `user_id`.
+- Runtime services do not inject fallback tenant/user identities for provider list requests.

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -45,7 +45,7 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "21f45858b6ca19ec7b47936f6e05b9526eb2583a52d9a1e4207a2967e3cef837",
+    "chunk_hash": "ae764d1a08b454af56d44ec98550afc6d98dc4ca4c6272306d712ef9d733f11c",
     "concepts": [
       "interfaces",
       "public_api",
@@ -65,7 +65,7 @@
       "Architecture/Contracts lead"
     ],
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "bcf8242178de7da6c8c7e42f78b37193cf6a3e13016057acf5081fba1b40053c",
+    "source_hash": "f822f28829251915007d6a14c465137b5c2da598053109191b20f64e490a9d98",
     "title": "Architecture Interfaces",
     "topic": "architecture",
     "workflows": [
@@ -96,7 +96,7 @@
   },
   {
     "chunk": "docs/llm/chunks/portal_gate3_execution_hardening_v1.md",
-    "chunk_hash": "b128a7928f63d52ee470b0e9bc1253d951685ab6a1af67e97b5a9624efc84ee4",
+    "chunk_hash": "025d9356b913f999316ccef2a00d4ef6ebe69668c7e36489c98770a716635a0f",
     "concepts": [
       "execution_adapter",
       "lifecycle_mapping",
@@ -115,7 +115,7 @@
       "Team G"
     ],
     "source": "docs/portal/operations/gate3-execution-hardening.md",
-    "source_hash": "623d90a005653c1199d26359bac5dc482cd7c58ac49a718ecaef05c357907d36",
+    "source_hash": "6b30016f1803ff7961aec0eb4486879467156164b24b384e4c01b7032386a6b1",
     "title": "Gate3 Execution Hardening",
     "topic": "operations",
     "workflows": [

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -15,10 +15,10 @@
   },
   {
     "chunk": "docs/llm/chunks/architecture_interfaces_v1.md",
-    "chunk_hash": "21f45858b6ca19ec7b47936f6e05b9526eb2583a52d9a1e4207a2967e3cef837",
+    "chunk_hash": "ae764d1a08b454af56d44ec98550afc6d98dc4ca4c6272306d712ef9d733f11c",
     "id": "architecture_interfaces_v1",
     "source": "docs/architecture/INTERFACES.md",
-    "source_hash": "bcf8242178de7da6c8c7e42f78b37193cf6a3e13016057acf5081fba1b40053c"
+    "source_hash": "f822f28829251915007d6a14c465137b5c2da598053109191b20f64e490a9d98"
   },
   {
     "chunk": "docs/llm/chunks/architecture_target_v2_v1.md",
@@ -29,10 +29,10 @@
   },
   {
     "chunk": "docs/llm/chunks/portal_gate3_execution_hardening_v1.md",
-    "chunk_hash": "b128a7928f63d52ee470b0e9bc1253d951685ab6a1af67e97b5a9624efc84ee4",
+    "chunk_hash": "025d9356b913f999316ccef2a00d4ef6ebe69668c7e36489c98770a716635a0f",
     "id": "portal_gate3_execution_hardening_v1",
     "source": "docs/portal/operations/gate3-execution-hardening.md",
-    "source_hash": "623d90a005653c1199d26359bac5dc482cd7c58ac49a718ecaef05c357907d36"
+    "source_hash": "6b30016f1803ff7961aec0eb4486879467156164b24b384e4c01b7032386a6b1"
   },
   {
     "chunk": "docs/llm/chunks/portal_gate3_kb_data_schemas_v1.md",

--- a/docs/portal/operations/gate3-execution-hardening.md
+++ b/docs/portal/operations/gate3-execution-hardening.md
@@ -48,3 +48,8 @@ Drift event payloads include:
 - `resolution`
 
 Use these events to audit status corrections and detect recurring provider mismatches.
+
+## Post-GateX R1 Remediation
+
+- `#207`: list adapter paths (`deployments`, `orders`, `portfolios`) now forward caller `tenant_id` and `user_id`.
+- Runtime services do not inject fallback tenant/user identities for provider list requests.


### PR DESCRIPTION
## Summary
- propagate caller `tenant_id`/`user_id` through execution list paths (`list_deployments`, `list_orders`, `list_portfolios`) instead of hardcoded fallback identities
- thread tenant/user context from `ExecutionService` list endpoints into `ExecutionAdapter` list calls
- add contract coverage asserting non-default tenant context is forwarded on live-engine list requests
- update architecture + operations docs and regenerate LLM traceability artifacts

## Acceptance Mapping (#207)
- list adapters now accept and forward request tenant/user context
- tests prove non-default tenant propagation in adapter list calls
- docs/traceability updated (`docs/architecture/INTERFACES.md`, `docs/portal/operations/gate3-execution-hardening.md`, regenerated `docs/llm/*`)

## Validation
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`
- `python3 -m compileall backend/src/platform_api/adapters/execution_adapter.py backend/src/platform_api/services/execution_service.py backend/tests/contracts/test_live_engine_execution_adapter.py backend/tests/contracts/test_execution_service_reconciliation_policy.py backend/tests/contracts/test_execution_adapter_boundary.py backend/tests/contracts/test_execution_command_layer.py`
- Note: `pytest` execution is blocked in this sandbox due missing offline deps/DNS restrictions; CI contract checks are required before merge.

Fixes #207
Refs #211

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-tenant identity propagation on core listing endpoints and changes adapter method signatures, which can break callers or cause cross-tenant data issues if any call sites weren’t updated.
> 
> **Overview**
> Execution list paths now propagate request identity end-to-end: `ExecutionAdapter`’s `list_deployments`, `list_orders`, and `list_portfolios` require `tenant_id`/`user_id`, and `ExecutionService` passes `RequestContext` values through instead of calling list methods without context.
> 
> `LiveEngineExecutionAdapter` removes hardcoded `tenant-local`/`service-account` headers for list requests and forwards the caller’s identity; in-memory/stub adapters and contract tests are updated accordingly, with a new test asserting list calls forward non-default tenant/user. Docs and regenerated LLM traceability artifacts are updated to reflect the interface change and remediation note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22c5288ebdff47bf57d3f46992c1fd93d07dfa07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a multi-tenant identity propagation gap: `list_deployments`, `list_orders`, and `list_portfolios` on the `ExecutionAdapter` protocol now require `tenant_id`/`user_id` parameters, and `ExecutionService` threads the caller's `RequestContext` identity through instead of relying on hardcoded `"tenant-local"`/`"service-account"` fallbacks in `LiveEngineExecutionAdapter`.

- **Adapter protocol & implementations**: `ExecutionAdapter` (Protocol), `InMemoryExecutionAdapter`, and `LiveEngineExecutionAdapter` all updated to accept and forward `tenant_id`/`user_id` on list methods. `InMemoryExecutionAdapter` accepts but ignores the context (appropriate for a test baseline).
- **Service layer**: `ExecutionService.list_deployments`, `list_orders`, and `list_portfolios` now pass `context.tenant_id`/`context.user_id` to the adapter.
- **Test coverage**: New contract test (`test_live_engine_execution_adapter_list_paths_forward_context`) verifies non-default tenant/user context is forwarded. All existing test stubs updated to match the new signatures.
- **Docs & traceability**: Architecture interface docs, gate3 hardening operations doc, and LLM traceability artifacts updated to reflect the interface change.
- All call sites verified — no missed callers. Other test stub adapters that don't implement list methods are unaffected.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a straightforward, mechanically consistent signature change with full call-site coverage and no missed callers.
- The change is a well-scoped signature update across a Protocol, two concrete adapters, the service layer, and all test stubs. Every call site has been updated consistently. The new contract test validates the key behavior (context propagation). No logic changes, no new control flow, no risk of cross-tenant data leakage. The removal of hardcoded fallback identities is strictly an improvement.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/adapters/execution_adapter.py | Protocol, InMemoryExecutionAdapter, and LiveEngineExecutionAdapter all updated to require tenant_id/user_id on list_deployments, list_orders, and list_portfolios. LiveEngine now forwards caller identity instead of hardcoded "tenant-local"/"service-account". InMemory adapter accepts but ignores context via `_ = (tenant_id, user_id)`. Changes are consistent across all three classes. |
| backend/src/platform_api/services/execution_service.py | ExecutionService now passes context.tenant_id and context.user_id through to the adapter's list_deployments, list_orders, and list_portfolios calls. All three list endpoints updated consistently. |
| backend/tests/contracts/test_live_engine_execution_adapter.py | New contract test _run_list_context_propagation_contract verifies that list_deployments, list_orders, and list_portfolios forward tenant_id/user_id to _request. Uses a mock that captures call arguments and asserts correct propagation of non-default tenant context. |
| backend/tests/contracts/test_execution_adapter_boundary.py | Updated list_portfolios call in portfolio boundary test to pass required tenant_id/user_id parameters. |
| backend/tests/contracts/test_execution_command_layer.py | _NoSideEffectAdapter stub updated to accept tenant_id/user_id on list_deployments, list_orders, and list_portfolios, matching the new Protocol signature. |
| backend/tests/contracts/test_execution_service_reconciliation_policy.py | _StubExecutionAdapter updated to accept tenant_id/user_id on list_deployments and list_orders, matching the new Protocol signature. |
| docs/architecture/INTERFACES.md | Added listDeployments, listPortfolios, and listOrders to the ExecutionAdapter TypeScript interface definition with tenantId/userId parameters. |
| docs/portal/operations/gate3-execution-hardening.md | Added Post-GateX R1 Remediation section documenting that list adapter paths now forward caller tenant/user context. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Router as Router (v1)
    participant ES as ExecutionService
    participant EA as ExecutionAdapter
    participant LE as Live Engine

    Client->>Router: GET /v1/deployments
    Note right of Router: RequestContext(tenant_id, user_id)
    Router->>ES: list_deployments(status, cursor, context)
    ES->>EA: list_deployments(status, tenant_id=context.tenant_id, user_id=context.user_id)
    Note right of EA: Previously hardcoded "tenant-local"/"service-account"
    EA->>LE: GET /api/internal/deployments<br/>X-Tenant-Id: {tenant_id}<br/>X-User-Id: {user_id}
    LE-->>EA: {items: [...]}
    EA-->>ES: list[DeploymentRecord]
    ES-->>Router: DeploymentListResponse
    Router-->>Client: 200 OK
```

<sub>Last reviewed commit: 22c5288</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->