### PR TITLE
docs(validation): publish review-web portal docs and runbooks (#282)

### DIFF
--- a/docs/portal/api/validation-review-api-semantics.md
+++ b/docs/portal/api/validation-review-api-semantics.md
@@ -1,0 +1,73 @@
+---
+title: Validation Review API Contracts And Response Semantics
+summary: Contract-first endpoint and payload semantics for validation review web/API integrations.
+owners:
+  - Validation Review Web Docs
+updated: 2026-02-20
+---
+
+# Validation Review API Contracts And Response Semantics
+
+## Canonical Contract Source
+
+Validation review APIs are defined in `/docs/architecture/specs/platform-api.openapi.yaml` under the `Validation` tag.
+
+## Endpoint Matrix
+
+| Route | OperationId | Success Code | Semantics |
+| --- | --- | --- | --- |
+| `POST /v2/validation-runs` | `createValidationRunV2` | `202` | Starts a validation run and returns queued/accepted run metadata. |
+| `GET /v2/validation-runs/{runId}` | `getValidationRunV2` | `200` | Returns run status (`queued`, `running`, `completed`, `failed`) and final decision state. |
+| `GET /v2/validation-runs/{runId}/artifact` | `getValidationRunArtifactV2` | `200` | Returns canonical artifact payload (`validation_run` or compact snapshot). |
+| `POST /v2/validation-runs/{runId}/review` | `submitValidationRunReviewV2` | `202` | Accepts trader/agent review decision for the run. |
+| `POST /v2/validation-runs/{runId}/render` | `createValidationRunRenderV2` | `202` | Queues optional HTML/PDF render generation from canonical JSON. |
+| `POST /v2/validation-baselines` | `createValidationBaselineV2` | `201` | Promotes an existing run as baseline for replay/regression checks. |
+| `POST /v2/validation-regressions/replay` | `replayValidationRegressionV2` | `202` | Compares baseline vs candidate run and returns merge/release gate decisions. |
+
+## Canonical Artifact Semantics
+
+1. `validation_run` JSON is authoritative for merge/release and audit.
+2. `validation_llm_snapshot` is a compact derivative for agent analysis.
+3. Render artifacts (`html`, `pdf`) are derived and must not replace canonical JSON records.
+4. `finalDecision` uses contract enum values: `pass`, `conditional_pass`, `fail`.
+
+## Review Decision Semantics
+
+1. `reviewerType` is constrained to `agent` or `trader`.
+2. `decision` is constrained to `pass`, `conditional_pass`, or `fail`.
+3. `findings` are structured entries with `priority`, `confidence`, `summary`, and `evidenceRefs`.
+4. Trader review is policy-controlled (`requireTraderReview`) and optional by profile.
+
+## Identity, Auth, and Request Correlation
+
+1. Clients authenticate with bearer token or API key per OpenAPI security schemes.
+2. User/tenant scope must be derived from authenticated session context, not caller-provided identity headers.
+3. `X-Request-Id` is used for trace correlation across web proxy and Platform API.
+4. `Idempotency-Key` should be supplied for write calls (`POST`) to avoid duplicate effects.
+
+## Error and Retry Semantics
+
+1. `400` indicates invalid payload or policy shape.
+2. `401` indicates missing/invalid auth context.
+3. `404` indicates unknown run/baseline resource.
+4. Retrying write calls should reuse the same `Idempotency-Key` only when payload is unchanged.
+
+## Governance Checks
+
+Run these checks for contract and docs alignment:
+
+```bash
+npx --yes --package=@redocly/cli@1.34.5 redocly lint docs/architecture/specs/platform-api.openapi.yaml
+pytest backend/tests/contracts/test_openapi_contract_v2_validation_freeze.py
+pytest backend/tests/contracts/test_platform_api_v2_handlers.py
+npm --prefix docs/portal-site run ci
+```
+
+## Traceability
+
+- Child issue: [#282](https://github.com/iamtxena/trade-nexus/issues/282)
+- Parent issue: [#288](https://github.com/iamtxena/trade-nexus/issues/288)
+- Validation web proxy auth: `/frontend/src/lib/validation/server/auth.ts`
+- Validation web proxy transport: `/frontend/src/lib/validation/server/platform-api.ts`
+- Contract governance: `/.github/workflows/contracts-governance.yml`
+- Docs governance: `/.github/workflows/docs-governance.yml`

--- a/docs/portal/operations/validation-review-incident-runbook.md
+++ b/docs/portal/operations/validation-review-incident-runbook.md
@@ -1,0 +1,121 @@
+---
+title: Validation Review Incident Runbook
+summary: Operator incident procedures for validation render failures, auth failures, and replay-regression failures.
+owners:
+  - Validation Review Web Docs
+  - Team F
+updated: 2026-02-20
+---
+
+# Validation Review Incident Runbook
+
+## Objective
+
+Provide deterministic incident handling for the validation review web program across the three blocking failure classes in scope for `#282`.
+
+## Incident Class A: Render Failures (`/render`)
+
+### Trigger
+
+`POST /v2/validation-runs/{runId}/render` returns repeated failures or render jobs remain non-completing.
+
+### Triage Commands
+
+```bash
+RUN_ID="<run-id>"
+TOKEN="<bearer-token>"
+API_BASE="https://api.trade-nexus.io"
+
+curl -sS "$API_BASE/v2/validation-runs/$RUN_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Request-Id: req-validation-render-status-001"
+
+curl -sS "$API_BASE/v2/validation-runs/$RUN_ID/artifact" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Request-Id: req-validation-render-artifact-001"
+```
+
+### Containment And Recovery
+
+1. Keep JSON artifact workflow active; do not block reviewer decision on HTML/PDF.
+2. Re-submit render request with a fresh `Idempotency-Key`.
+3. Capture request/response payloads and backend logs in the issue evidence comment.
+
+## Incident Class B: Auth Failures (`401`)
+
+### Trigger
+
+Web proxy or direct API calls return `401 Unauthorized` during run creation/review/render retrieval.
+
+### Triage Commands
+
+```bash
+TOKEN="<bearer-token>"
+API_BASE="https://api.trade-nexus.io"
+
+curl -i "$API_BASE/v2/validation-runs/nonexistent" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Request-Id: req-validation-auth-check-001"
+
+curl -i "$API_BASE/v1/health"
+```
+
+### Containment And Recovery
+
+1. Re-authenticate the reviewer session and retry via `/validation`.
+2. Verify proxy auth resolution behavior in `/frontend/src/lib/validation/server/auth.ts`.
+3. Confirm identity scope is auth-derived and no caller-supplied tenant/user override path is being used.
+
+## Incident Class C: Regression Replay Failures (`/validation-regressions/replay`)
+
+### Trigger
+
+Replay response returns gate-blocking decision (`mergeGateStatus=blocked` or `releaseGateStatus=blocked`), or policy checks fail.
+
+### Triage Commands
+
+```bash
+pytest backend/tests/contracts/test_validation_replay_policy.py
+pytest backend/tests/contracts/test_validation_release_gate_check.py
+PYTHONPATH=backend python -m src.platform_api.validation.release_gate_check
+```
+
+### Containment And Recovery
+
+1. Freeze merge/release progression for the candidate change.
+2. Compare baseline and candidate evidence references from replay payload.
+3. Patch deterministic or policy drift, rerun contract/replay tests, and re-run replay.
+
+## Governance And Review Findings Disposition
+
+1. Resolve Cursor and Greptile findings before merge when a fix is feasible in-scope.
+2. If a finding is intentionally deferred, post explicit disposition in the PR thread with rationale, owner, and follow-up issue.
+3. Keep review threads resolved before merge (`review-governance`).
+
+## Evidence Capture Template
+
+Use this template in child issue `#282` and mirror summary in parent `#288`.
+
+```md
+Validation Review incident update:
+- Parent: #288
+- Child: #282
+- Incident class: render_failure | auth_failure | regression_failure
+- Run ID / Replay ID: <id>
+- Request IDs: <list>
+- Impact: <scope + user effect>
+- Containment: <actions completed>
+- Recovery: <actions completed>
+- CI checks: contracts-governance=<status>, docs-governance=<status>, llm-package-governance=<status>
+- Cursor/Greptile findings: resolved | disposition linked
+- Evidence links: <logs, artifacts, workflow runs, PR>
+```
+
+## Traceability
+
+- Child issue: [#282](https://github.com/iamtxena/trade-nexus/issues/282)
+- Parent issue: [#288](https://github.com/iamtxena/trade-nexus/issues/288)
+- Contract source: `/docs/architecture/specs/platform-api.openapi.yaml`
+- Replay gate check: `/backend/src/platform_api/validation/release_gate_check.py`
+- Contract tests: `/backend/tests/contracts/test_validation_replay_policy.py`
+- Governance workflows: `/.github/workflows/contracts-governance.yml`, `/.github/workflows/docs-governance.yml`, `/.github/workflows/llm-package-governance.yml`

--- a/docs/portal/platform/validation-reviewer-workflow.md
+++ b/docs/portal/platform/validation-reviewer-workflow.md
@@ -1,0 +1,104 @@
+---
+title: Validation Review Web Reviewer Workflow
+summary: Web-first reviewer workflow for validation runs, canonical JSON artifacts, and trader decisions.
+owners:
+  - Validation Review Web Docs
+updated: 2026-02-20
+---
+
+# Validation Review Web Reviewer Workflow
+
+## Objective
+
+Define the production reviewer flow for validation decisions in the web lane, with optional API/CLI execution when needed.
+
+## Guardrails
+
+1. Contract-first: only use routes defined in `/docs/architecture/specs/platform-api.openapi.yaml`.
+2. Platform API is the only client entrypoint for web, SDK, and optional CLI flows.
+3. Identity is auth-derived; reviewer tooling must not treat raw tenant/user headers as trusted identity input.
+4. JSON is canonical (`validation_run` artifact). HTML/PDF are optional derived outputs.
+
+## Web Flow (`/validation`)
+
+1. Open `/validation` and authenticate through the dashboard session.
+2. Create a run in the web form.
+3. Confirm the proxy creates the run through `POST /api/validation/runs` -> `POST /v2/validation-runs`.
+4. Load run status and canonical artifact:
+   - `GET /api/validation/runs/{runId}`
+   - `GET /api/validation/runs/{runId}/artifact`
+5. Submit reviewer decision from the review form:
+   - `POST /api/validation/runs/{runId}/review`
+   - `POST /v2/validation-runs/{runId}/review`
+   - required fields: `reviewerType`, `decision`
+6. Request render output only when required for external distribution:
+   - `POST /api/validation/runs/{runId}/render`
+   - body `{"format":"html"}` or `{"format":"pdf"}`
+
+## Optional API/CLI Lane
+
+Until dedicated CLI review commands from `#279` are merged, use SDK or direct Platform API requests.
+
+```bash
+export API_BASE="https://api.trade-nexus.io"
+export TOKEN="<bearer-token>"
+export REQUEST_ID="req-validation-review-$(date +%s)"
+export IDEM_KEY="idem-validation-review-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+curl -sS "$API_BASE/v2/validation-runs" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Request-Id: $REQUEST_ID" \
+  -H "Idempotency-Key: $IDEM_KEY" \
+  -d '{
+    "strategyId":"strat-001",
+    "requestedIndicators":["zigzag","ema"],
+    "datasetIds":["dataset-btc-1h-2025"],
+    "backtestReportRef":"blob://validation/candidate/backtest-report.json",
+    "policy":{
+      "profile":"STANDARD",
+      "blockMergeOnFail":true,
+      "blockReleaseOnFail":true,
+      "blockMergeOnAgentFail":true,
+      "blockReleaseOnAgentFail":false,
+      "requireTraderReview":true,
+      "hardFailOnMissingIndicators":true,
+      "failClosedOnEvidenceUnavailable":true
+    }
+  }'
+```
+
+## Reviewer Evidence Checklist
+
+1. Record `runId`, `requestId`, and decision timestamp.
+2. Save canonical artifact output from `GET /v2/validation-runs/{runId}/artifact`.
+3. Save review submission request/response payloads.
+4. Save render request/response payloads when HTML/PDF is requested.
+5. Link governance checks from the PR:
+   - `contracts-governance`
+   - `docs-governance`
+   - `llm-package-governance`
+
+## PR and Program Status Updates
+
+When opening and merging the PR for `#282`, post status updates in both the child issue and `#288`.
+
+```md
+Validation Review Web status:
+- Parent: #288
+- Child: #282
+- PR: <url>
+- Status: OPEN | IN_REVIEW | MERGED
+- Checks: contracts-governance=<status>, docs-governance=<status>, llm-package-governance=<status>
+- Cursor/Greptile findings: resolved | disposition linked
+- Evidence: <CI run links + artifact refs>
+```
+
+## Traceability
+
+- Child issue: [#282](https://github.com/iamtxena/trade-nexus/issues/282)
+- Parent issue: [#288](https://github.com/iamtxena/trade-nexus/issues/288)
+- Web lane page: `/frontend/src/app/(dashboard)/validation/page.tsx`
+- Web API proxy: `/frontend/src/app/api/validation/runs/route.ts`
+- Contract source: `/docs/architecture/specs/platform-api.openapi.yaml`
+- Governance: `/.github/workflows/contracts-governance.yml`, `/.github/workflows/docs-governance.yml`, `/.github/workflows/llm-package-governance.yml`

--- a/scripts/docs/check_stale_references.py
+++ b/scripts/docs/check_stale_references.py
@@ -103,6 +103,35 @@ def main() -> int:
     require_contains(portal_package, "\"check:stale\"", errors)
     require_contains(portal_package, "npm run check:stale", errors)
 
+    reviewer_doc = ROOT / "docs" / "portal" / "platform" / "validation-reviewer-workflow.md"
+    for token in [
+        "/validation",
+        "POST /v2/validation-runs",
+        "POST /v2/validation-runs/{runId}/review",
+        "#288",
+    ]:
+        require_contains(reviewer_doc, token, errors)
+
+    validation_api_doc = ROOT / "docs" / "portal" / "api" / "validation-review-api-semantics.md"
+    for token in [
+        "docs/architecture/specs/platform-api.openapi.yaml",
+        "createValidationRunV2",
+        "submitValidationRunReviewV2",
+        "Idempotency-Key",
+    ]:
+        require_contains(validation_api_doc, token, errors)
+
+    incident_doc = (
+        ROOT / "docs" / "portal" / "operations" / "validation-review-incident-runbook.md"
+    )
+    for token in [
+        "render_failure | auth_failure | regression_failure",
+        "Cursor and Greptile findings",
+        "contracts-governance=<status>",
+        "#288",
+    ]:
+        require_contains(incident_doc, token, errors)
+
     generated_ref = ROOT / "docs" / "portal-site" / "static" / "api" / "platform-api.html"
     if not generated_ref.exists():
         errors.append(f"Missing generated API reference: {generated_ref}")


### PR DESCRIPTION
## Summary\n- add portal-delivered docs for validation review web reviewer flow, API contract semantics, and incident runbook\n- encode contract-first/platform-entrypoint/auth-derived-identity/JSON-canonical guardrails in docs\n- add stale-reference CI checks so these docs are governance-enforced\n\n## Related Issues\n- Closes #282\n- Parent: #288\n\n## Validation\n- python3 scripts/docs/check_frontmatter.py\n- python3 scripts/docs/check_links.py\n- python3 scripts/docs/check_stale_references.py\n- npm --prefix docs/portal-site run ci\n- python3 scripts/docs/generate_llm_package.py\n- python3 scripts/docs/check_llm_package.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes plus additional CI assertions in `check_stale_references.py`; low risk beyond potentially introducing false CI failures if the required tokens change.
> 
> **Overview**
> Publishes new portal docs for the validation review program: a contract/response semantics page for `v2` validation endpoints, a reviewer workflow for the `/validation` web lane (including optional API/CLI usage), and an incident runbook covering render, auth, and regression replay failures.
> 
> Extends `scripts/docs/check_stale_references.py` to *govern* these new docs by asserting the presence of critical routes/operationIds, correlation/idempotency headers, and traceability tokens so CI fails on documentation drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d00087f43887044bf5e584d644d9575842feafd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive validation review documentation covering API semantics, incident runbooks, and reviewer workflows. The documentation establishes contract-first guardrails for the validation review web portal, specifying that the Platform API is the sole entrypoint, identity must be auth-derived (not from caller headers), and JSON artifacts are canonical (HTML/PDF are optional derivatives). All referenced API endpoints (`createValidationRunV2`, `submitValidationRunReviewV2`, etc.) exist in the OpenAPI spec at `docs/architecture/specs/platform-api.openapi.yaml`. The new CI script `check_stale_references.py` enforces that critical tokens and references remain present in these docs, preventing documentation drift.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues
- Documentation-only PR with accurate references to existing code and API contracts, governance-enforced via new stale reference checks
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/portal/api/validation-review-api-semantics.md | Comprehensive API contract documentation with accurate OpenAPI references and semantic guardrails |
| docs/portal/operations/validation-review-incident-runbook.md | Well-structured incident response procedures with clear triage commands and recovery steps |
| docs/portal/platform/validation-reviewer-workflow.md | Clear reviewer workflow documentation with web and CLI paths, accurate API endpoints |
| scripts/docs/check_stale_references.py | Governance script validates critical references in validation review documentation |

</details>


</details>


<sub>Last reviewed commit: 4461a40</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->