### PR TITLE
Validation review runtime handlers and contract enforcement (#276)

### DIFF
--- a/backend/src/platform_api/schemas_v2.py
+++ b/backend/src/platform_api/schemas_v2.py
@@ -350,6 +350,109 @@ class ValidationRenderResponse(BaseModel):
     render: ValidationRenderJob
 
 
+ValidationReviewDecisionAction = Literal["approve", "reject"]
+
+
+class ValidationReviewRunSummary(BaseModel):
+    id: str
+    status: ValidationRunStatus
+    profile: ValidationProfile
+    finalDecision: ValidationRunDecision
+    traderReviewStatus: ValidationTraderReviewStatus
+    commentCount: int = Field(ge=0)
+    pendingDecision: bool
+    createdAt: str
+    updatedAt: str
+
+
+class ValidationReviewRunListResponse(BaseModel):
+    requestId: str
+    items: list[ValidationReviewRunSummary] = Field(default_factory=list)
+    nextCursor: str | None = None
+
+
+class ValidationReviewComment(BaseModel):
+    id: str
+    runId: str
+    tenantId: str
+    userId: str
+    body: str = Field(min_length=1)
+    evidenceRefs: list[str] = Field(default_factory=list)
+    createdAt: str
+
+
+class CreateValidationReviewCommentRequest(BaseModel):
+    body: str = Field(min_length=1)
+    evidenceRefs: list[str] = Field(default_factory=list)
+
+
+class ValidationReviewCommentResponse(BaseModel):
+    requestId: str
+    runId: str
+    commentAccepted: bool
+    comment: ValidationReviewComment
+
+
+class ValidationReviewDecision(BaseModel):
+    runId: str
+    action: ValidationReviewDecisionAction
+    decision: ValidationDecision
+    reason: str = Field(min_length=1)
+    evidenceRefs: list[str] = Field(default_factory=list)
+    decidedByTenantId: str
+    decidedByUserId: str
+    createdAt: str
+
+
+class CreateValidationReviewDecisionRequest(BaseModel):
+    action: ValidationReviewDecisionAction
+    decision: ValidationDecision
+    reason: str = Field(min_length=1)
+    evidenceRefs: list[str] = Field(default_factory=list)
+
+
+class ValidationReviewDecisionResponse(BaseModel):
+    requestId: str
+    runId: str
+    decisionAccepted: bool
+    decision: ValidationReviewDecision
+
+
+class CreateValidationReviewRenderRequest(BaseModel):
+    format: ValidationRenderFormat
+
+
+class ValidationReviewRenderJob(BaseModel):
+    runId: str
+    format: ValidationRenderFormat
+    status: Literal["queued", "running", "completed", "failed"]
+    artifactRef: str | None = None
+    downloadUrl: str | None = None
+    checksumSha256: str | None = None
+    expiresAt: str | None = None
+    requestedAt: str
+    updatedAt: str
+
+
+class ValidationReviewRenderResponse(BaseModel):
+    requestId: str
+    render: ValidationReviewRenderJob
+
+
+class ValidationReviewArtifact(BaseModel):
+    schemaVersion: Literal["validation-review.v1"]
+    run: ValidationRun
+    artifact: ValidationRunArtifact
+    comments: list[ValidationReviewComment] = Field(default_factory=list)
+    decision: ValidationReviewDecision | None = None
+    renders: list[ValidationReviewRenderJob] = Field(default_factory=list)
+
+
+class ValidationReviewRunDetailResponse(BaseModel):
+    requestId: str
+    artifact: ValidationReviewArtifact
+
+
 class CreateValidationBaselineRequest(BaseModel):
     runId: str
     name: str = Field(min_length=1)

--- a/backend/src/platform_api/services/validation_v2_service.py
+++ b/backend/src/platform_api/services/validation_v2_service.py
@@ -15,6 +15,9 @@ from src.platform_api.schemas_v2 import (
     CreateValidationBaselineRequest,
     CreateValidationRegressionReplayRequest,
     CreateValidationRenderRequest,
+    CreateValidationReviewCommentRequest,
+    CreateValidationReviewDecisionRequest,
+    CreateValidationReviewRenderRequest,
     CreateValidationRunRequest,
     CreateValidationRunReviewRequest,
     ValidationArtifactResponse,
@@ -26,11 +29,21 @@ from src.platform_api.schemas_v2 import (
     ValidationRegressionReplayResponse,
     ValidationRenderJob,
     ValidationRenderResponse,
+    ValidationReviewArtifact,
+    ValidationReviewComment,
+    ValidationReviewCommentResponse,
+    ValidationReviewDecision,
+    ValidationReviewDecisionResponse,
+    ValidationReviewRenderJob,
+    ValidationReviewRenderResponse,
+    ValidationReviewRunDetailResponse,
+    ValidationReviewRunListResponse,
+    ValidationReviewRunSummary,
     ValidationRun,
-    ValidationRunListResponse,
     ValidationRunArtifact,
-    ValidationRunReviewResponse,
+    ValidationRunListResponse,
     ValidationRunResponse,
+    ValidationRunReviewResponse,
 )
 from src.platform_api.services.validation_agent_review_service import ValidationAgentReviewService
 from src.platform_api.services.validation_deterministic_service import (
@@ -71,6 +84,9 @@ class _ValidationRunRecord:
     policy: ValidationPolicyConfig
     trader_decision: ValidationDecision | None = None
     render_jobs: dict[str, ValidationRenderJob] = field(default_factory=dict)
+    review_comments: list[ValidationReviewComment] = field(default_factory=list)
+    review_decision: ValidationReviewDecision | None = None
+    review_render_jobs: dict[str, ValidationReviewRenderJob] = field(default_factory=dict)
 
 
 @dataclass
@@ -111,6 +127,7 @@ class ValidationV2Service:
         self._run_counter = 1
         self._baseline_counter = 1
         self._replay_counter = 1
+        self._review_comment_counter = 1
 
     async def create_validation_run(
         self,
@@ -376,6 +393,315 @@ class ValidationV2Service:
             requestId=context.request_id,
             artifactType="validation_run",
             artifact=record.artifact,
+        )
+
+    async def list_validation_review_runs(
+        self,
+        *,
+        context: RequestContext,
+        status_filter: str | None = None,
+        final_decision_filter: str | None = None,
+        cursor: str | None = None,
+        limit: int = 25,
+    ) -> ValidationReviewRunListResponse:
+        items = [
+            self._build_validation_review_run_summary(record=record)
+            for record in self._runs.values()
+            if record.tenant_id == context.tenant_id and record.user_id == context.user_id
+        ]
+        if status_filter is not None:
+            items = [item for item in items if item.status == status_filter]
+        if final_decision_filter is not None:
+            items = [item for item in items if item.finalDecision == final_decision_filter]
+        items.sort(key=lambda item: item.updatedAt, reverse=True)
+
+        start = self._decode_pagination_cursor(cursor=cursor)
+        bounded_start = min(start, len(items))
+        page = items[bounded_start : bounded_start + limit]
+        next_cursor: str | None = None
+        if bounded_start + limit < len(items):
+            next_cursor = str(bounded_start + limit)
+        return ValidationReviewRunListResponse(
+            requestId=context.request_id,
+            items=page,
+            nextCursor=next_cursor,
+        )
+
+    async def get_validation_review_run(
+        self,
+        *,
+        run_id: str,
+        context: RequestContext,
+    ) -> ValidationReviewRunDetailResponse:
+        record = self._require_run(run_id=run_id, context=context)
+        review_artifact = ValidationReviewArtifact(
+            schemaVersion="validation-review.v1",
+            run=record.run.model_copy(),
+            artifact=record.artifact.model_copy(),
+            comments=[item.model_copy() for item in record.review_comments],
+            decision=record.review_decision.model_copy() if record.review_decision is not None else None,
+            renders=[
+                item.model_copy()
+                for item in sorted(
+                    record.review_render_jobs.values(),
+                    key=lambda render_job: render_job.requestedAt,
+                )
+            ],
+        )
+        return ValidationReviewRunDetailResponse(
+            requestId=context.request_id,
+            artifact=review_artifact,
+        )
+
+    async def create_validation_review_comment(
+        self,
+        *,
+        run_id: str,
+        request: CreateValidationReviewCommentRequest,
+        context: RequestContext,
+        idempotency_key: str | None,
+    ) -> ValidationReviewCommentResponse:
+        payload = {"runId": run_id, **request.model_dump(mode="json")}
+        key = self._resolve_idempotency_key(context=context, idempotency_key=idempotency_key)
+        conflict, cached = self._get_idempotent_response(
+            scope="validation_review_comments",
+            key=self._scoped_idempotency_key(context=context, key=key),
+            payload=payload,
+        )
+        if conflict:
+            raise PlatformAPIError(
+                status_code=409,
+                code="IDEMPOTENCY_KEY_CONFLICT",
+                message="Idempotency-Key reused with different payload.",
+                request_id=context.request_id,
+            )
+        if cached is not None:
+            return ValidationReviewCommentResponse.model_validate(cached)
+
+        record = self._require_run(run_id=run_id, context=context)
+        normalized_body = _non_empty(request.body)
+        if normalized_body is None:
+            raise PlatformAPIError(
+                status_code=400,
+                code="VALIDATION_REVIEW_INVALID",
+                message="body must be a non-empty string.",
+                request_id=context.request_id,
+                details={"body": request.body},
+            )
+        evidence_refs = self._normalize_evidence_refs(
+            evidence_refs=request.evidenceRefs,
+            request_id=context.request_id,
+        )
+
+        created_at = utc_now()
+        comment = ValidationReviewComment(
+            id=self._next_review_comment_id(),
+            runId=run_id,
+            tenantId=context.tenant_id,
+            userId=context.user_id,
+            body=normalized_body,
+            evidenceRefs=evidence_refs,
+            createdAt=created_at,
+        )
+        record.review_comments.append(comment)
+        await self._touch_run_record(record=record, updated_at=created_at)
+
+        response = ValidationReviewCommentResponse(
+            requestId=context.request_id,
+            runId=run_id,
+            commentAccepted=True,
+            comment=comment,
+        )
+        self._save_idempotent_response(
+            scope="validation_review_comments",
+            key=self._scoped_idempotency_key(context=context, key=key),
+            payload=payload,
+            response=response.model_dump(mode="json"),
+        )
+        return response
+
+    async def create_validation_review_decision(
+        self,
+        *,
+        run_id: str,
+        request: CreateValidationReviewDecisionRequest,
+        context: RequestContext,
+        idempotency_key: str | None,
+    ) -> ValidationReviewDecisionResponse:
+        payload = {"runId": run_id, **request.model_dump(mode="json")}
+        key = self._resolve_idempotency_key(context=context, idempotency_key=idempotency_key)
+        conflict, cached = self._get_idempotent_response(
+            scope="validation_review_decisions",
+            key=self._scoped_idempotency_key(context=context, key=key),
+            payload=payload,
+        )
+        if conflict:
+            raise PlatformAPIError(
+                status_code=409,
+                code="IDEMPOTENCY_KEY_CONFLICT",
+                message="Idempotency-Key reused with different payload.",
+                request_id=context.request_id,
+            )
+        if cached is not None:
+            return ValidationReviewDecisionResponse.model_validate(cached)
+
+        record = self._require_run(run_id=run_id, context=context)
+        if request.action == "approve" and request.decision == "fail":
+            raise PlatformAPIError(
+                status_code=400,
+                code="VALIDATION_REVIEW_INVALID",
+                message="action=approve cannot be used with decision=fail.",
+                request_id=context.request_id,
+                details={"action": request.action, "decision": request.decision},
+            )
+        if request.action == "reject" and request.decision != "fail":
+            raise PlatformAPIError(
+                status_code=400,
+                code="VALIDATION_REVIEW_INVALID",
+                message="action=reject requires decision=fail.",
+                request_id=context.request_id,
+                details={"action": request.action, "decision": request.decision},
+            )
+        normalized_reason = _non_empty(request.reason)
+        if normalized_reason is None:
+            raise PlatformAPIError(
+                status_code=400,
+                code="VALIDATION_REVIEW_INVALID",
+                message="reason must be a non-empty string.",
+                request_id=context.request_id,
+                details={"reason": request.reason},
+            )
+        evidence_refs = self._normalize_evidence_refs(
+            evidence_refs=request.evidenceRefs,
+            request_id=context.request_id,
+        )
+
+        created_at = utc_now()
+        decision = ValidationReviewDecision(
+            runId=run_id,
+            action=request.action,
+            decision=request.decision,
+            reason=normalized_reason,
+            evidenceRefs=evidence_refs,
+            decidedByTenantId=context.tenant_id,
+            decidedByUserId=context.user_id,
+            createdAt=created_at,
+        )
+        record.review_decision = decision
+
+        artifact_payload = record.artifact.model_dump(mode="json")
+        snapshot_payload = record.llm_snapshot.model_dump(mode="json")
+        trader_review = cast(dict[str, Any], artifact_payload["traderReview"])
+        trader_review["status"] = "approved" if request.action == "approve" else "rejected"
+        record.trader_decision = cast(ValidationDecision, request.decision)
+        deterministic_decision = self._resolve_deterministic_decision(artifact_payload)
+        agent_review_payload = cast(dict[str, Any], artifact_payload["agentReview"])
+        final_decision = self._resolve_final_decision(
+            deterministic_decision=deterministic_decision,
+            agent_status=cast(ValidationDecision, agent_review_payload["status"]),
+            trader_status=cast(str, trader_review["status"]),
+            policy=record.policy,
+            trader_decision=record.trader_decision,
+        )
+        artifact_payload["finalDecision"] = final_decision
+        snapshot_payload["finalDecision"] = final_decision
+
+        record.artifact = ValidationRunArtifact.model_validate(artifact_payload)
+        record.llm_snapshot = ValidationLlmSnapshotArtifact.model_validate(snapshot_payload)
+        await self._touch_run_record(
+            record=record,
+            updated_at=created_at,
+            final_decision=final_decision,
+        )
+
+        response = ValidationReviewDecisionResponse(
+            requestId=context.request_id,
+            runId=run_id,
+            decisionAccepted=True,
+            decision=decision,
+        )
+        self._save_idempotent_response(
+            scope="validation_review_decisions",
+            key=self._scoped_idempotency_key(context=context, key=key),
+            payload=payload,
+            response=response.model_dump(mode="json"),
+        )
+        return response
+
+    async def create_validation_review_render(
+        self,
+        *,
+        run_id: str,
+        request: CreateValidationReviewRenderRequest,
+        context: RequestContext,
+        idempotency_key: str | None,
+    ) -> ValidationReviewRenderResponse:
+        payload = {"runId": run_id, **request.model_dump(mode="json")}
+        key = self._resolve_idempotency_key(context=context, idempotency_key=idempotency_key)
+        conflict, cached = self._get_idempotent_response(
+            scope="validation_review_renders",
+            key=self._scoped_idempotency_key(context=context, key=key),
+            payload=payload,
+        )
+        if conflict:
+            raise PlatformAPIError(
+                status_code=409,
+                code="IDEMPOTENCY_KEY_CONFLICT",
+                message="Idempotency-Key reused with different payload.",
+                request_id=context.request_id,
+            )
+        if cached is not None:
+            return ValidationReviewRenderResponse.model_validate(cached)
+
+        record = self._require_run(run_id=run_id, context=context)
+        render_job = record.review_render_jobs.get(request.format)
+        if render_job is None:
+            now = utc_now()
+            render_job = ValidationReviewRenderJob(
+                runId=run_id,
+                format=request.format,
+                status="queued",
+                artifactRef=None,
+                downloadUrl=None,
+                checksumSha256=None,
+                expiresAt=None,
+                requestedAt=now,
+                updatedAt=now,
+            )
+            record.review_render_jobs[request.format] = render_job
+            await self._touch_run_record(record=record, updated_at=now)
+
+        response = ValidationReviewRenderResponse(
+            requestId=context.request_id,
+            render=render_job,
+        )
+        self._save_idempotent_response(
+            scope="validation_review_renders",
+            key=self._scoped_idempotency_key(context=context, key=key),
+            payload=payload,
+            response=response.model_dump(mode="json"),
+        )
+        return response
+
+    async def get_validation_review_render(
+        self,
+        *,
+        run_id: str,
+        format: Literal["html", "pdf"],
+        context: RequestContext,
+    ) -> ValidationReviewRenderResponse:
+        record = self._require_run(run_id=run_id, context=context)
+        render_job = record.review_render_jobs.get(format)
+        if render_job is None:
+            raise PlatformAPIError(
+                status_code=404,
+                code="VALIDATION_RENDER_NOT_FOUND",
+                message=f"Validation review render {format} not found for run {run_id}.",
+                request_id=context.request_id,
+            )
+        return ValidationReviewRenderResponse(
+            requestId=context.request_id,
+            render=render_job,
         )
 
     async def submit_validation_run_review(
@@ -955,7 +1281,7 @@ class ValidationV2Service:
             f"# run {run_id}\n"
             "def execute(context):\n"
             "    return {'status': 'ok'}\n"
-        ).encode("utf-8")
+        ).encode()
         backtest_payload = json.dumps(
             {
                 "strategyId": artifact.strategyRef.strategyId,
@@ -973,10 +1299,10 @@ class ValidationV2Service:
             sort_keys=True,
         ).encode("utf-8")
         execution_logs_payload = (
-            "created ord-001\n"
-            "accepted ord-001\n"
-            "filled ord-001\n"
-        ).encode("utf-8")
+            b"created ord-001\n"
+            b"accepted ord-001\n"
+            b"filled ord-001\n"
+        )
         chart_payload = json.dumps(
             {
                 "requestedIndicators": artifact.inputs.requestedIndicators,
@@ -1090,6 +1416,73 @@ class ValidationV2Service:
             )
         )
 
+    async def _touch_run_record(
+        self,
+        *,
+        record: _ValidationRunRecord,
+        updated_at: str,
+        final_decision: ValidationDecision | None = None,
+    ) -> None:
+        updates: dict[str, Any] = {"updatedAt": updated_at}
+        if final_decision is not None:
+            updates["finalDecision"] = cast(
+                Literal["pending", "pass", "conditional_pass", "fail"],
+                final_decision,
+            )
+        record.run = record.run.model_copy(update=updates)
+        await self._persist_run_metadata(record=record)
+
+    @staticmethod
+    def _decode_pagination_cursor(*, cursor: str | None) -> int:
+        normalized = _non_empty(cursor)
+        if normalized is None:
+            return 0
+        try:
+            parsed = int(normalized)
+        except ValueError:
+            return 0
+        if parsed < 0:
+            return 0
+        return parsed
+
+    @staticmethod
+    def _normalize_evidence_refs(
+        *,
+        evidence_refs: list[str],
+        request_id: str,
+    ) -> list[str]:
+        normalized: list[str] = []
+        for ref in evidence_refs:
+            candidate = _non_empty(ref)
+            if candidate is None or not is_valid_blob_reference(candidate):
+                raise PlatformAPIError(
+                    status_code=400,
+                    code="VALIDATION_REVIEW_INVALID",
+                    message="evidenceRefs entries must use blob:// reference format.",
+                    request_id=request_id,
+                    details={"evidenceRef": ref},
+                )
+            normalized.append(candidate)
+        return normalized
+
+    @staticmethod
+    def _build_validation_review_run_summary(
+        *,
+        record: _ValidationRunRecord,
+    ) -> ValidationReviewRunSummary:
+        trader_status = record.artifact.traderReview.status
+        return ValidationReviewRunSummary(
+            id=record.run.id,
+            status=record.run.status,
+            profile=record.run.profile,
+            finalDecision=record.run.finalDecision,
+            traderReviewStatus=trader_status,
+            commentCount=len(record.review_comments),
+            pendingDecision=record.review_decision is None and trader_status == "requested",
+            createdAt=record.run.createdAt,
+            updatedAt=record.run.updatedAt,
+        )
+
     def _next_run_id(self) -> str:
         value = self._run_counter
         self._run_counter += 1
@@ -1104,6 +1497,11 @@ class ValidationV2Service:
         value = self._replay_counter
         self._replay_counter += 1
         return f"valreplay-{value:03d}"
+
+    def _next_review_comment_id(self) -> str:
+        value = self._review_comment_counter
+        self._review_comment_counter += 1
+        return f"valcomment-{value:03d}"
 
     @staticmethod
     def _resolve_idempotency_key(*, context: RequestContext, idempotency_key: str | None) -> str:

--- a/backend/src/platform_api/state_store.py
+++ b/backend/src/platform_api/state_store.py
@@ -390,6 +390,9 @@ class InMemoryStateStore:
             "validation_renders": {},
             "validation_baselines": {},
             "validation_replays": {},
+            "validation_review_comments": {},
+            "validation_review_decisions": {},
+            "validation_review_renders": {},
         }
 
     def next_id(self, scope: str) -> str:

--- a/backend/tests/contracts/test_validation_review_runtime_contract.py
+++ b/backend/tests/contracts/test_validation_review_runtime_contract.py
@@ -1,0 +1,268 @@
+"""Runtime contract checks for /v2/validation-review endpoints (#276)."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+
+def _jwt_segment(payload: dict[str, str]) -> str:
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(encoded).decode("utf-8").rstrip("=")
+
+
+def _validation_headers(
+    *,
+    request_id: str,
+    tenant_id: str,
+    user_id: str,
+) -> dict[str, str]:
+    token = (
+        f"{_jwt_segment({'alg': 'none', 'typ': 'JWT'})}."
+        f"{_jwt_segment({'sub': user_id, 'tenant_id': tenant_id})}."
+    )
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-API-Key": "test-key",
+        "X-Request-Id": request_id,
+        "X-Tenant-Id": tenant_id,
+        "X-User-Id": user_id,
+    }
+
+
+def _create_validation_run(
+    client: TestClient,
+    *,
+    headers: dict[str, str],
+    idempotency_key: str,
+) -> str:
+    response = client.post(
+        "/v2/validation-runs",
+        headers={**headers, "Idempotency-Key": idempotency_key},
+        json={
+            "strategyId": "strat-001",
+            "providerRefId": "lona-strategy-123",
+            "prompt": "Build zig-zag strategy for BTC 1h with trend filter",
+            "requestedIndicators": ["zigzag", "ema"],
+            "datasetIds": ["dataset-btc-1h-2025"],
+            "backtestReportRef": "blob://validation/candidate/backtest-report.json",
+            "policy": {
+                "profile": "STANDARD",
+                "blockMergeOnFail": True,
+                "blockReleaseOnFail": True,
+                "blockMergeOnAgentFail": True,
+                "blockReleaseOnAgentFail": False,
+                "requireTraderReview": True,
+                "hardFailOnMissingIndicators": True,
+                "failClosedOnEvidenceUnavailable": True,
+            },
+        },
+    )
+    assert response.status_code == 202
+    return response.json()["run"]["id"]
+
+
+def _assert_error_envelope(payload: dict[str, object]) -> None:
+    assert "requestId" in payload
+    assert "error" in payload
+    error = payload["error"]
+    assert isinstance(error, dict)
+    assert "code" in error
+    assert "message" in error
+
+
+def test_validation_review_requires_authentication() -> None:
+    client = TestClient(app)
+    response = client.get(
+        "/v2/validation-review/runs",
+        headers={"X-Request-Id": "req-v2-validation-review-unauth-001"},
+    )
+    assert response.status_code == 401
+    payload = response.json()
+    _assert_error_envelope(payload)
+    assert payload["requestId"] == "req-v2-validation-review-unauth-001"
+    assert payload["error"]["code"] == "AUTH_UNAUTHORIZED"
+
+
+def test_validation_review_list_and_detail_are_tenant_scoped() -> None:
+    client = TestClient(app)
+    scoped_headers = _validation_headers(
+        request_id="req-v2-validation-review-tenant-001",
+        tenant_id="tenant-v2-validation-review-scope",
+        user_id="user-v2-validation-review-scope",
+    )
+    other_headers = _validation_headers(
+        request_id="req-v2-validation-review-tenant-002",
+        tenant_id="tenant-v2-validation-review-other",
+        user_id="user-v2-validation-review-other",
+    )
+
+    scoped_run = _create_validation_run(
+        client,
+        headers=scoped_headers,
+        idempotency_key="idem-v2-validation-review-tenant-run-001",
+    )
+    other_run = _create_validation_run(
+        client,
+        headers=other_headers,
+        idempotency_key="idem-v2-validation-review-tenant-run-002",
+    )
+
+    scoped_list = client.get("/v2/validation-review/runs", headers=scoped_headers)
+    assert scoped_list.status_code == 200
+    listed_ids = {item["id"] for item in scoped_list.json()["items"]}
+    assert scoped_run in listed_ids
+    assert other_run not in listed_ids
+
+    forbidden_detail = client.get(f"/v2/validation-review/runs/{other_run}", headers=scoped_headers)
+    assert forbidden_detail.status_code == 404
+    forbidden_payload = forbidden_detail.json()
+    _assert_error_envelope(forbidden_payload)
+    assert forbidden_payload["error"]["code"] == "VALIDATION_RUN_NOT_FOUND"
+
+
+def test_validation_review_write_routes_are_idempotent() -> None:
+    client = TestClient(app)
+    headers = _validation_headers(
+        request_id="req-v2-validation-review-idem-001",
+        tenant_id="tenant-v2-validation-review-idem",
+        user_id="user-v2-validation-review-idem",
+    )
+    run_id = _create_validation_run(
+        client,
+        headers=headers,
+        idempotency_key="idem-v2-validation-review-idem-run-001",
+    )
+
+    comment_payload = {
+        "body": "Comment from review idempotency contract test.",
+        "evidenceRefs": ["blob://validation/review/comment-001.json"],
+    }
+    comment_headers = {**headers, "Idempotency-Key": "idem-v2-validation-review-comment-001"}
+    first_comment = client.post(
+        f"/v2/validation-review/runs/{run_id}/comments",
+        headers=comment_headers,
+        json=comment_payload,
+    )
+    assert first_comment.status_code == 202
+    second_comment = client.post(
+        f"/v2/validation-review/runs/{run_id}/comments",
+        headers=comment_headers,
+        json=comment_payload,
+    )
+    assert second_comment.status_code == 202
+    assert second_comment.json()["comment"]["id"] == first_comment.json()["comment"]["id"]
+    comment_conflict = client.post(
+        f"/v2/validation-review/runs/{run_id}/comments",
+        headers=comment_headers,
+        json={**comment_payload, "body": "different"},
+    )
+    assert comment_conflict.status_code == 409
+    assert comment_conflict.json()["error"]["code"] == "IDEMPOTENCY_KEY_CONFLICT"
+
+    decision_payload = {
+        "action": "approve",
+        "decision": "conditional_pass",
+        "reason": "Approve with safeguards.",
+        "evidenceRefs": ["blob://validation/review/decision-001.json"],
+    }
+    decision_headers = {**headers, "Idempotency-Key": "idem-v2-validation-review-decision-001"}
+    first_decision = client.post(
+        f"/v2/validation-review/runs/{run_id}/decisions",
+        headers=decision_headers,
+        json=decision_payload,
+    )
+    assert first_decision.status_code == 202
+    second_decision = client.post(
+        f"/v2/validation-review/runs/{run_id}/decisions",
+        headers=decision_headers,
+        json=decision_payload,
+    )
+    assert second_decision.status_code == 202
+    assert second_decision.json()["decision"]["createdAt"] == first_decision.json()["decision"]["createdAt"]
+    decision_conflict = client.post(
+        f"/v2/validation-review/runs/{run_id}/decisions",
+        headers=decision_headers,
+        json={
+            "action": "reject",
+            "decision": "fail",
+            "reason": "different payload",
+            "evidenceRefs": ["blob://validation/review/decision-002.json"],
+        },
+    )
+    assert decision_conflict.status_code == 409
+    assert decision_conflict.json()["error"]["code"] == "IDEMPOTENCY_KEY_CONFLICT"
+
+    render_headers = {**headers, "Idempotency-Key": "idem-v2-validation-review-render-001"}
+    first_render = client.post(
+        f"/v2/validation-review/runs/{run_id}/renders",
+        headers=render_headers,
+        json={"format": "html"},
+    )
+    assert first_render.status_code == 202
+    second_render = client.post(
+        f"/v2/validation-review/runs/{run_id}/renders",
+        headers=render_headers,
+        json={"format": "html"},
+    )
+    assert second_render.status_code == 202
+    assert second_render.json()["render"]["requestedAt"] == first_render.json()["render"]["requestedAt"]
+    render_conflict = client.post(
+        f"/v2/validation-review/runs/{run_id}/renders",
+        headers=render_headers,
+        json={"format": "pdf"},
+    )
+    assert render_conflict.status_code == 409
+    assert render_conflict.json()["error"]["code"] == "IDEMPOTENCY_KEY_CONFLICT"
+
+
+def test_validation_review_routes_return_error_envelopes() -> None:
+    client = TestClient(app)
+    headers = _validation_headers(
+        request_id="req-v2-validation-review-errors-001",
+        tenant_id="tenant-v2-validation-review-errors",
+        user_id="user-v2-validation-review-errors",
+    )
+    run_id = _create_validation_run(
+        client,
+        headers=headers,
+        idempotency_key="idem-v2-validation-review-errors-run-001",
+    )
+
+    missing_run = client.post(
+        "/v2/validation-review/runs/valrun-missing/comments",
+        headers={**headers, "Idempotency-Key": "idem-v2-validation-review-errors-missing-001"},
+        json={
+            "body": "attempting to comment on missing run",
+            "evidenceRefs": ["blob://validation/review/missing.json"],
+        },
+    )
+    assert missing_run.status_code == 404
+    missing_payload = missing_run.json()
+    _assert_error_envelope(missing_payload)
+    assert missing_payload["error"]["code"] == "VALIDATION_RUN_NOT_FOUND"
+
+    invalid_decision = client.post(
+        f"/v2/validation-review/runs/{run_id}/decisions",
+        headers={**headers, "Idempotency-Key": "idem-v2-validation-review-errors-invalid-001"},
+        json={
+            "action": "approve",
+            "decision": "fail",
+            "reason": "invalid action/decision pair",
+            "evidenceRefs": ["blob://validation/review/invalid-decision.json"],
+        },
+    )
+    assert invalid_decision.status_code == 400
+    invalid_payload = invalid_decision.json()
+    _assert_error_envelope(invalid_payload)
+    assert invalid_payload["error"]["code"] == "VALIDATION_REVIEW_INVALID"
+
+    missing_render = client.get(f"/v2/validation-review/runs/{run_id}/renders/html", headers=headers)
+    assert missing_render.status_code == 404
+    render_payload = missing_render.json()
+    _assert_error_envelope(render_payload)
+    assert render_payload["error"]["code"] == "VALIDATION_RENDER_NOT_FOUND"


### PR DESCRIPTION
## Summary
- implement `/v2/validation-review/*` runtime handlers in the Platform API v2 router
- add review-web schemas and service logic for list/detail/comments/decisions/renders
- enforce tenant/user scoping from auth-derived identity, idempotent writes, and canonical JSON review artifact responses
- extend runtime route contract checks and add dedicated validation-review runtime contract tests

## Contract & Governance
- Child issue: #276
- Parent program issue: #288

## Validation
- `uv run --extra dev pytest tests/contracts/test_validation_review_runtime_contract.py tests/contracts/test_runtime_openapi_contract_v2.py tests/contracts/test_platform_api_v2_handlers.py -k "validation_review or validation_v2"`
- `uv run --extra dev pytest tests/contracts/test_openapi_validation_review_contract_freeze.py tests/contracts/test_openapi_contract_v2_validation_freeze.py tests/contracts/test_openapi_contract_v2_baseline.py tests/contracts/test_sdk_validation_review_contract_shape.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new API endpoints and mutates validation run decision state based on review actions; mistakes could impact review scoping or decision outcomes, though changes are contained to runtime v2 handlers with contract coverage.
> 
> **Overview**
> Adds a new `/v2/validation-review` API surface to support validation run review workflows: list/detail views plus write endpoints for reviewer `comments`, `decisions`, and review `renders` (with filtering + cursor pagination for lists).
> 
> Implements the backing runtime logic in `ValidationV2Service`, including tenant/user scoping, idempotent write handling per new state-store scopes, input validation for decisions/evidence refs, and updating run `finalDecision`/metadata when a review decision is recorded. Extends the v2 OpenAPI runtime contract test and adds a dedicated contract suite covering auth, scoping, idempotency conflicts, and error envelopes for the new endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 026441387baa0052298da8a22da260c995639500. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements `/v2/validation-review/*` API surface for validation run review workflows. Adds list/detail endpoints with cursor pagination and filtering by status/decision, plus write endpoints for reviewer comments, decisions, and render requests. All write operations enforce tenant/user scoping from auth-derived identity, require idempotency headers, validate evidence refs use `blob://` format, and return proper error envelopes.

**Major changes:**
- Added 6 new routes in `router_v2.py`: list runs, get run detail, create comment, create decision, create/get render
- New schemas for `ValidationReviewComment`, `ValidationReviewDecision`, `ValidationReviewRenderJob`, and `ValidationReviewArtifact`
- Service methods in `validation_v2_service.py` implement decision resolution logic that combines deterministic checks, agent review status, and trader decisions to compute `finalDecision`
- Decision endpoint validates action/decision pairs (approve cannot use fail, reject requires fail) and mutates run state
- Comment and decision creation updates run metadata and persists changes to storage
- Added 3 new idempotency scopes in `state_store.py` for review operations
- Comprehensive contract test coverage for auth, scoping, idempotency conflicts, and error handling

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; changes are well-contained to new validation-review endpoints with strong contract coverage
- Score reflects solid implementation with comprehensive testing, proper scoping, and validation. The one point deduction is due to the complexity of decision resolution logic that mutates run state - while properly tested, this state mutation logic in `_resolve_final_decision` and decision endpoint handling requires careful review to ensure correctness across all policy/status combinations
- Pay close attention to `backend/src/platform_api/services/validation_v2_service.py` lines 523-629 for the decision resolution and state mutation logic

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/router_v2.py | Added 6 new validation-review endpoints with proper idempotency headers and tenant/user scoping |
| backend/src/platform_api/schemas_v2.py | Introduced validation-review schemas for comments, decisions, and render jobs with proper validation constraints |
| backend/src/platform_api/services/validation_v2_service.py | Implemented review workflow service methods with decision resolution logic, evidence validation, and state mutations |
| backend/tests/contracts/test_validation_review_runtime_contract.py | New dedicated test suite for validation-review auth, scoping, idempotency, and error envelopes |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Router as router_v2
    participant Service as ValidationV2Service
    participant Store as StateStore
    
    Client->>Router: POST /v2/validation-review/runs/{runId}/comments
    Note over Client,Router: Idempotency-Key header required
    Router->>Service: create_validation_review_comment()
    Service->>Store: Check idempotency key
    alt Idempotent replay
        Store-->>Service: Return cached response
        Service-->>Router: ValidationReviewCommentResponse
    else New request
        Service->>Service: Validate run access (tenant/user scope)
        Service->>Service: Validate evidence refs (blob://)
        Service->>Service: Create comment and append to record
        Service->>Store: Save idempotent response
        Service-->>Router: ValidationReviewCommentResponse (202)
    end
    Router-->>Client: HTTP 202 with comment
    
    Client->>Router: POST /v2/validation-review/runs/{runId}/decisions
    Router->>Service: create_validation_review_decision()
    Service->>Service: Validate action/decision pair
    Service->>Service: Update trader review status
    Service->>Service: Resolve final decision (deterministic + agent + trader)
    Service->>Service: Mutate run finalDecision
    Service->>Store: Persist updated run metadata
    Service-->>Router: ValidationReviewDecisionResponse (202)
    Router-->>Client: HTTP 202 with decision
    
    Client->>Router: GET /v2/validation-review/runs/{runId}
    Router->>Service: get_validation_review_run()
    Service->>Service: Require run with tenant/user scope
    Service->>Service: Build ValidationReviewArtifact
    Service-->>Router: ValidationReviewRunDetailResponse
    Router-->>Client: HTTP 200 with full artifact
```

<sub>Last reviewed commit: 0264413</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->