### PR TITLE
fix(validation): fail closed on tool executor errors (#247)

### DIFF
--- a/backend/src/platform_api/services/validation_agent_review_service.py
+++ b/backend/src/platform_api/services/validation_agent_review_service.py
@@ -315,8 +315,18 @@ class ValidationAgentReviewService:
                     reason="tool_ref_out_of_scope",
                 )
 
-            tool_payload = self._tool_executor.run(tool_name=call.tool_name, evidence_ref=call.evidence_ref)
             tool_calls_used += 1
+            try:
+                tool_payload = self._tool_executor.run(tool_name=call.tool_name, evidence_ref=call.evidence_ref)
+            except Exception as exc:
+                return self._breach_result(
+                    parsed=parsed,
+                    budget=budget,
+                    started_at=started_at,
+                    tokens_used=tokens_used,
+                    tool_calls_used=tool_calls_used,
+                    reason=f"tool_executor_error:{type(exc).__name__}",
+                )
             tokens_used += _estimate_tokens(tool_payload)
             if tokens_used > budget.max_tokens:
                 return self._breach_result(


### PR DESCRIPTION
## Summary

Fail closed in the agent review lane when the tool executor raises runtime errors.

## Related Issue

Fixes #247
Parent #223

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Wrapped `tool_executor.run(...)` in `ValidationAgentReviewService.review(...)` with fail-closed handling.
- Convert executor exceptions into deterministic review failure output with budget breach reason: `tool_executor_error:<ExceptionType>`.
- Preserve bounded-cost accounting by tracking attempted tool calls when the executor fails.
- Added contract test to enforce fail-closed behavior and machine-readable breach output.

## Testing

- [x] Ran `uv run pytest` (backend)
- [x] Added new tests for this feature/fix

Commands:

- `uv run --extra dev ruff check src/platform_api/services/validation_agent_review_service.py tests/contracts/test_validation_agent_review_service.py`
- `uv run --extra dev pytest tests/contracts/test_validation_schema_contract.py tests/contracts/test_validation_deterministic_service.py tests/contracts/test_validation_agent_review_service.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings
- [x] I confirmed all PR review threads are resolved before requesting merge
- [ ] For Platform API/runtime contract changes, Cursor and Greptile reviews are completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change that only affects the agent review lane’s behavior when the tool executor throws; main risk is slightly different failure reporting/metrics in these rare error cases.
> 
> **Overview**
> Ensures `ValidationAgentReviewService.review()` **fails closed** if `tool_executor.run()` raises, returning a deterministic breach reason in the form `tool_executor_error:<ExceptionType>`.
> 
> Adds a contract test with a failing tool executor to verify the failure status, machine-readable breach reason, and that attempted tool calls are still counted (`tool_calls_used` increments).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e16fecbde7596575309ee2dab967c921ddf04ed3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wrapped `tool_executor.run()` in a try-except block at validation_agent_review_service.py:319-329 to handle runtime exceptions. When the tool executor throws, the service now fails closed with status `fail` and a machine-readable breach reason formatted as `tool_executor_error:<ExceptionType>`. The implementation correctly increments `tool_calls_used` before attempting execution, ensuring accurate budget accounting even when the executor fails. A comprehensive contract test verifies the fail-closed behavior, validates the breach reason format, and confirms that attempted tool calls are properly tracked.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is small, well-scoped, and properly tested. The fail-closed error handling follows the existing pattern used for other breach conditions, incrementing `tool_calls_used` before the try-except ensures accurate accounting, and the contract test validates all requirements.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/services/validation_agent_review_service.py | Added try-except block around `tool_executor.run()` to fail closed on exceptions with machine-readable breach reason format |
| backend/tests/contracts/test_validation_agent_review_service.py | Added `_FailingToolExecutor` mock and contract test verifying fail-closed behavior with correct breach reason and tool call accounting |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[review method called] --> B[Parse snapshot & get budget]
    B --> C{Validate budgets<br/>tokens/runtime/tool_calls}
    C -->|Budget exceeded| D[Return breach result]
    C -->|Within budget| E[Iterate over tool calls]
    E --> F{Check tool_name<br/>in allowed list}
    F -->|Not allowed| D
    F -->|Allowed| G{Check evidence_ref<br/>in scope}
    G -->|Out of scope| D
    G -->|In scope| H[Increment tool_calls_used]
    H --> I{Try: tool_executor.run}
    I -->|Exception thrown| J[Catch exception]
    J --> K[Return breach result with<br/>tool_executor_error:ExceptionType]
    I -->|Success| L[Process tool payload]
    L --> M{Check token budget}
    M -->|Exceeded| D
    M -->|OK| N[Add findings]
    N --> O{More tool calls?}
    O -->|Yes| E
    O -->|No| P[Return success result]
    
    style H fill:#e1f5ff
    style I fill:#fff4e1
    style J fill:#ffe1e1
    style K fill:#ffe1e1
```

<sub>Last reviewed commit: e16fecb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->