### PR TITLE
fix(r1-210): normalize SDK BacktestDataExportResponse export field mapping

### DIFF
--- a/backend/tests/contracts/test_sdk_backtest_export_response_shape.py
+++ b/backend/tests/contracts/test_sdk_backtest_export_response_shape.py
@@ -1,0 +1,27 @@
+"""Contract checks for generated SDK response shapes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SDK_MODEL = REPO_ROOT / "sdk/typescript/src/models/BacktestDataExportResponse.ts"
+
+
+def _model_text() -> str:
+    return SDK_MODEL.read_text(encoding="utf-8")
+
+
+def test_backtest_export_response_model_exposes_export_field() -> None:
+    model = _model_text()
+    assert "export: BacktestDataExport;" in model
+    assert "_export: BacktestDataExport;" not in model
+    assert "if (!('export' in value) || value['export'] === undefined) return false;" in model
+
+
+def test_backtest_export_response_model_serialization_uses_export_field() -> None:
+    model = _model_text()
+    assert "'export': BacktestDataExportFromJSON(json['export'])" in model
+    assert "'export': BacktestDataExportToJSON(value['export'])" in model
+    assert "value['_export']" not in model

--- a/contracts/scripts/generate-sdk.sh
+++ b/contracts/scripts/generate-sdk.sh
@@ -49,6 +49,10 @@ const repoRoot = process.argv[2];
 const packageJsonPath = path.join(repoRoot, 'sdk/typescript/package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 const backtestsApiPath = path.join(repoRoot, 'sdk/typescript/src/apis/BacktestsApi.ts');
+const backtestDataExportResponsePath = path.join(
+  repoRoot,
+  'sdk/typescript/src/models/BacktestDataExportResponse.ts',
+);
 
 packageJson.description = 'Generated TypeScript SDK for the Trade Nexus Platform API';
 packageJson.license = 'MIT';
@@ -78,6 +82,40 @@ if (fs.existsSync(backtestsApiPath)) {
 
   if (normalizedBacktestsApi !== backtestsApi) {
     fs.writeFileSync(backtestsApiPath, normalizedBacktestsApi, 'utf8');
+  }
+}
+
+if (fs.existsSync(backtestDataExportResponsePath)) {
+  const backtestDataExportResponse = fs.readFileSync(backtestDataExportResponsePath, 'utf8');
+  let normalizedBacktestDataExportResponse = backtestDataExportResponse;
+
+  normalizedBacktestDataExportResponse = normalizedBacktestDataExportResponse.replace(
+    '    _export: BacktestDataExport;',
+    '    export: BacktestDataExport;',
+  );
+  normalizedBacktestDataExportResponse = normalizedBacktestDataExportResponse.replace(
+    `    if (!('_export' in value) || value['_export'] === undefined) return false;`,
+    `    if (!('export' in value) || value['export'] === undefined) return false;`,
+  );
+  normalizedBacktestDataExportResponse = normalizedBacktestDataExportResponse.replace(
+    `        '_export': BacktestDataExportFromJSON(json['export']),`,
+    `        'export': BacktestDataExportFromJSON(json['export']),`,
+  );
+  normalizedBacktestDataExportResponse = normalizedBacktestDataExportResponse.replace(
+    `        'export': BacktestDataExportToJSON(value['_export']),`,
+    `        'export': BacktestDataExportToJSON(value['export']),`,
+  );
+
+  if (!normalizedBacktestDataExportResponse.includes('    export: BacktestDataExport;')) {
+    throw new Error('Failed to normalize BacktestDataExportResponse export field.');
+  }
+
+  if (normalizedBacktestDataExportResponse.includes('_export')) {
+    throw new Error('BacktestDataExportResponse still exposes _export after normalization.');
+  }
+
+  if (normalizedBacktestDataExportResponse !== backtestDataExportResponse) {
+    fs.writeFileSync(backtestDataExportResponsePath, normalizedBacktestDataExportResponse, 'utf8');
   }
 }
 NODE

--- a/docs/architecture/specs/SDK_RELEASE.md
+++ b/docs/architecture/specs/SDK_RELEASE.md
@@ -31,6 +31,13 @@ canonical OpenAPI source.
    - enforces tag format `sdk-v<version>` on tag-triggered runs
    - runs SDK build and package dry-run
 
+## Post-generation normalizations
+
+`contracts/scripts/generate-sdk.sh` applies deterministic normalizations after OpenAPI generation so the published SDK matches the API contract and consumer expectations:
+
+- `BacktestsApi` request parameter is normalized to required `CreateBacktestRequest` (non-null).
+- `BacktestDataExportResponse` public field is normalized to `export` (not `_export`) to match the OpenAPI response shape.
+
 ## Local validation command
 
 ```bash

--- a/sdk/typescript/src/models/BacktestDataExportResponse.ts
+++ b/sdk/typescript/src/models/BacktestDataExportResponse.ts
@@ -38,7 +38,7 @@ export interface BacktestDataExportResponse {
      * @type {BacktestDataExport}
      * @memberof BacktestDataExportResponse
      */
-    _export: BacktestDataExport;
+    export: BacktestDataExport;
 }
 
 /**
@@ -46,7 +46,7 @@ export interface BacktestDataExportResponse {
  */
 export function instanceOfBacktestDataExportResponse(value: object): value is BacktestDataExportResponse {
     if (!('requestId' in value) || value['requestId'] === undefined) return false;
-    if (!('_export' in value) || value['_export'] === undefined) return false;
+    if (!('export' in value) || value['export'] === undefined) return false;
     return true;
 }
 
@@ -61,7 +61,7 @@ export function BacktestDataExportResponseFromJSONTyped(json: any, ignoreDiscrim
     return {
         
         'requestId': json['requestId'],
-        '_export': BacktestDataExportFromJSON(json['export']),
+        'export': BacktestDataExportFromJSON(json['export']),
     };
 }
 
@@ -77,7 +77,7 @@ export function BacktestDataExportResponseToJSONTyped(value?: BacktestDataExport
     return {
         
         'requestId': value['requestId'],
-        'export': BacktestDataExportToJSON(value['_export']),
+        'export': BacktestDataExportToJSON(value['export']),
     };
 }
 


### PR DESCRIPTION
## Summary
- normalize TypeScript SDK generation so BacktestDataExportResponse exposes export instead of _export
- regenerate SDK artifacts and keep drift deterministic via contracts/scripts/generate-sdk.sh
- add consumer-shape contract tests for generated SDK response mapping
- document SDK generation normalization in release workflow docs

## Issue Links
- Primary: Closes #210
- Program parent: #211

## Validation
- uv run pytest tests/contracts/test_sdk_backtest_export_response_shape.py -q
- bash contracts/scripts/verify-sdk-drift.sh
- python3 scripts/docs/generate_llm_package.py
- python3 scripts/docs/check_llm_package.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to SDK generation artifacts and deterministic normalization/tests, with no runtime backend behavior or security-sensitive logic modified.
> 
> **Overview**
> Fixes the generated TypeScript SDK model `BacktestDataExportResponse` to expose `export` instead of `_export`, updating instance checks and JSON (de)serialization to use the correct field.
> 
> Extends `contracts/scripts/generate-sdk.sh` with a deterministic post-generation normalization step (with hard failure checks) to rewrite any `_export` occurrences, adds a backend contract test to lock the expected SDK shape, and documents these post-generation normalizations in `SDK_RELEASE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c39fb50869e29c5faf420b424d6101d45b09d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes SDK generation to expose `export` field instead of `_export` in `BacktestDataExportResponse`. The OpenAPI generator was renaming the field to avoid JavaScript reserved keyword conflicts, but this created a mismatch between the API contract and SDK consumer expectations.

**Key Changes:**
- Extended `contracts/scripts/generate-sdk.sh` with post-generation normalization that rewrites `_export` to `export` in the TypeScript interface, instance checks, and JSON serialization/deserialization functions
- Added validation checks in the generation script that fail hard if normalization is incomplete or if `_export` remains after processing
- Created backend contract test `test_sdk_backtest_export_response_shape.py` to lock the expected SDK shape and prevent regression
- Updated `SDK_RELEASE.md` to document this normalization step alongside the existing `BacktestsApi` normalization

**Approach:**
The solution applies deterministic string replacements after OpenAPI generation rather than modifying the generator configuration, ensuring the SDK matches the OpenAPI spec field name while maintaining type safety.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk - changes are deterministic, well-tested, and isolated to SDK generation artifacts
- All changes are confined to SDK generation and testing infrastructure with no runtime backend logic modified. The normalization script includes hard failure checks to prevent incomplete transformations, contract tests lock the expected SDK shape, and the approach follows the existing pattern for `BacktestsApi` normalization already in production.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/tests/contracts/test_sdk_backtest_export_response_shape.py | Adds contract test to validate SDK field mapping for `export` field |
| contracts/scripts/generate-sdk.sh | Extends SDK generation with deterministic normalization and validation for `export` field |
| sdk/typescript/src/models/BacktestDataExportResponse.ts | Normalizes field from `_export` to `export` across interface, serialization, and validation |
| docs/architecture/specs/SDK_RELEASE.md | Documents post-generation normalization step for `BacktestDataExportResponse` field |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[OpenAPI Spec<br/>export field] --> B[OpenAPI Generator]
    B --> C[Generated SDK<br/>_export conflict avoidance]
    C --> D{Normalization Script}
    D --> E[Replace _export with export<br/>in interface declaration]
    D --> F[Update instanceOf check<br/>export in value]
    D --> G[Fix FromJSON mapping<br/>json export to export]
    D --> H[Fix ToJSON mapping<br/>value export to export]
    E --> I{Validation Checks}
    F --> I
    G --> I
    H --> I
    I -->|export field exists| J[Normalized SDK]
    I -->|_export still present| K[Error: Normalization failed]
    J --> L[Contract Test Validates<br/>SDK shape matches API]
```

<sub>Last reviewed commit: 68c39fb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->