### PR TITLE
fix(validation): resolve portable-module import-cycle regression

### DIFF
--- a/backend/src/platform_api/validation/__init__.py
+++ b/backend/src/platform_api/validation/__init__.py
@@ -1,25 +1,9 @@
-"""Validation storage package."""
+"""Validation package public exports."""
 
-from src.platform_api.validation.storage import (
-    VALIDATION_STORAGE_FAIL_CLOSED_CODE,
-    InMemoryValidationMetadataStore,
-    NoopValidationVectorHook,
-    PersistedValidationRun,
-    SupabaseValidationMetadataStore,
-    ValidationBaselineMetadata,
-    ValidationBlobReferenceMetadata,
-    ValidationMetadataStore,
-    ValidationMetadataStoreError,
-    ValidationReviewStateMetadata,
-    ValidationRunMetadata,
-    ValidationStorageFailClosedError,
-    ValidationStorageService,
-    ValidationVectorHook,
-    compute_sha256_digest,
-    create_validation_metadata_store,
-    is_valid_blob_reference,
-    validate_blob_payload_integrity,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "InMemoryValidationMetadataStore",
@@ -41,3 +25,36 @@ __all__ = [
     "is_valid_blob_reference",
     "validate_blob_payload_integrity",
 ]
+
+if TYPE_CHECKING:
+    from src.platform_api.validation.storage import (
+        VALIDATION_STORAGE_FAIL_CLOSED_CODE,
+        InMemoryValidationMetadataStore,
+        NoopValidationVectorHook,
+        PersistedValidationRun,
+        SupabaseValidationMetadataStore,
+        ValidationBaselineMetadata,
+        ValidationBlobReferenceMetadata,
+        ValidationMetadataStore,
+        ValidationMetadataStoreError,
+        ValidationReviewStateMetadata,
+        ValidationRunMetadata,
+        ValidationStorageFailClosedError,
+        ValidationStorageService,
+        ValidationVectorHook,
+        compute_sha256_digest,
+        create_validation_metadata_store,
+        is_valid_blob_reference,
+        validate_blob_payload_integrity,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("src.platform_api.validation.storage")
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/backend/src/platform_api/validation/connectors/__init__.py
+++ b/backend/src/platform_api/validation/connectors/__init__.py
@@ -1,11 +1,9 @@
 """Provider connector boundaries for portable validation module."""
 
-from src.platform_api.validation.connectors.lona import LonaValidationConnector
-from src.platform_api.validation.connectors.ports import (
-    ConnectorRequestContext,
-    ValidationConnector,
-    ValidationConnectorPayload,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "ConnectorRequestContext",
@@ -13,3 +11,29 @@ __all__ = [
     "ValidationConnector",
     "ValidationConnectorPayload",
 ]
+
+if TYPE_CHECKING:
+    from src.platform_api.validation.connectors.lona import LonaValidationConnector
+    from src.platform_api.validation.connectors.ports import (
+        ConnectorRequestContext,
+        ValidationConnector,
+        ValidationConnectorPayload,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    if name == "LonaValidationConnector":
+        module = import_module("src.platform_api.validation.connectors.lona")
+        return getattr(module, name)
+    if name in {
+        "ConnectorRequestContext",
+        "ValidationConnector",
+        "ValidationConnectorPayload",
+    }:
+        module = import_module("src.platform_api.validation.connectors.ports")
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/backend/src/platform_api/validation/core/__init__.py
+++ b/backend/src/platform_api/validation/core/__init__.py
@@ -1,49 +1,44 @@
 """Validation core package for portable module boundaries."""
 
-from src.platform_api.validation.core.agent_review import (
-    AgentReviewBudget,
-    AgentReviewBudgetReport,
-    AgentReviewBudgetUsage,
-    AgentReviewFinding,
-    AgentReviewResult,
-    AgentReviewToolCall,
-    AgentReviewToolExecutor,
-    InMemoryAgentReviewToolExecutor,
-    ValidationAgentReviewService,
-)
-from src.platform_api.validation.core.agent_review import (
-    ValidationDecision as AgentReviewDecision,
-)
-from src.platform_api.validation.core.agent_review import (
-    ValidationProfile as AgentReviewProfile,
-)
-from src.platform_api.validation.core.deterministic import (
-    DeterministicValidationEngine,
-    DeterministicValidationEvidence,
-    DeterministicValidationResult,
-    IndicatorFidelityCheckResult,
-    LineageCompletenessCheckResult,
-    MetricConsistencyCheckResult,
-    TradeCoherenceCheckResult,
-    ValidationArtifactContext,
-    ValidationFinding,
-    ValidationPolicyConfig,
-)
-from src.platform_api.validation.core.deterministic import (
-    ValidationDecision as DeterministicValidationDecision,
-)
-from src.platform_api.validation.core.deterministic import (
-    ValidationProfile as DeterministicValidationProfile,
-)
-from src.platform_api.validation.core.portable import (
-    PortableValidationDecision,
-    PortableValidationModule,
-    PortableValidationResult,
-)
+from __future__ import annotations
 
-# Backward-compatible aliases at the package level.
-ValidationDecision = AgentReviewDecision
-ValidationProfile = DeterministicValidationProfile
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+_AGENT_EXPORTS: dict[str, str] = {
+    "AgentReviewBudget": "AgentReviewBudget",
+    "AgentReviewBudgetReport": "AgentReviewBudgetReport",
+    "AgentReviewBudgetUsage": "AgentReviewBudgetUsage",
+    "AgentReviewDecision": "ValidationDecision",
+    "AgentReviewFinding": "AgentReviewFinding",
+    "AgentReviewProfile": "ValidationProfile",
+    "AgentReviewResult": "AgentReviewResult",
+    "AgentReviewToolCall": "AgentReviewToolCall",
+    "AgentReviewToolExecutor": "AgentReviewToolExecutor",
+    "InMemoryAgentReviewToolExecutor": "InMemoryAgentReviewToolExecutor",
+    "ValidationAgentReviewService": "ValidationAgentReviewService",
+}
+
+_DETERMINISTIC_EXPORTS: dict[str, str] = {
+    "DeterministicValidationDecision": "ValidationDecision",
+    "DeterministicValidationEngine": "DeterministicValidationEngine",
+    "DeterministicValidationEvidence": "DeterministicValidationEvidence",
+    "DeterministicValidationProfile": "ValidationProfile",
+    "DeterministicValidationResult": "DeterministicValidationResult",
+    "IndicatorFidelityCheckResult": "IndicatorFidelityCheckResult",
+    "LineageCompletenessCheckResult": "LineageCompletenessCheckResult",
+    "MetricConsistencyCheckResult": "MetricConsistencyCheckResult",
+    "TradeCoherenceCheckResult": "TradeCoherenceCheckResult",
+    "ValidationArtifactContext": "ValidationArtifactContext",
+    "ValidationFinding": "ValidationFinding",
+    "ValidationPolicyConfig": "ValidationPolicyConfig",
+}
+
+_PORTABLE_EXPORTS: dict[str, str] = {
+    "PortableValidationDecision": "PortableValidationDecision",
+    "PortableValidationModule": "PortableValidationModule",
+    "PortableValidationResult": "PortableValidationResult",
+}
 
 __all__ = [
     "AgentReviewBudget",
@@ -75,3 +70,71 @@ __all__ = [
     "ValidationPolicyConfig",
     "ValidationProfile",
 ]
+
+if TYPE_CHECKING:
+    from src.platform_api.validation.core.agent_review import (
+        AgentReviewBudget,
+        AgentReviewBudgetReport,
+        AgentReviewBudgetUsage,
+        AgentReviewFinding,
+        AgentReviewResult,
+        AgentReviewToolCall,
+        AgentReviewToolExecutor,
+        InMemoryAgentReviewToolExecutor,
+        ValidationAgentReviewService,
+    )
+    from src.platform_api.validation.core.agent_review import (
+        ValidationDecision as AgentReviewDecision,
+    )
+    from src.platform_api.validation.core.agent_review import (
+        ValidationProfile as AgentReviewProfile,
+    )
+    from src.platform_api.validation.core.deterministic import (
+        DeterministicValidationEngine,
+        DeterministicValidationEvidence,
+        DeterministicValidationResult,
+        IndicatorFidelityCheckResult,
+        LineageCompletenessCheckResult,
+        MetricConsistencyCheckResult,
+        TradeCoherenceCheckResult,
+        ValidationArtifactContext,
+        ValidationFinding,
+        ValidationPolicyConfig,
+    )
+    from src.platform_api.validation.core.deterministic import (
+        ValidationDecision as DeterministicValidationDecision,
+    )
+    from src.platform_api.validation.core.deterministic import (
+        ValidationProfile as DeterministicValidationProfile,
+    )
+    from src.platform_api.validation.core.portable import (
+        PortableValidationDecision,
+        PortableValidationModule,
+        PortableValidationResult,
+    )
+
+    ValidationDecision = AgentReviewDecision
+    ValidationProfile = DeterministicValidationProfile
+
+
+def __getattr__(name: str) -> Any:
+    if name in _AGENT_EXPORTS:
+        module = import_module("src.platform_api.validation.core.agent_review")
+        return getattr(module, _AGENT_EXPORTS[name])
+    if name in _DETERMINISTIC_EXPORTS:
+        module = import_module("src.platform_api.validation.core.deterministic")
+        return getattr(module, _DETERMINISTIC_EXPORTS[name])
+    if name in _PORTABLE_EXPORTS:
+        module = import_module("src.platform_api.validation.core.portable")
+        return getattr(module, _PORTABLE_EXPORTS[name])
+    if name == "ValidationDecision":
+        module = import_module("src.platform_api.validation.core.agent_review")
+        return getattr(module, "ValidationDecision")
+    if name == "ValidationProfile":
+        module = import_module("src.platform_api.validation.core.deterministic")
+        return getattr(module, "ValidationProfile")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/backend/src/platform_api/validation/store/__init__.py
+++ b/backend/src/platform_api/validation/store/__init__.py
@@ -1,13 +1,9 @@
 """Validation store boundaries and adapters."""
 
-from src.platform_api.validation.store.adapters import ValidationStorageServiceAdapter
-from src.platform_api.validation.store.metadata import *  # noqa: F401,F403
-from src.platform_api.validation.store.ports import (
-    InMemoryValidationStorePort,
-    ValidationFinalDecision,
-    ValidationStorePort,
-    ValidationStoreRecord,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "InMemoryValidationStorePort",
@@ -16,3 +12,31 @@ __all__ = [
     "ValidationStorePort",
     "ValidationStoreRecord",
 ]
+
+if TYPE_CHECKING:
+    from src.platform_api.validation.store.adapters import ValidationStorageServiceAdapter
+    from src.platform_api.validation.store.ports import (
+        InMemoryValidationStorePort,
+        ValidationFinalDecision,
+        ValidationStorePort,
+        ValidationStoreRecord,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    if name == "ValidationStorageServiceAdapter":
+        module = import_module("src.platform_api.validation.store.adapters")
+        return getattr(module, name)
+    if name in {
+        "InMemoryValidationStorePort",
+        "ValidationFinalDecision",
+        "ValidationStorePort",
+        "ValidationStoreRecord",
+    }:
+        module = import_module("src.platform_api.validation.store.ports")
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))


### PR DESCRIPTION
## Summary
Fixes post-merge regression found in #232 portable validation packaging:

1. Break package import cycles by replacing eager re-exports with lazy `__getattr__` exports in:
- `backend/src/platform_api/validation/__init__.py`
- `backend/src/platform_api/validation/core/__init__.py`
- `backend/src/platform_api/validation/connectors/__init__.py`
- `backend/src/platform_api/validation/store/__init__.py`

2. Harden boundary-isolation coverage in `backend/tests/contracts/test_validation_portable_module.py`:
- Runs import-order checks in fresh subprocess interpreters.
- Removes module-load side effects from test collection.
- Verifies both import orders (`connectors -> core`, `core -> connectors`).

## Repro addressed
- `uv run python -c "import src.platform_api.validation.connectors.ports"` failed with circular import.
- Single-file portable-module test could fail when run first due order-dependent collection imports.

## Validation
- `uv run python -c "import src.platform_api.validation.connectors.ports"`
- `uv run --extra dev ruff check src/platform_api/validation/__init__.py src/platform_api/validation/core/__init__.py src/platform_api/validation/connectors/__init__.py src/platform_api/validation/store/__init__.py tests/contracts/test_validation_portable_module.py`
- `uv run --extra dev pytest tests/contracts`

Refs #232
Refs #223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily changes import/export mechanics and test coverage; main risk is subtle runtime differences in when modules are imported and attributes are resolved.
> 
> **Overview**
> Fixes an import-cycle regression in the portable validation packaging by replacing eager imports/re-exports in `validation`, `validation.core`, `validation.connectors`, and `validation.store` `__init__.py` files with lazy exports via `__getattr__`/`__dir__` (and `TYPE_CHECKING`-only imports).
> 
> Updates the portable-module contract test to avoid collection-time side effects by moving imports inside fakes, and verifies isolation in a fresh subprocess for both import orders (`connectors.ports` then `core.portable`, and vice versa), asserting that `store.metadata` and `connectors.lona` are not implicitly loaded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51f80c2247e82567ba818f97f59d543ad107b7f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes post-merge regression from #232 by replacing eager package-level re-exports with lazy `__getattr__`-based exports across four validation subpackages (`validation`, `validation.core`, `validation.connectors`, `validation.store`), breaking circular import chains that previously caused `ImportError` when importing `validation.connectors.ports` directly.

**Key Changes:**
- Converted all package `__init__.py` files from eager imports to lazy loading via `__getattr__` and `TYPE_CHECKING` blocks
- Removed wildcard import (`from .metadata import *`) in `validation.store/__init__.py` that could load unnecessary modules
- Enhanced contract tests to run isolation checks in fresh subprocess interpreters for both import orders (`connectors -> core` and `core -> connectors`)
- Refactored test fakes to defer imports until runtime (inside methods) rather than at class definition time, preventing unintended module loading during test collection

**Impact:**
The lazy loading pattern ensures that importing core validation modules like `validation.core.portable` no longer triggers eager loading of concrete implementations (`validation.store.metadata`, `validation.connectors.lona`), maintaining proper boundary isolation.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - refactors import mechanics without changing runtime behavior
- Changes are purely structural import/export refactoring with equivalent runtime semantics. The lazy loading pattern is a well-established Python technique (PEP 562), and the enhanced subprocess-based isolation tests provide strong verification that the fix resolves the import cycle while maintaining boundary isolation. All changes preserve the public API via `__all__` declarations.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/validation/__init__.py | Replaces eager imports with lazy `__getattr__` exports to break import cycles |
| backend/src/platform_api/validation/core/__init__.py | Converts to lazy exports with mapping dictionaries for agent, deterministic, and portable modules |
| backend/src/platform_api/validation/connectors/__init__.py | Implements lazy loading for connector ports and lona implementation |
| backend/src/platform_api/validation/store/__init__.py | Removes wildcard import, adds lazy exports for store ports and adapters |
| backend/tests/contracts/test_validation_portable_module.py | Hardens isolation tests with subprocess checks and moves imports inside test fakes |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validation/__init__.py] -->|lazy __getattr__| B[validation/storage]
    C[validation/core/__init__.py] -->|lazy __getattr__| D[validation/core/agent_review]
    C -->|lazy __getattr__| E[validation/core/deterministic]
    C -->|lazy __getattr__| F[validation/core/portable]
    G[validation/connectors/__init__.py] -->|lazy __getattr__| H[validation/connectors/ports]
    G -->|lazy __getattr__| I[validation/connectors/lona]
    J[validation/store/__init__.py] -->|lazy __getattr__| K[validation/store/ports]
    J -->|lazy __getattr__| L[validation/store/adapters]
    
    F -->|imports at runtime| H
    F -->|imports at runtime| E
    
    style A fill:#90EE90
    style C fill:#90EE90
    style G fill:#90EE90
    style J fill:#90EE90
    style F fill:#FFE4B5
```

<sub>Last reviewed commit: 51f80c2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->