### PR TITLE
docs(llm): regenerate review-web LLM package and traceability (#283)

### DIFF
--- a/docs/llm/chunks/portal_validation_review_api_semantics_v1.md
+++ b/docs/llm/chunks/portal_validation_review_api_semantics_v1.md
@@ -1,0 +1,71 @@
+# Validation Review API Contracts And Response Semantics
+
+Source: `docs/portal/api/validation-review-api-semantics.md`
+Topic: `api`
+Stable ID: `portal_validation_review_api_semantics_v1`
+
+# Validation Review API Contracts And Response Semantics
+
+## Canonical Contract Source
+
+Validation review APIs are defined in `/docs/architecture/specs/platform-api.openapi.yaml` under the `Validation` tag.
+
+## Endpoint Matrix
+
+| Route | OperationId | Success Code | Semantics |
+| --- | --- | --- | --- |
+| `POST /v2/validation-runs` | `createValidationRunV2` | `202` | Starts a validation run and returns queued/accepted run metadata. |
+| `GET /v2/validation-runs/{runId}` | `getValidationRunV2` | `200` | Returns run status (`queued`, `running`, `completed`, `failed`) and final decision state. |
+| `GET /v2/validation-runs/{runId}/artifact` | `getValidationRunArtifactV2` | `200` | Returns canonical artifact payload (`validation_run` or compact snapshot). |
+| `POST /v2/validation-runs/{runId}/review` | `submitValidationRunReviewV2` | `202` | Accepts trader/agent review decision for the run. |
+| `POST /v2/validation-runs/{runId}/render` | `createValidationRunRenderV2` | `202` | Queues optional HTML/PDF render generation from canonical JSON. |
+| `POST /v2/validation-baselines` | `createValidationBaselineV2` | `201` | Promotes an existing run as baseline for replay/regression checks. |
+| `POST /v2/validation-regressions/replay` | `replayValidationRegressionV2` | `202` | Compares baseline vs candidate run and returns merge/release gate decisions. |
+
+## Canonical Artifact Semantics
+
+1. `validation_run` JSON is authoritative for merge/release and audit.
+2. `validation_llm_snapshot` is a compact derivative for agent analysis.
+3. Render artifacts (`html`, `pdf`) are derived and must not replace canonical JSON records.
+4. `finalDecision` uses contract enum values: `pass`, `conditional_pass`, `fail`.
+
+## Review Decision Semantics
+
+1. `reviewerType` is constrained to `agent` or `trader`.
+2. `decision` is constrained to `pass`, `conditional_pass`, or `fail`.
+3. `findings` are structured entries with `priority`, `confidence`, `summary`, and `evidenceRefs`.
+4. Trader review is policy-controlled (`requireTraderReview`) and optional by profile.
+
+## Identity, Auth, and Request Correlation
+
+1. Clients authenticate with bearer token or API key per OpenAPI security schemes.
+2. User/tenant scope must be derived from authenticated session context, not caller-provided identity headers.
+3. `X-Request-Id` is used for trace correlation across web proxy and Platform API.
+4. `Idempotency-Key` should be supplied for write calls (`POST`) to avoid duplicate effects.
+
+## Error and Retry Semantics
+
+1. `400` indicates invalid payload or policy shape.
+2. `401` indicates missing/invalid auth context.
+3. `404` indicates unknown run/baseline resource.
+4. Retrying write calls should reuse the same `Idempotency-Key` only when payload is unchanged.
+
+## Governance Checks
+
+Run these checks for contract and docs alignment:
+
+```bash
+npx --yes --package=@redocly/cli@1.34.5 redocly lint docs/architecture/specs/platform-api.openapi.yaml
+pytest backend/tests/contracts/test_openapi_contract_v2_validation_freeze.py
+pytest backend/tests/contracts/test_platform_api_v2_handlers.py
+npm --prefix docs/portal-site run ci
+```
+
+## Traceability
+
+- Child issue: [#282](https://github.com/iamtxena/trade-nexus/issues/282)
+- Parent issue: [#288](https://github.com/iamtxena/trade-nexus/issues/288)
+- Validation web proxy auth: `/frontend/src/lib/validation/server/auth.ts`
+- Validation web proxy transport: `/frontend/src/lib/validation/server/platform-api.ts`
+- Contract governance: `/.github/workflows/contracts-governance.yml`
+- Docs governance: `/.github/workflows/docs-governance.yml`

--- a/docs/llm/chunks/portal_validation_review_incident_runbook_v1.md
+++ b/docs/llm/chunks/portal_validation_review_incident_runbook_v1.md
@@ -1,0 +1,118 @@
+# Validation Review Incident Runbook
+
+Source: `docs/portal/operations/validation-review-incident-runbook.md`
+Topic: `operations`
+Stable ID: `portal_validation_review_incident_runbook_v1`
+
+# Validation Review Incident Runbook
+
+## Objective
+
+Provide deterministic incident handling for the validation review web program across the three blocking failure classes in scope for `#282`.
+
+## Incident Class A: Render Failures (`/render`)
+
+### Trigger
+
+`POST /v2/validation-runs/{runId}/render` returns repeated failures or render jobs remain non-completing.
+
+### Triage Commands
+
+```bash
+RUN_ID="<run-id>"
+TOKEN="<bearer-token>"
+API_BASE="https://api.trade-nexus.io"
+
+curl -sS "$API_BASE/v2/validation-runs/$RUN_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Request-Id: req-validation-render-status-001"
+
+curl -sS "$API_BASE/v2/validation-runs/$RUN_ID/artifact" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Request-Id: req-validation-render-artifact-001"
+```
+
+### Containment And Recovery
+
+1. Keep JSON artifact workflow active; do not block reviewer decision on HTML/PDF.
+2. Re-submit render request with a fresh `Idempotency-Key`.
+3. Capture request/response payloads and backend logs in the issue evidence comment.
+
+## Incident Class B: Auth Failures (`401`)
+
+### Trigger
+
+Web proxy or direct API calls return `401 Unauthorized` during run creation/review/render retrieval.
+
+### Triage Commands
+
+```bash
+TOKEN="<bearer-token>"
+API_BASE="https://api.trade-nexus.io"
+
+curl -i "$API_BASE/v2/validation-runs/nonexistent" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Request-Id: req-validation-auth-check-001"
+
+curl -i "$API_BASE/v1/health"
+```
+
+### Containment And Recovery
+
+1. Re-authenticate the reviewer session and retry via `/validation`.
+2. Verify proxy auth resolution behavior in `/frontend/src/lib/validation/server/auth.ts`.
+3. Confirm identity scope is auth-derived and no caller-supplied tenant/user override path is being used.
+
+## Incident Class C: Regression Replay Failures (`/validation-regressions/replay`)
+
+### Trigger
+
+Replay response returns gate-blocking decision (`mergeGateStatus=blocked` or `releaseGateStatus=blocked`), or policy checks fail.
+
+### Triage Commands
+
+```bash
+pytest backend/tests/contracts/test_validation_replay_policy.py
+pytest backend/tests/contracts/test_validation_release_gate_check.py
+PYTHONPATH=backend python -m src.platform_api.validation.release_gate_check
+```
+
+### Containment And Recovery
+
+1. Freeze merge/release progression for the candidate change.
+2. Compare baseline and candidate evidence references from replay payload.
+3. Patch deterministic or policy drift, rerun contract/replay tests, and re-run replay.
+
+## Governance And Review Findings Disposition
+
+1. Resolve Cursor and Greptile findings before merge when a fix is feasible in-scope.
+2. If a finding is intentionally deferred, post explicit disposition in the PR thread with rationale, owner, and follow-up issue.
+3. Keep review threads resolved before merge (`review-governance`).
+
+## Evidence Capture Template
+
+Use this template in child issue `#282` and mirror summary in parent `#288`.
+
+```md
+Validation Review incident update:
+- Parent: #288
+- Child: #282
+- Incident class: render_failure | auth_failure | regression_failure
+- Run ID / Replay ID: <id>
+- Request IDs: <list>
+- Impact: <scope + user effect>
+- Containment: <actions completed>
+- Recovery: <actions completed>
+- CI checks: contracts-governance=<status>, docs-governance=<status>, llm-package-governance=<status>
+- Cursor/Greptile findings: resolved | disposition linked
+- Evidence links: <logs, artifacts, workflow runs, PR>
+```
+
+## Traceability
+
+- Child issue: [#282](https://github.com/iamtxena/trade-nexus/issues/282)
+- Parent issue: [#288](https://github.com/iamtxena/trade-nexus/issues/288)
+- Contract source: `/docs/architecture/specs/platform-api.openapi.yaml`
+- Replay gate check: `/backend/src/platform_api/validation/release_gate_check.py`
+- Contract tests: `/backend/tests/contracts/test_validation_replay_policy.py`
+- Governance workflows: `/.github/workflows/contracts-governance.yml`, `/.github/workflows/docs-governance.yml`, `/.github/workflows/llm-package-governance.yml`

--- a/docs/llm/chunks/portal_validation_reviewer_workflow_v1.md
+++ b/docs/llm/chunks/portal_validation_reviewer_workflow_v1.md
@@ -1,0 +1,102 @@
+# Validation Review Web Reviewer Workflow
+
+Source: `docs/portal/platform/validation-reviewer-workflow.md`
+Topic: `platform`
+Stable ID: `portal_validation_reviewer_workflow_v1`
+
+# Validation Review Web Reviewer Workflow
+
+## Objective
+
+Define the production reviewer flow for validation decisions in the web lane, with optional API/CLI execution when needed.
+
+## Guardrails
+
+1. Contract-first: only use routes defined in `/docs/architecture/specs/platform-api.openapi.yaml`.
+2. Platform API is the only client entrypoint for web, SDK, and optional CLI flows.
+3. Identity is auth-derived; reviewer tooling must not treat raw tenant/user headers as trusted identity input.
+4. JSON is canonical (`validation_run` artifact). HTML/PDF are optional derived outputs.
+
+## Web Flow (`/validation`)
+
+1. Open `/validation` and authenticate through the dashboard session.
+2. Create a run in the web form.
+3. Confirm the proxy creates the run through `POST /api/validation/runs` -> `POST /v2/validation-runs`.
+4. Load run status and canonical artifact:
+   - `GET /api/validation/runs/{runId}`
+   - `GET /api/validation/runs/{runId}/artifact`
+5. Submit reviewer decision from the review form:
+   - `POST /api/validation/runs/{runId}/review`
+   - `POST /v2/validation-runs/{runId}/review`
+   - required fields: `reviewerType`, `decision`
+6. Request render output only when required for external distribution:
+   - `POST /api/validation/runs/{runId}/render`
+   - body `{"format":"html"}` or `{"format":"pdf"}`
+
+## Optional API/CLI Lane
+
+Until dedicated CLI review commands from `#279` are merged, use SDK or direct Platform API requests.
+
+```bash
+export API_BASE="https://api.trade-nexus.io"
+export TOKEN="<bearer-token>"
+export REQUEST_ID="req-validation-review-$(date +%s)"
+export IDEM_KEY="idem-validation-review-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+curl -sS "$API_BASE/v2/validation-runs" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Request-Id: $REQUEST_ID" \
+  -H "Idempotency-Key: $IDEM_KEY" \
+  -d '{
+    "strategyId":"strat-001",
+    "requestedIndicators":["zigzag","ema"],
+    "datasetIds":["dataset-btc-1h-2025"],
+    "backtestReportRef":"blob://validation/candidate/backtest-report.json",
+    "policy":{
+      "profile":"STANDARD",
+      "blockMergeOnFail":true,
+      "blockReleaseOnFail":true,
+      "blockMergeOnAgentFail":true,
+      "blockReleaseOnAgentFail":false,
+      "requireTraderReview":true,
+      "hardFailOnMissingIndicators":true,
+      "failClosedOnEvidenceUnavailable":true
+    }
+  }'
+```
+
+## Reviewer Evidence Checklist
+
+1. Record `runId`, `requestId`, and decision timestamp.
+2. Save canonical artifact output from `GET /v2/validation-runs/{runId}/artifact`.
+3. Save review submission request/response payloads.
+4. Save render request/response payloads when HTML/PDF is requested.
+5. Link governance checks from the PR:
+   - `contracts-governance`
+   - `docs-governance`
+   - `llm-package-governance`
+
+## PR and Program Status Updates
+
+When opening and merging the PR for `#282`, post status updates in both the child issue and `#288`.
+
+```md
+Validation Review Web status:
+- Parent: #288
+- Child: #282
+- PR: <url>
+- Status: OPEN | IN_REVIEW | MERGED
+- Checks: contracts-governance=<status>, docs-governance=<status>, llm-package-governance=<status>
+- Cursor/Greptile findings: resolved | disposition linked
+- Evidence: <CI run links + artifact refs>
+```
+
+## Traceability
+
+- Child issue: [#282](https://github.com/iamtxena/trade-nexus/issues/282)
+- Parent issue: [#288](https://github.com/iamtxena/trade-nexus/issues/288)
+- Web lane page: `/frontend/src/app/(dashboard)/validation/page.tsx`
+- Web API proxy: `/frontend/src/app/api/validation/runs/route.ts`
+- Contract source: `/docs/architecture/specs/platform-api.openapi.yaml`
+- Governance: `/.github/workflows/contracts-governance.yml`, `/.github/workflows/docs-governance.yml`, `/.github/workflows/llm-package-governance.yml`

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -541,5 +541,97 @@
       "runtime_observability",
       "incident_traceability"
     ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_validation_review_api_semantics_v1.md",
+    "chunk_hash": "90b085e9d845625dfdd92f5377ad5cd80f7b0573902f1c1383e177527a560383",
+    "concepts": [
+      "validation_api",
+      "response_semantics",
+      "auth_derived_identity",
+      "idempotency"
+    ],
+    "endpoints": [
+      "/v2/validation-runs",
+      "/v2/validation-runs/{runId}",
+      "/v2/validation-runs/{runId}/artifact",
+      "/v2/validation-runs/{runId}/review",
+      "/v2/validation-runs/{runId}/render",
+      "/v2/validation-baselines",
+      "/v2/validation-regressions/replay"
+    ],
+    "id": "portal_validation_review_api_semantics_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/282",
+    "owners": [
+      "Validation Review Web Docs"
+    ],
+    "source": "docs/portal/api/validation-review-api-semantics.md",
+    "source_hash": "2d22f0cbc5370eb6c4bb26937d7d08a2ec995b00451bc4112766c2c8e6e97300",
+    "title": "Validation Review API Contracts And Response Semantics",
+    "topic": "api",
+    "workflows": [
+      "validation_review_web",
+      "contract_first_review"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_validation_review_incident_runbook_v1.md",
+    "chunk_hash": "169704803ed1c8a549339466bfacccc75a36fdeed422dbcba51ee35930317b74",
+    "concepts": [
+      "incident_runbook",
+      "render_failure",
+      "auth_failure",
+      "regression_failure"
+    ],
+    "endpoints": [
+      "/v1/health",
+      "/v2/validation-runs/{runId}/artifact",
+      "/v2/validation-runs/{runId}/render",
+      "/v2/validation-regressions/replay"
+    ],
+    "id": "portal_validation_review_incident_runbook_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/282",
+    "owners": [
+      "Validation Review Web Docs",
+      "Team F"
+    ],
+    "source": "docs/portal/operations/validation-review-incident-runbook.md",
+    "source_hash": "aad96e458a28f2d237ca5362df37a42ebb199e42cc03c2b91cfc0b8f6d461987",
+    "title": "Validation Review Incident Runbook",
+    "topic": "operations",
+    "workflows": [
+      "incident_response",
+      "findings_disposition"
+    ]
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_validation_reviewer_workflow_v1.md",
+    "chunk_hash": "dbb5107241f8ecee33ae803a34b842db8101a30add91b86abc0691796b17c05d",
+    "concepts": [
+      "reviewer_workflow",
+      "web_lane",
+      "json_canonical",
+      "status_reporting"
+    ],
+    "endpoints": [
+      "/v2/validation-runs",
+      "/v2/validation-runs/{runId}",
+      "/v2/validation-runs/{runId}/artifact",
+      "/v2/validation-runs/{runId}/review",
+      "/v2/validation-runs/{runId}/render"
+    ],
+    "id": "portal_validation_reviewer_workflow_v1",
+    "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/282",
+    "owners": [
+      "Validation Review Web Docs"
+    ],
+    "source": "docs/portal/platform/validation-reviewer-workflow.md",
+    "source_hash": "76621ea3538b3bc3cf93280874449de29d830df35ce4d6e6dbc7012d620bfb80",
+    "title": "Validation Review Web Reviewer Workflow",
+    "topic": "platform",
+    "workflows": [
+      "reviewer_decision_flow",
+      "issue_status_reporting"
+    ]
   }
 ]

--- a/docs/llm/manifest.json
+++ b/docs/llm/manifest.json
@@ -1,6 +1,6 @@
 {
-  "entry_count": 20,
+  "entry_count": 23,
   "schema_version": "1.0",
   "source_map": "docs/llm/source-map.json",
-  "source_map_hash": "3d00e8a00fbfe515671ffd4c4f7d574d8bb57b3a551c437dce2e07d0320f0df2"
+  "source_map_hash": "400e070c45ee5889cc33c325e14969cac3d7a618287b1fdc033cb16da073637c"
 }

--- a/docs/llm/source-map.json
+++ b/docs/llm/source-map.json
@@ -220,6 +220,39 @@
       "workflows": ["release_validation_sequence", "client_lane_compatibility"],
       "owners": ["Team E", "Team F", "Team G"],
       "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/106"
+    },
+    {
+      "id": "portal_validation_review_api_semantics_v1",
+      "title": "Validation Review API Contracts And Response Semantics",
+      "source": "docs/portal/api/validation-review-api-semantics.md",
+      "topic": "api",
+      "concepts": ["validation_api", "response_semantics", "auth_derived_identity", "idempotency"],
+      "endpoints": ["/v2/validation-runs", "/v2/validation-runs/{runId}", "/v2/validation-runs/{runId}/artifact", "/v2/validation-runs/{runId}/review", "/v2/validation-runs/{runId}/render", "/v2/validation-baselines", "/v2/validation-regressions/replay"],
+      "workflows": ["validation_review_web", "contract_first_review"],
+      "owners": ["Validation Review Web Docs"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/282"
+    },
+    {
+      "id": "portal_validation_review_incident_runbook_v1",
+      "title": "Validation Review Incident Runbook",
+      "source": "docs/portal/operations/validation-review-incident-runbook.md",
+      "topic": "operations",
+      "concepts": ["incident_runbook", "render_failure", "auth_failure", "regression_failure"],
+      "endpoints": ["/v1/health", "/v2/validation-runs/{runId}/artifact", "/v2/validation-runs/{runId}/render", "/v2/validation-regressions/replay"],
+      "workflows": ["incident_response", "findings_disposition"],
+      "owners": ["Validation Review Web Docs", "Team F"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/282"
+    },
+    {
+      "id": "portal_validation_reviewer_workflow_v1",
+      "title": "Validation Review Web Reviewer Workflow",
+      "source": "docs/portal/platform/validation-reviewer-workflow.md",
+      "topic": "platform",
+      "concepts": ["reviewer_workflow", "web_lane", "json_canonical", "status_reporting"],
+      "endpoints": ["/v2/validation-runs", "/v2/validation-runs/{runId}", "/v2/validation-runs/{runId}/artifact", "/v2/validation-runs/{runId}/review", "/v2/validation-runs/{runId}/render"],
+      "workflows": ["reviewer_decision_flow", "issue_status_reporting"],
+      "owners": ["Validation Review Web Docs"],
+      "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/282"
     }
   ]
 }

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -138,5 +138,26 @@
     "id": "portal_gate5_structured_observability_v1",
     "source": "docs/portal/operations/gate5-structured-observability.md",
     "source_hash": "8ddfab927bcb3e472c645da2d7aff342e40e003ba0a3d56a034df21fb4a37369"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_validation_review_api_semantics_v1.md",
+    "chunk_hash": "90b085e9d845625dfdd92f5377ad5cd80f7b0573902f1c1383e177527a560383",
+    "id": "portal_validation_review_api_semantics_v1",
+    "source": "docs/portal/api/validation-review-api-semantics.md",
+    "source_hash": "2d22f0cbc5370eb6c4bb26937d7d08a2ec995b00451bc4112766c2c8e6e97300"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_validation_review_incident_runbook_v1.md",
+    "chunk_hash": "169704803ed1c8a549339466bfacccc75a36fdeed422dbcba51ee35930317b74",
+    "id": "portal_validation_review_incident_runbook_v1",
+    "source": "docs/portal/operations/validation-review-incident-runbook.md",
+    "source_hash": "aad96e458a28f2d237ca5362df37a42ebb199e42cc03c2b91cfc0b8f6d461987"
+  },
+  {
+    "chunk": "docs/llm/chunks/portal_validation_reviewer_workflow_v1.md",
+    "chunk_hash": "dbb5107241f8ecee33ae803a34b842db8101a30add91b86abc0691796b17c05d",
+    "id": "portal_validation_reviewer_workflow_v1",
+    "source": "docs/portal/platform/validation-reviewer-workflow.md",
+    "source_hash": "76621ea3538b3bc3cf93280874449de29d830df35ce4d6e6dbc7012d620bfb80"
   }
 ]

--- a/scripts/docs/check_llm_package.py
+++ b/scripts/docs/check_llm_package.py
@@ -11,7 +11,7 @@ LLM_DIR = ROOT / "docs" / "llm"
 CHUNKS_DIR = LLM_DIR / "chunks"
 
 OWNER_URL_PATTERN = re.compile(r"^https://github\.com/iamtxena/trade-nexus/issues/\d+$")
-ALLOWED_OWNER_ISSUES = {"76", "77", "78", "79", "80", "81", "106"}
+ALLOWED_OWNER_ISSUES = {"76", "77", "78", "79", "80", "81", "106", "282", "283", "288"}
 
 
 def load_json(path: Path):


### PR DESCRIPTION
## Summary\n- extend docs/llm source-map with the new validation review web portal pages from #282\n- regenerate chunks/index/traceability/manifest for deterministic LLM package outputs\n- update LLM package validation ownership allowlist for #282/#283/#288\n\n## Related Issues\n- Closes #283\n- Parent: #288\n- Depends on: #282\n\n## Validation\n- python3 scripts/docs/generate_llm_package.py\n- python3 scripts/docs/check_llm_package.py\n- python3 scripts/docs/check_frontmatter.py\n- python3 scripts/docs/check_links.py\n- python3 scripts/docs/check_stale_references.py\n- npm --prefix docs/portal-site run ci

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docs-governance script updates only; main risk is CI failures due to regenerated hashes/manifest counts or new stale-reference assertions.
> 
> **Overview**
> Adds three new portal docs for the validation review web program: **API contract/response semantics**, a **reviewer workflow** for `/validation` (including proxy + Platform API calls), and an **incident runbook** covering render/auth/replay failure triage.
> 
> Regenerates the `docs/llm` package outputs to include these pages (new chunks plus updated `source-map.json`, `index.json`, `traceability.json`, and `manifest.json` entry counts/hashes), and updates docs governance scripts (`check_llm_package.py` allowlist for issues `#282/#283/#288` and `check_stale_references.py` token assertions for the new docs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0e22e8c436da14d50da308d277ff8f2ff991585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended the LLM documentation package with three new validation review web portal documentation pages and regenerated all deterministic LLM package outputs (chunks, index, traceability, manifest). Updated validation ownership allowlists to include issues `#282`, `#283`, and `#288`.

- Added comprehensive validation review API semantics documentation covering endpoint contracts, response semantics, auth-derived identity, and idempotency patterns
- Added incident runbook for render failures, auth failures, and regression replay failures with triage and recovery procedures  
- Added reviewer workflow documentation for web-first validation decisions with API/CLI lane support
- Regenerated LLM chunks with stable IDs and proper metadata headers from source documentation
- Updated `source-map.json` with three new entries containing correct concepts, endpoints, workflows, and ownership metadata
- Updated `index.json` and `traceability.json` with corresponding entries and content hashes
- Updated `manifest.json` entry count from 20 to 23 and refreshed source map hash
- Extended `check_llm_package.py` ALLOWED_OWNER_ISSUES to include `#282`, `#283`, `#288`
- Added validation checks in `check_stale_references.py` for the three new documentation files
- Fixed README.md workflow reference from `docs-governance` to `llm-package-governance`

All changes are documentation-only, with proper traceability links to parent issue `#288` and child issue `#282`. The generated LLM chunks correctly mirror their source documents with appropriate stable ID markers.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only changes with correctly generated LLM package outputs, proper metadata structure, accurate hashes, and complete traceability. All validation scripts properly updated to include new owner issue references. No code logic changes or runtime impact.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/portal/api/validation-review-api-semantics.md | New documentation defining validation review API contracts, endpoints, and response semantics for web/API integrations |
| docs/portal/operations/validation-review-incident-runbook.md | New incident runbook covering render failures, auth failures, and regression replay failures with triage procedures |
| docs/portal/platform/validation-reviewer-workflow.md | New reviewer workflow documentation for validation decisions via web UI and API/CLI lanes |
| docs/llm/source-map.json | Added three new entries for validation review documentation with correct metadata, concepts, and endpoints |
| docs/llm/index.json | Added index entries for three validation review chunks with correct hashes, owners, and owner_issue references |
| scripts/docs/check_llm_package.py | Extended ALLOWED_OWNER_ISSUES allowlist to include issues #282, #283, and #288 for validation review documentation |
| scripts/docs/check_stale_references.py | Added validation checks for three new validation review documentation files to ensure required tokens and references are present |

</details>


</details>


<sub>Last reviewed commit: fd86d41</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->