### PR TITLE
fix(#279): avoid deep-link listener churn in validation page

### DIFF
--- a/frontend/src/app/(dashboard)/validation/page.tsx
+++ b/frontend/src/app/(dashboard)/validation/page.tsx
@@ -9,7 +9,7 @@ import {
   ShieldCheck,
   Sparkles,
 } from 'lucide-react';
-import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -133,7 +133,7 @@ function decisionToBadgeVariant(decision: ValidationRunSummary['finalDecision'])
 }
 
 export default function ValidationPage() {
-  const [lastDeepLinkedRunId, setLastDeepLinkedRunId] = useState<string | null>(null);
+  const lastDeepLinkedRunIdRef = useRef<string | null>(null);
   const [runLookupId, setRunLookupId] = useState('');
   const [runList, setRunList] = useState<ValidationRunSummary[]>([]);
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
@@ -283,17 +283,17 @@ export default function ValidationPage() {
 
   const loadDeepLinkedRun = useCallback(() => {
     const deepLinkedRunId = new URLSearchParams(window.location.search).get('runId')?.trim() ?? '';
-    if (!deepLinkedRunId || deepLinkedRunId === lastDeepLinkedRunId) {
+    if (!deepLinkedRunId || deepLinkedRunId === lastDeepLinkedRunIdRef.current) {
       return;
     }
 
-    setLastDeepLinkedRunId(deepLinkedRunId);
+    lastDeepLinkedRunIdRef.current = deepLinkedRunId;
     setRunLookupId(deepLinkedRunId);
     void loadRunById(deepLinkedRunId, {
       clearNotice: false,
       successNotice: `Loaded validation run ${deepLinkedRunId} from URL.`,
     });
-  }, [lastDeepLinkedRunId, loadRunById]);
+  }, [loadRunById]);
 
   useEffect(() => {
     loadDeepLinkedRun();


### PR DESCRIPTION
## Summary
- replace `lastDeepLinkedRunId` state with `useRef` in validation page deep-link loader
- keep dedupe behavior identical while avoiding render-triggered effect/listener churn

## Why
- addresses late Cursor reviewer thread on merged PR #296 (`discussion_r2834624566`)

## Validation
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_Y2xlcmsuZXhhbXBsZS5jb20k bun run build` (frontend)

Refs:
- Child: #279
- Parent: #288
- Follow-up to: #296

No auto-merge: hold until reviewer checks/comments are complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized React hook change that only affects URL-driven run loading and event listener registration.
> 
> **Overview**
> Updates `ValidationPage` deep-link handling to track the last loaded `runId` via `useRef` instead of React state, preserving the same dedupe behavior while avoiding re-renders.
> 
> This removes `lastDeepLinkedRunId` from the `loadDeepLinkedRun` hook dependencies so the `popstate` listener setup no longer churns on each deep-link load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 907859cf28c5d6d054adb82eba54466ad37e39e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Optimized deep-link handling by replacing `lastDeepLinkedRunId` state with `useRef` to prevent effect/listener churn.

- Moved from `useState` to `useRef` for tracking last deep-linked run ID
- Removed state dependency from `loadDeepLinkedRun` callback dependencies
- Prevents unnecessary re-creation of callback and re-registration of `popstate` listener
- Maintains identical deduplication behavior (prevents reloading same run from URL)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Textbook React optimization replacing unnecessary state with ref, preserving all logic while eliminating re-render churn. Single file change with clear scope and verification via build test.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/app/(dashboard)/validation/page.tsx | Replaced state with ref to prevent unnecessary effect re-runs and popstate listener churn |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component Mount] --> B[useEffect: loadRunList]
    A --> C[useEffect: Deep-Link Setup]
    C --> D[Call loadDeepLinkedRun]
    C --> E[Register popstate listener]
    D --> F{Check URL for runId}
    F -->|No runId| G[Return early]
    F -->|runId exists| H{Compare with lastDeepLinkedRunIdRef.current}
    H -->|Same as last| G
    H -->|Different/New| I[Update lastDeepLinkedRunIdRef.current]
    I --> J[setRunLookupId]
    J --> K[loadRunById with deep-link notice]
    L[Browser back/forward] --> M[popstate event]
    M --> D
    N[Component unmount] --> O[Remove popstate listener]
    
    style I fill:#90EE90
    style H fill:#FFE4B5
    style C fill:#ADD8E6
```

<sub>Last reviewed commit: 907859c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->