### PR TITLE
fix(r1-209): normalize adapter JSON decode errors

### DIFF
--- a/backend/src/platform_api/adapters/data_knowledge_adapter.py
+++ b/backend/src/platform_api/adapters/data_knowledge_adapter.py
@@ -655,7 +655,14 @@ class TraderDataHTTPAdapter:
                 code="TRADER_DATA_REQUEST_FAILED",
                 status_code=response.status_code,
             )
-        payload = response.json()
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise AdapterError(
+                "Trader-data response is not valid JSON.",
+                code="TRADER_DATA_BAD_RESPONSE_JSON",
+                status_code=502,
+            ) from exc
         if not isinstance(payload, dict):
             raise AdapterError("Trader-data response must be an object.", code="TRADER_DATA_BAD_RESPONSE")
         return payload

--- a/backend/src/platform_api/adapters/execution_adapter.py
+++ b/backend/src/platform_api/adapters/execution_adapter.py
@@ -500,7 +500,14 @@ class LiveEngineExecutionAdapter:
                 code="LIVE_ENGINE_REQUEST_FAILED",
                 status_code=response.status_code,
             )
-        body = response.json()
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise AdapterError(
+                "Live-engine response is not valid JSON.",
+                code="LIVE_ENGINE_BAD_RESPONSE_JSON",
+                status_code=502,
+            ) from exc
         if not isinstance(body, dict):
             raise AdapterError("Live-engine response must be an object.", code="LIVE_ENGINE_BAD_RESPONSE")
         return body

--- a/backend/tests/contracts/test_adapter_json_decode_envelopes.py
+++ b/backend/tests/contracts/test_adapter_json_decode_envelopes.py
@@ -1,0 +1,72 @@
+"""Contract tests for adapter JSON-decode normalization into AdapterError envelopes."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import httpx
+
+from src.platform_api.adapters.data_knowledge_adapter import TraderDataHTTPAdapter
+from src.platform_api.adapters.execution_adapter import LiveEngineExecutionAdapter
+from src.platform_api.adapters.lona_adapter import AdapterError
+
+
+def test_live_engine_adapter_maps_non_json_payload_to_adapter_error() -> None:
+    async def _run() -> None:
+        adapter = LiveEngineExecutionAdapter(
+            base_url="http://live-engine.local",
+            service_api_key="svc-key",
+        )
+
+        async def _fake_request(  # type: ignore[no-untyped-def]
+            self,
+            method: str,
+            url: str,
+            headers: dict[str, str] | None = None,
+            json: dict[str, object] | None = None,
+        ):
+            _ = (self, headers, json)
+            return httpx.Response(
+                status_code=200,
+                text="<html>not-json</html>",
+                request=httpx.Request(method, url),
+            )
+
+        with patch(
+            "src.platform_api.adapters.execution_adapter.httpx.AsyncClient.request",
+            new=_fake_request,
+        ):
+            try:
+                await adapter._request(
+                    method="GET",
+                    path="/api/internal/deployments",
+                    payload=None,
+                    tenant_id="tenant-remediate",
+                    user_id="user-remediate",
+                )
+                raise AssertionError("Expected non-JSON live-engine payload to raise AdapterError.")
+            except AdapterError as exc:
+                assert exc.code == "LIVE_ENGINE_BAD_RESPONSE_JSON"
+                assert exc.status_code == 502
+
+    asyncio.run(_run())
+
+
+def test_trader_data_adapter_maps_non_json_payload_to_adapter_error() -> None:
+    adapter = TraderDataHTTPAdapter(
+        base_url="http://trader-data.local",
+        service_api_key="svc-key",
+    )
+    response = httpx.Response(
+        status_code=200,
+        text="not-json",
+        request=httpx.Request("GET", "http://trader-data.local/internal/v1/context/market"),
+    )
+
+    try:
+        adapter._parse_response(response=response, allow_not_found=False)
+        raise AssertionError("Expected non-JSON trader-data payload to raise AdapterError.")
+    except AdapterError as exc:
+        assert exc.code == "TRADER_DATA_BAD_RESPONSE_JSON"
+        assert exc.status_code == 502

--- a/docs/portal/platform/boundaries.md
+++ b/docs/portal/platform/boundaries.md
@@ -21,3 +21,7 @@ updated: 2026-02-14
 - `/docs/architecture/specs/platform-api.openapi.yaml`
 - `/docs/architecture/API_CONTRACT_GOVERNANCE.md`
 - `/docs/architecture/INTERFACES.md`
+
+## Post-GateX R1 Remediation
+
+- `#209`: adapter JSON decode failures are normalized into deterministic `AdapterError` envelopes.


### PR DESCRIPTION
## Summary
- normalize non-JSON decode failures in `LiveEngineExecutionAdapter` to deterministic `AdapterError` (`LIVE_ENGINE_BAD_RESPONSE_JSON`, `502`)
- normalize non-JSON decode failures in `TraderDataHTTPAdapter` to deterministic `AdapterError` (`TRADER_DATA_BAD_RESPONSE_JSON`, `502`)
- add contract tests for malformed upstream payload handling in both adapters
- update boundary docs with Post-GateX R1 remediation note

## Acceptance Mapping (#209)
- JSON decode failures now map to deterministic adapter error envelopes with stable code/status
- malformed/non-JSON upstream payload tests added in `backend/tests/contracts/test_adapter_json_decode_envelopes.py`
- docs/traceability update included in `docs/portal/platform/boundaries.md`

## Validation
- `python3 scripts/docs/generate_llm_package.py`
- `python3 scripts/docs/check_llm_package.py`
- `python3 -m compileall backend/src/platform_api/adapters/execution_adapter.py backend/src/platform_api/adapters/data_knowledge_adapter.py backend/tests/contracts/test_adapter_json_decode_envelopes.py`
- Note: `pytest` execution is blocked in this sandbox due missing offline deps/DNS restrictions; CI contract checks are required before merge.

Fixes #209
Refs #211

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change in adapter response parsing with explicit tests; main risk is altering surfaced error codes for malformed upstream responses.
> 
> **Overview**
> Normalizes adapter behavior when upstream services return **non-JSON payloads**: `TraderDataHTTPAdapter._parse_response` and `LiveEngineExecutionAdapter._request` now catch JSON decode failures and raise deterministic `AdapterError` envelopes (`TRADER_DATA_BAD_RESPONSE_JSON` / `LIVE_ENGINE_BAD_RESPONSE_JSON`, `502`).
> 
> Adds contract tests asserting the new error codes/status for malformed upstream responses, and updates platform boundary docs with a Post-GateX R1 remediation note referencing `#209`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 748b493f0edeb074cf73a959b83e26c451f6432a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR normalizes non-JSON decode failures in `LiveEngineExecutionAdapter` and `TraderDataHTTPAdapter` into deterministic `AdapterError` envelopes with stable error codes and 502 status. The implementation wraps `response.json()` calls in try-except blocks that catch `ValueError` exceptions and re-raise as `AdapterError` with appropriate codes (`LIVE_ENGINE_BAD_RESPONSE_JSON` and `TRADER_DATA_BAD_RESPONSE_JSON`). Contract tests verify the correct behavior for both adapters, and documentation is updated to reflect the remediation.

- Added error handling for JSON decode failures in both adapters
- Contract tests confirm malformed upstream payloads are handled correctly
- Follows existing adapter error handling patterns consistently
- Documentation updated with Post-GateX R1 remediation note

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-tested, and follow existing patterns. Error handling is correctly implemented with proper exception chaining using `from exc`, both adapters are covered symmetrically, and contract tests verify the expected behavior. The fix addresses a specific edge case (non-JSON responses) without affecting existing functionality.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/adapters/execution_adapter.py | Added try-except block to catch JSON decode failures and normalize to `AdapterError` with code `LIVE_ENGINE_BAD_RESPONSE_JSON` and status 502 |
| backend/src/platform_api/adapters/data_knowledge_adapter.py | Added try-except block to catch JSON decode failures and normalize to `AdapterError` with code `TRADER_DATA_BAD_RESPONSE_JSON` and status 502 |
| backend/tests/contracts/test_adapter_json_decode_envelopes.py | New contract tests verify both adapters correctly handle non-JSON responses by raising `AdapterError` with appropriate error codes and 502 status |
| docs/portal/platform/boundaries.md | Documentation updated with Post-GateX R1 remediation note referencing issue #209 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Adapter receives HTTP response] --> B{Status >= 400?}
    B -->|Yes| C[Raise AdapterError with REQUEST_FAILED code]
    B -->|No| D[Attempt response.json parse]
    D -->|Success| E{Is dict?}
    D -->|ValueError| F[Raise AdapterError with BAD_RESPONSE_JSON, status 502]
    E -->|Yes| G[Return parsed body]
    E -->|No| H[Raise AdapterError with BAD_RESPONSE code]
    
    style F fill:#ff9999
    style G fill:#99ff99
    style C fill:#ff9999
    style H fill:#ff9999
```

<sub>Last reviewed commit: 748b493</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->