### PR TITLE
ops: align domains to lona.agency + ops docs

### DIFF
--- a/.ops/scripts/ops-drill.sh
+++ b/.ops/scripts/ops-drill.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTAINER_APP="trade-nexus-backend"
 RESOURCE_GROUP="trade-nexus"
-FQDN="trade-nexus-backend.whitecliff-198cd26a.westeurope.azurecontainerapps.io"
+FQDN="api-nexus.lona.agency"
 AUTO_CONFIRM=false
 RESULTS=()
 HAS_FAILURE=false

--- a/.ops/scripts/rollback.sh
+++ b/.ops/scripts/rollback.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTAINER_APP="trade-nexus-backend"
 RESOURCE_GROUP="trade-nexus"
-FQDN="trade-nexus-backend.whitecliff-198cd26a.westeurope.azurecontainerapps.io"
+FQDN="api-nexus.lona.agency"
 AUTO_CONFIRM=false
 TARGET_REVISION=""
 

--- a/.ops/scripts/smoke-check.sh
+++ b/.ops/scripts/smoke-check.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Exit:  0 = all endpoints healthy, 1 = one or more endpoints failed
 # =============================================================================
 
-DEFAULT_URL="https://trade-nexus-backend.whitecliff-198cd26a.westeurope.azurecontainerapps.io"
+DEFAULT_URL="https://api-nexus.lona.agency"
 BASE_URL="${DEFAULT_URL}"
 
 # --- Cleanup / trap --------------------------------------------------------

--- a/contracts/schemas/risk-policy.v1.schema.json
+++ b/contracts/schemas/risk-policy.v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://trade-nexus.io/schemas/risk-policy.v1.schema.json",
+  "$id": "https://trade-nexus.lona.agency/schemas/risk-policy.v1.schema.json",
   "title": "Trade Nexus Risk Policy v1",
   "type": "object",
   "additionalProperties": false,

--- a/contracts/schemas/validation_agent_review_result.json
+++ b/contracts/schemas/validation_agent_review_result.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://trade-nexus.io/schemas/validation_agent_review_result.json",
+  "$id": "https://trade-nexus.lona.agency/schemas/validation_agent_review_result.json",
   "title": "Trade Nexus Validation Agent Review Result",
   "type": "object",
   "additionalProperties": false,

--- a/contracts/schemas/validation_llm_snapshot.json
+++ b/contracts/schemas/validation_llm_snapshot.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://trade-nexus.io/schemas/validation_llm_snapshot.json",
+  "$id": "https://trade-nexus.lona.agency/schemas/validation_llm_snapshot.json",
   "title": "Trade Nexus Validation LLM Snapshot Artifact",
   "type": "object",
   "additionalProperties": false,

--- a/contracts/schemas/validation_policy_profile.json
+++ b/contracts/schemas/validation_policy_profile.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://trade-nexus.io/schemas/validation_policy_profile.json",
+  "$id": "https://trade-nexus.lona.agency/schemas/validation_policy_profile.json",
   "title": "Trade Nexus Validation Policy Profile",
   "type": "object",
   "additionalProperties": false,

--- a/contracts/schemas/validation_replay_gate_report.json
+++ b/contracts/schemas/validation_replay_gate_report.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://trade-nexus.io/schemas/validation_replay_gate_report.json",
+  "$id": "https://trade-nexus.lona.agency/schemas/validation_replay_gate_report.json",
   "title": "Trade Nexus Validation Replay Gate Report",
   "type": "object",
   "additionalProperties": false,

--- a/contracts/schemas/validation_run.json
+++ b/contracts/schemas/validation_run.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://trade-nexus.io/schemas/validation_run.json",
+  "$id": "https://trade-nexus.lona.agency/schemas/validation_run.json",
   "title": "Trade Nexus Validation Run Canonical Artifact",
   "type": "object",
   "additionalProperties": false,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,7 +159,7 @@ backend/
 
 ## Production Deployment
 
-**Backend URL**: https://trade-nexus-backend.whitecliff-198cd26a.westeurope.azurecontainerapps.io/
+**Backend URL**: https://api-nexus.lona.agency/
 
 **Health Check**: `GET /health`
 

--- a/docs/architecture/specs/platform-api.openapi.yaml
+++ b/docs/architecture/specs/platform-api.openapi.yaml
@@ -1702,7 +1702,7 @@ paths:
                       format: html
                       status: completed
                       artifactRef: blob://validation/valrun-20260217-0001/review.html
-                      downloadUrl: https://cdn.trade-nexus.io/validation/valrun-20260217-0001/review.html
+                      downloadUrl: https://cdn.trade-nexus.lona.agency/validation/valrun-20260217-0001/review.html
                       checksumSha256: 5d41402abc4b2a76b9719d911017c592ad8846f8d1b522f11f2e6f64044f16f8
                       expiresAt: '2026-02-17T11:40:00Z'
                       requestedAt: '2026-02-17T10:37:00Z'
@@ -1879,7 +1879,7 @@ paths:
                   format: html
                   status: completed
                   artifactRef: blob://validation/valrun-20260217-0001/review.html
-                  downloadUrl: https://cdn.trade-nexus.io/validation/valrun-20260217-0001/review.html
+                  downloadUrl: https://cdn.trade-nexus.lona.agency/validation/valrun-20260217-0001/review.html
                   checksumSha256: 5d41402abc4b2a76b9719d911017c592ad8846f8d1b522f11f2e6f64044f16f8
                   expiresAt: '2026-02-17T11:40:00Z'
                   requestedAt: '2026-02-17T10:37:00Z'

--- a/docs/ops/ENV_MATRIX.md
+++ b/docs/ops/ENV_MATRIX.md
@@ -1,7 +1,7 @@
 # Trade Nexus — Environment Variable Contract
 
 > **Owner**: Team VOps
-> **Last updated**: 2026-02-18
+> **Last updated**: 2026-02-21
 > **Purpose**: Handoff document for dev lanes. Defines what environment variables are available per deployment target.
 
 ## For Dev Teams
@@ -12,50 +12,77 @@
 
 ## Backend (Azure Container Apps)
 
-| Env Var | Source | Required | Format | Purpose |
-|---------|--------|----------|--------|---------|
-| XAI_API_KEY | secretRef | Yes | `xai-...` | xAI Grok model access |
-| SUPABASE_URL | plain | Yes | `https://<project>.supabase.co` | Database endpoint |
-| SUPABASE_KEY | secretRef | Yes | `eyJ...` (JWT) | Database service role key |
-| LANGSMITH_API_KEY | secretRef | Yes | `lsv2_...` | LangSmith observability |
-| LANGSMITH_ENDPOINT | plain | Yes | `https://api.smith.langchain.com` | LangSmith API |
+| Env Var | Source | Required | Default | Purpose |
+|---------|--------|----------|---------|---------|
+| XAI_API_KEY | secretRef: xai-api-key | Yes | — | xAI Grok model access |
+| SUPABASE_URL | plain | Yes | — | Database endpoint |
+| SUPABASE_KEY | secretRef: supabase-key | Yes | — | Database service role key |
+| LANGSMITH_API_KEY | secretRef: langsmith-api-key | Yes | — | LangSmith observability |
+| LANGSMITH_ENDPOINT | plain | Yes | — | LangSmith API URL |
 | LANGSMITH_PROJECT | plain | Yes | `trade-nexus-backend` | Project name |
 | LANGSMITH_TRACING | plain | Yes | `true` | Enable tracing |
 | LONA_GATEWAY_URL | plain | Yes | `https://gateway.lona.agency` | Lona platform |
 | LONA_AGENT_ID | plain | Yes | `trade-nexus` | Agent identifier |
 | LONA_AGENT_NAME | plain | Yes | `Trade Nexus Orchestrator` | Display name |
-| LONA_AGENT_TOKEN | secretRef | Yes | `<token>` | Lona auth (30-day TTL) |
+| LONA_AGENT_TOKEN | secretRef: lona-agent-token | Yes | — | Lona auth (30-day TTL) |
 | LIVE_ENGINE_URL | plain | Yes | `https://live.lona.agency` | Live engine endpoint |
+| LIVE_ENGINE_SERVICE_API_KEY | secretRef: live-engine-service-api-key | Yes | — | Live engine auth |
 
-> **Note**: This table covers *deployed* Container App variables only. Local development requires additional variables (e.g., `LONA_AGENT_REGISTRATION_SECRET`, `LIVE_ENGINE_SERVICE_API_KEY`, `INITIAL_CAPITAL`, `MAX_POSITION_PCT`, `MAX_DRAWDOWN_PCT`, `TRADER_DATA_*`). See `backend/.env.example` for the full local dev set.
+> **Note**: This table covers *deployed* Container App variables only. Local development requires additional variables (e.g., `LONA_AGENT_REGISTRATION_SECRET`, `INITIAL_CAPITAL`, `MAX_POSITION_PCT`, `MAX_DRAWDOWN_PCT`, `TRADER_DATA_*`). See `backend/.env.example` for the full local dev set.
 
 ## Frontend (Vercel)
 
-| Env Var | Visibility | Required | Purpose |
-|---------|------------|----------|---------|
-| NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY | Public | Yes | Clerk client auth |
-| CLERK_SECRET_KEY | Server | Yes | Clerk server auth |
-| NEXT_PUBLIC_CLERK_SIGN_IN_URL | Public | Yes | `/sign-in` |
-| NEXT_PUBLIC_CLERK_SIGN_UP_URL | Public | Yes | `/sign-up` |
-| NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL | Public | Yes | `/dashboard` |
-| NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL | Public | Yes | `/dashboard` |
-| NEXT_PUBLIC_SUPABASE_URL | Public | Yes | Supabase endpoint |
-| NEXT_PUBLIC_SUPABASE_ANON_KEY | Public | Yes | Supabase anon key |
-| SUPABASE_SERVICE_ROLE_KEY | Server | Yes | Supabase admin key |
-| UPSTASH_REDIS_REST_URL | Server | Yes | Redis endpoint |
-| UPSTASH_REDIS_REST_TOKEN | Server | Yes | Redis auth |
-| XAI_API_KEY | Server | Yes | AI model access |
-| LANGSMITH_API_KEY | Server | Yes | Observability |
-| LANGSMITH_PROJECT | Server | Yes | Project name |
-| ML_BACKEND_URL | Server | Yes | Backend API |
-| LONA_GATEWAY_URL | Server | Yes | Lona platform |
-| LONA_AGENT_ID | Server | Yes | Agent ID |
-| LONA_AGENT_NAME | Server | Yes | Agent name |
-| LONA_AGENT_REGISTRATION_SECRET | Server | No | Registration secret |
-| LONA_AGENT_TOKEN | Server | Yes | Lona auth |
-| LONA_TOKEN_TTL_DAYS | Server | No | Token TTL (default 30) |
-| LIVE_ENGINE_URL | Server | Yes | Live engine |
-| LIVE_ENGINE_SERVICE_KEY | Server | Yes | Live engine auth |
+| Env Var | Visibility | Required | Default | Purpose |
+|---------|------------|----------|---------|---------|
+| NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY | Public | Yes | — | Clerk client auth |
+| CLERK_SECRET_KEY | Server | Yes | — | Clerk server auth |
+| NEXT_PUBLIC_CLERK_SIGN_IN_URL | Public | Yes | `/sign-in` | Sign-in path |
+| NEXT_PUBLIC_CLERK_SIGN_UP_URL | Public | Yes | `/sign-up` | Sign-up path |
+| NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL | Public | Yes | `/dashboard` | Post sign-in redirect |
+| NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL | Public | Yes | `/dashboard` | Post sign-up redirect |
+| NEXT_PUBLIC_SUPABASE_URL | Public | Yes | — | Supabase endpoint |
+| NEXT_PUBLIC_SUPABASE_ANON_KEY | Public | Yes | — | Supabase anon key |
+| SUPABASE_SERVICE_ROLE_KEY | Server | Yes | — | Supabase admin key |
+| UPSTASH_REDIS_REST_URL | Server | Yes | — | Redis endpoint |
+| UPSTASH_REDIS_REST_TOKEN | Server | Yes | — | Redis auth |
+| XAI_API_KEY | Server | Yes | — | AI model access |
+| LANGSMITH_API_KEY | Server | Yes | — | Observability |
+| LANGSMITH_PROJECT | Server | Yes | `trade-nexus` | Project name |
+| ML_BACKEND_URL | Server | Yes | `http://localhost:8000` | Backend API |
+| LONA_GATEWAY_URL | Server | Yes | `https://gateway.lona.agency` | Lona platform |
+| LONA_AGENT_ID | Server | Yes | `trade-nexus` | Agent ID |
+| LONA_AGENT_NAME | Server | Yes | `Trade Nexus Orchestrator` | Agent name |
+| LONA_AGENT_REGISTRATION_SECRET | Server | No | — | Registration secret |
+| LONA_AGENT_TOKEN | Server | Yes | — | Lona auth |
+| LONA_TOKEN_TTL_DAYS | Server | No | `30` | Token TTL |
+| LIVE_ENGINE_URL | Server | Yes | `https://live.lona.agency` | Live engine |
+| LIVE_ENGINE_SERVICE_KEY | Server | Yes | — | Live engine auth |
+
+## trading-cli (External CLI)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PLATFORM_API_BASE_URL` | Yes (non-local) | `http://localhost:3000` | Must point to `https://api-nexus.lona.agency` in production |
+
+## CI/CD (GitHub Actions)
+
+| Secret | Used In | Description |
+|--------|---------|-------------|
+| `AZURE_CREDENTIALS` | `backend-deploy.yml` | SP OIDC federation JSON |
+| `ACR_LOGIN_SERVER` | `backend-deploy.yml` | `tradenexusacr.azurecr.io` |
+| `ACR_USERNAME` | `backend-deploy.yml` | ACR admin user (**remove after MI migration**) |
+| `ACR_PASSWORD` | `backend-deploy.yml` | ACR admin password (**remove after MI migration**) |
+| `NPM_TOKEN` | `publish-sdk.yml` | npm publishing |
+
+## Domain References — Canonical Values
+
+| Purpose | Old value | New value |
+|---------|-----------|-----------|
+| Frontend | *(Vercel default)* | `https://trade-nexus.lona.agency` |
+| Backend API | `https://api.trade-nexus.io` | `https://api-nexus.lona.agency` |
+| Docs portal | *(none)* | `https://docs-nexus.lona.agency` |
+| Schema IDs | `https://trade-nexus.io/schemas/...` | `https://trade-nexus.lona.agency/schemas/...` |
+| Ops scripts | `trade-nexus-backend.whitecliff-*.azurecontainerapps.io` | `api-nexus.lona.agency` |
 
 ## Local Development
 
@@ -67,9 +94,7 @@
 
 | Issue | Feature | Required Env Vars | Status |
 |-------|---------|-------------------|--------|
-| #226 | Validation storage adapters | SUPABASE_URL, SUPABASE_KEY | **Available** — no new vars needed |
-| #229 | Baseline replay + gates | No new env vars (uses existing Supabase) | **N/A** |
+| #226 | Validation storage adapters | SUPABASE_URL, SUPABASE_KEY | **Available** |
+| #229 | Baseline replay + gates | No new env vars | **N/A** |
 | #230 | Web review lane | Frontend Supabase vars | **Available** |
 | #231 | CLI validation commands | Backend env vars | **Available** |
-
-**Conclusion**: All environment variables needed for the validation program (#226–#231) are already provisioned. No new cloud resource provisioning is required for these issues.

--- a/docs/ops/IAM_SECRETS_OWNERSHIP.md
+++ b/docs/ops/IAM_SECRETS_OWNERSHIP.md
@@ -1,29 +1,72 @@
 # Trade Nexus — IAM & Secrets Ownership
 
 > **Owner**: Team VOps
-> **Last updated**: 2026-02-18
+> **Last updated**: 2026-02-21
 > **Governance**: Only VOps provisions, rotates, or modifies secrets and IAM roles.
+
+## Service Principal
+
+| Property | Value |
+|----------|-------|
+| Display name | `trade-nexus-github` |
+| App ID | `7b72321f-4018-4344-80ce-d89c7fd5ad1f` |
+| Object ID | `686cfecc-30f6-4302-9c35-7a6d36cb4d11` |
+| Auth method | OIDC Federation (GitHub Actions) |
+| Credentials | None (no passwords/certificates — OIDC only) |
+| Role | Contributor on `trade-nexus` resource group |
+| Risk | Over-provisioned — should scope to AcrPush + Container Apps only |
+
+## Managed Identity
+
+| Property | Value |
+|----------|-------|
+| Type | System-assigned (Container App) |
+| Principal ID | `6759fd3c-1516-4d84-ac79-43668cd8f17d` |
+| Tenant ID | `478adfc8-a82d-4cc9-b064-32ca91c7db7a` |
+| Role | AcrPull on `tradenexusacr` |
+
+## Key Vault
+
+| Property | Value |
+|----------|-------|
+| Name | `trade-nexus-kv` |
+| URI | `https://trade-nexus-kv.vault.azure.net/` |
+| Location | West Europe |
+| Auth | RBAC (no access policies) |
+| Soft delete | 90 days |
+| Public access | Enabled |
+| Status | Created — secrets not yet migrated from Container App env vars |
+
+## RBAC Gap: Key Vault Access
+
+**Issue**: `trade-nexus-kv` exists but the CLI user lacks `Microsoft.KeyVault/vaults/secrets/readMetadata/action`.
+
+**Remediation**: Run `.ops/scripts/fix-kv-rbac.sh` (prepared, not yet executed).
+
+**Impact**: Cannot list or manage Key Vault secrets from CLI. Container App secrets are managed separately and are unaffected.
 
 ## Secrets Inventory
 
 | Secret | Location(s) | Owner | Rotation | Classification |
 |--------|-------------|-------|----------|----------------|
-| xai-api-key | Container App secret, backend .env | VOps | Manual | API credential |
-| supabase-key | Container App secret, backend .env | VOps | Manual | DB credential |
-| langsmith-api-key | Container App secret, backend .env | VOps | Manual | Observability |
-| lona-agent-token | Container App secret, backend .env | VOps | 30-day TTL | Service auth |
+| xai-api-key | Container App secret | VOps | 90 days | API credential |
+| supabase-key | Container App secret | VOps | On compromise | DB credential |
+| langsmith-api-key | Container App secret | VOps | 90 days | Observability |
+| lona-agent-token | Container App secret | VOps | 30-day TTL | Service auth |
+| live-engine-service-api-key | Container App secret | VOps | On compromise | Service auth |
 | ACR pull credential | Container App secret (managed) | VOps | Auto-managed | Registry |
-| AZURE_CREDENTIALS | GitHub Actions secret | VOps | Annual | CI/CD SP |
+| AZURE_CREDENTIALS | GitHub Actions secret | VOps | N/A (OIDC) | CI/CD SP |
 | ACR_LOGIN_SERVER | GitHub Actions secret | VOps | Static | Registry |
-| ACR_USERNAME | GitHub Actions secret | VOps | Annual | Registry |
-| ACR_PASSWORD | GitHub Actions secret | VOps | Annual | Registry |
+| ACR_USERNAME | GitHub Actions secret | VOps | **Remove after MI migration** | Registry (legacy) |
+| ACR_PASSWORD | GitHub Actions secret | VOps | **Remove after MI migration** | Registry (legacy) |
 | NPM_TOKEN | GitHub Actions secret | VOps | Annual | SDK publishing |
-| CLERK_SECRET_KEY | Vercel env var | VOps | Manual | Auth |
+| CLERK_SECRET_KEY | Vercel env var | VOps | On compromise | Auth |
 | NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY | Vercel env var | VOps | Static | Auth (public) |
-| SUPABASE_SERVICE_ROLE_KEY | Vercel env var | VOps | Manual | DB admin |
+| SUPABASE_SERVICE_ROLE_KEY | Vercel env var | VOps | On compromise | DB admin |
 | NEXT_PUBLIC_SUPABASE_ANON_KEY | Vercel env var | VOps | Static | DB (public) |
 | UPSTASH_REDIS_REST_URL | Vercel env var | VOps | Static | Cache |
-| UPSTASH_REDIS_REST_TOKEN | Vercel env var | VOps | Manual | Cache |
+| UPSTASH_REDIS_REST_TOKEN | Vercel env var | VOps | On compromise | Cache |
+| LIVE_ENGINE_SERVICE_KEY | Vercel env var | VOps | On compromise | Service auth |
 
 ## IAM Roles
 
@@ -34,20 +77,61 @@
 | GitHub Actions SP | Service Principal | trade-nexus RG | ACR push, Container App deploy | Active |
 | Supabase service role | API key | Supabase project | Full DB (bypasses RLS) | Active |
 
-## RBAC Gap: Key Vault Access
+## Credential Rotation Status
 
-**Issue**: `trade-nexus-kv` exists but the CLI user lacks `Microsoft.KeyVault/vaults/secrets/readMetadata/action`.
+| Secret | Last Rotated | Next Due | Status |
+|--------|-------------|----------|--------|
+| OIDC federation | N/A | N/A | No rotation needed (federated) |
+| ACR admin creds | N/A | **Remove** | Pending MI migration in CI/CD |
+| xai-api-key | Unknown | TBD | Document initial rotation |
+| supabase-key | Unknown | On compromise | Supabase dashboard |
+| langsmith-api-key | Unknown | TBD | Document initial rotation |
+| lona-agent-token | Auto (TTL) | 30-day cycle | Self-rotating via TTL |
+| live-engine-service-api-key | 2026-02-21 | On compromise | Just provisioned |
 
-**Error**: `Caller is not authorized to perform action on resource`
+## Break-Glass Procedures
 
-**Remediation**: Run `.ops/scripts/fix-kv-rbac.sh` (prepared, not yet executed).
+### Compromised API Key (xai / langsmith / lona / live-engine)
+1. Revoke at provider
+2. Generate new key
+3. `az containerapp secret set --name trade-nexus-backend --resource-group trade-nexus --secrets <name>=<new-value>`
+4. Restart active revision
+5. Verify `/health` at `https://api-nexus.lona.agency/health`
 
-**Impact**: Cannot list or manage Key Vault secrets from CLI. Container App secrets are managed separately and are unaffected.
+### Compromised Service Principal
+1. `az ad sp credential reset --id 7b72321f-4018-4344-80ce-d89c7fd5ad1f`
+2. Update `AZURE_CREDENTIALS` GitHub secret
+3. Trigger test deployment
+4. Verify CI/CD pipeline
+
+### Compromised Supabase Key
+1. Rotate in Supabase Dashboard
+2. Update Container App secret + Vercel env
+3. Restart services
+4. Verify data access
+
+### Emergency Shutdown
+1. `az containerapp update --name trade-nexus-backend --resource-group trade-nexus --max-replicas 0`
+2. Traffic stops immediately
+3. Verify `api-nexus.lona.agency` returns 503
 
 ## Governance Rules
 
 1. **VOps-only mutations**: All Azure/Supabase/Vercel provisioning, IAM changes, and secret rotation must be executed by VOps.
-2. **Dev team consumption**: Dev lanes (V1-V4) receive env contract docs and `.env.example` templates. They never receive raw credentials.
+2. **Dev team consumption**: Dev lanes receive env contract docs and `.env.example` templates. They never receive raw credentials.
 3. **No hardcoded secrets**: All secret references use environment variables or secret refs.
 4. **Rotation protocol**: Manual rotation requires VOps ticket in #223, update in all locations (Container App, GitHub, Vercel).
 5. **Audit trail**: All secret changes documented in this file and PR history.
+
+## Open Items
+
+| # | Item | Priority | Owner |
+|---|------|----------|-------|
+| 1 | Scope SP roles (remove broad Contributor) | Medium | Platform Ops |
+| 2 | Migrate CI/CD from ACR admin to SP-based login | Medium | Platform Ops |
+| 3 | Disable ACR admin user after CI/CD migration | Medium | Platform Ops |
+| 4 | Migrate Container App secrets to Key Vault references | Low | Platform Ops |
+| 5 | Add RLS to 5 `kb_*` Supabase tables | High | Data Team |
+| 6 | Restrict Key Vault public access | Low | Platform Ops |
+| 7 | Add CORS policy to Container App (restrict to `trade-nexus.lona.agency`) | Medium | Platform Ops |
+| 8 | Fix Key Vault RBAC for CLI user | Medium | Platform Ops |

--- a/docs/ops/RESOURCE_MAP.md
+++ b/docs/ops/RESOURCE_MAP.md
@@ -1,39 +1,72 @@
 # Trade Nexus — Resource Map
 
 > **Owner**: Team VOps (Cloud DevOps)
-> **Last updated**: 2026-02-18
-> **Scope**: All cloud resources for the trade-nexus validation program
+> **Last updated**: 2026-02-21
+> **Scope**: All cloud resources for the trade-nexus platform
+
+## Domain Map
+
+| Domain | Service | Host | TLS | Status |
+|--------|---------|------|-----|--------|
+| `trade-nexus.lona.agency` | Frontend (Next.js) | Vercel | Vercel auto | Live |
+| `api-nexus.lona.agency` | Backend API (FastAPI) | Azure Container Apps | Azure managed cert | Live |
+| `docs-nexus.lona.agency` | Docs portal | Vercel | Vercel auto | Live |
+| `live.lona.agency` | Live Engine (Next.js) | Vercel | Vercel auto | Live |
+| `gateway.lona.agency` | Lona Gateway | Azure | Azure | Live |
+
+## DNS Records
+
+| Type | Name | Value | Provider |
+|------|------|-------|----------|
+| CNAME | `trade-nexus` | `545b87b784bec4d9.vercel-dns-016.com` | Vercel |
+| CNAME | `api-nexus` | `trade-nexus-backend.whitecliff-198cd26a.westeurope.azurecontainerapps.io` | Azure |
+| TXT | `asuid.api-nexus` | `56B5FC9FD245C8A5B4B3A9E9F26529931113F92541131B2CE8AEEAA5FC2940C1` | Azure (verification) |
+| CNAME | `docs-nexus` | `afe58594fb5d5a66.vercel-dns-016.com` | Vercel |
+| CNAME | `live` | `833303cf61168e1b.vercel-dns-016.com` | Vercel |
+| A | `gateway` | `4.209.43.158` | Azure |
+
+### Certificate
+
+| Domain | Certificate | Binding |
+|--------|-------------|---------|
+| `api-nexus.lona.agency` | `mc-trade-nexus-en-api-nexus-lona-a-2001` | SNI enabled |
 
 ## Azure Resources
 
 | Resource | Type | Resource Group | Location | FQDN / Endpoint | VOps Owned |
 |----------|------|----------------|----------|------------------|------------|
-| trade-nexus-backend | Container App | trade-nexus | westeurope | trade-nexus-backend.whitecliff-198cd26a.westeurope.azurecontainerapps.io | Yes |
+| trade-nexus-backend | Container App | trade-nexus | westeurope | api-nexus.lona.agency (custom domain) | Yes |
 | trade-nexus-env | Container App Environment | trade-nexus | westeurope | — | Yes |
 | tradenexusacr | Container Registry (Basic) | trade-nexus | westeurope | tradenexusacr.azurecr.io | Yes |
-| trade-nexus-kv | Key Vault | trade-nexus | westeurope | — | Yes (RBAC gap — see IAM doc) |
-| rg-openclaw-trader | Resource Group | — | westeurope | — | Related, not primary |
+| trade-nexus-kv | Key Vault | trade-nexus | westeurope | trade-nexus-kv.vault.azure.net | Yes (RBAC gap — see IAM doc) |
+| workspace-tradenexusrzM6 | Log Analytics | trade-nexus | westeurope | — | Yes |
 
 ## Container App Configuration
 
 | Property | Value |
 |----------|-------|
 | Image | tradenexusacr.azurecr.io/trade-nexus-backend:\<commit-sha\> |
+| Target port | 8000 |
+| External ingress | Yes |
+| HTTPS enforced | Yes (`allowInsecure: false`) |
 | Min replicas | 0 (scale-to-zero) |
 | Max replicas | 10 |
-| Active revision | trade-nexus-backend--0000039 (100% traffic) |
+| Resources | 2 CPU, 4Gi RAM, 8Gi ephemeral |
+| Cold-start | ~96s measured (2026-02-16) |
+| Custom domain | `api-nexus.lona.agency` (SNI, managed cert) |
 | Health check | GET /health (uvicorn, port 8000) |
 | Deployment trigger | Push to main with backend/** changes |
 
 ## Container App Secrets
 
-| Secret Name | Purpose |
-|-------------|---------|
-| xai-api-key | xAI Grok API credential |
-| supabase-key | Supabase service role key |
-| langsmith-api-key | LangSmith observability token |
-| lona-agent-token | Lona Gateway auth (30-day TTL) |
-| tradenexusacrazurecrio-tradenexusacr | ACR pull credential (managed) |
+| Secret Name | Env Var | Purpose |
+|-------------|---------|---------|
+| xai-api-key | XAI_API_KEY | xAI Grok API credential |
+| supabase-key | SUPABASE_KEY | Supabase service role key |
+| langsmith-api-key | LANGSMITH_API_KEY | LangSmith observability token |
+| lona-agent-token | LONA_AGENT_TOKEN | Lona Gateway auth (30-day TTL) |
+| live-engine-service-api-key | LIVE_ENGINE_SERVICE_API_KEY | Live Engine service auth |
+| tradenexusacrazurecrio-tradenexusacr | — | ACR pull credential (managed) |
 
 ## Container App Environment Variables
 
@@ -51,27 +84,37 @@
 | LONA_AGENT_NAME | plain | Agent display name |
 | LONA_AGENT_TOKEN | secretRef: lona-agent-token | Lona auth |
 | LIVE_ENGINE_URL | plain | Live engine endpoint |
+| LIVE_ENGINE_SERVICE_API_KEY | secretRef: live-engine-service-api-key | Live engine auth |
+
+## Vercel Projects
+
+| Project | Domain | Purpose |
+|---------|--------|---------|
+| trade-nexus (frontend) | `trade-nexus.lona.agency` | Dashboard, API routes, Clerk auth |
+| trade-nexus-docs | `docs-nexus.lona.agency` | Documentation portal |
+| live-engine | `live.lona.agency` | Market data, paper/live trading |
 
 ## External Services
 
 | Service | Purpose | Endpoint | VOps Owned |
 |---------|---------|----------|------------|
-| Supabase | PostgreSQL 15 + RLS | Project dashboard | Yes (provisioning) |
-| Vercel (frontend) | Next.js 16 hosting | Auto-deploy from main | Yes (env vars) |
+| Supabase | PostgreSQL 15 + RLS | zonuytrkkvqfyehiviot.supabase.co | Yes (provisioning) |
+| Vercel (frontend) | Next.js 16 hosting | trade-nexus.lona.agency | Yes (env vars) |
+| Vercel (docs) | Docusaurus hosting | docs-nexus.lona.agency | Yes (env vars) |
 | Vercel (live-engine) | Market data + trading | live.lona.agency | Yes (env vars) |
 | Clerk | Authentication | clerk.com dashboard | Yes (keys) |
-| Upstash Redis | Distributed cache | REST API | Yes (tokens) |
-| LangSmith | AI observability | smith.langchain.com | Yes (API key) |
+| Upstash Redis | Distributed cache | tops-quetzal-35882.upstash.io | Yes (tokens) |
+| LangSmith | AI observability | eu.api.smith.langchain.com | Yes (API key) |
 | Lona Gateway | Strategy/backtest platform | gateway.lona.agency | Yes (agent token) |
 
 ## GitHub Actions Secrets
 
 | Secret | Purpose | Rotation |
 |--------|---------|----------|
-| AZURE_CREDENTIALS | Azure AD service principal | Annual |
+| AZURE_CREDENTIALS | Azure AD service principal (OIDC) | N/A (federated) |
 | ACR_LOGIN_SERVER | tradenexusacr.azurecr.io | Static |
-| ACR_USERNAME | Registry service account | Annual |
-| ACR_PASSWORD | Registry access token | Annual |
+| ACR_USERNAME | Registry service account | **Remove after MI migration** |
+| ACR_PASSWORD | Registry access token | **Remove after MI migration** |
 | NPM_TOKEN | npm publishing (SDK) | Annual |
 
 ## CI/CD Workflows
@@ -79,9 +122,9 @@
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | backend-deploy.yml | Push to main (backend/**) | Build, push ACR, deploy Container App |
-| contracts-governance.yml | All `pull_request` events; push to `main` when contract/backend/docs paths change | OpenAPI lint, contract tests, replay preflight, review gates |
-| docs-governance.yml | All `pull_request` events; push to `main` when `docs/**`, `docs/portal-site/**`, `scripts/docs/**`, `CONTRIBUTING.md`, or `.github/workflows/docs-governance.yml` changes | Docusaurus build, link validation, frontmatter and stale-ref checks |
-| llm-package-governance.yml | All `pull_request` events; push to `main` when docs/scripts paths change | LLM package generation, validation, and committed-artifact drift check |
+| contracts-governance.yml | All `pull_request` events; push to `main` when contract/backend/docs paths change | OpenAPI lint, contract tests, replay preflight |
+| docs-governance.yml | All `pull_request` events; push to `main` when docs paths change | Docusaurus build, link validation |
+| llm-package-governance.yml | All `pull_request` events; push to `main` when docs/scripts paths change | LLM package generation and drift check |
 | publish-sdk.yml | Manual or sdk-v* tag | SDK regeneration and npm publish |
 
 ## Operational Scripts
@@ -92,6 +135,18 @@
 | ops-drill.sh | 5-scenario operational readiness | .ops/scripts/ |
 | rollback.sh | Revision rollback with validation | .ops/scripts/ |
 | fix-kv-rbac.sh | Key Vault RBAC remediation | .ops/scripts/ |
+
+## Managed Identity
+
+| Identity | Principal ID | Roles |
+|----------|-------------|-------|
+| System-assigned (Container App) | `6759fd3c-1516-4d84-ac79-43668cd8f17d` | AcrPull on `tradenexusacr` |
+
+## Service Principal
+
+| Name | App ID | Auth | Roles |
+|------|--------|------|-------|
+| `trade-nexus-github` | `7b72321f-4018-4344-80ce-d89c7fd5ad1f` | OIDC federation (GitHub) | Contributor on `trade-nexus` RG |
 
 ## SLO Targets
 


### PR DESCRIPTION
## Summary
- Bind `api-nexus.lona.agency` custom domain + Azure managed TLS cert to Container App
- Replace all stale `trade-nexus.io` and Azure FQDN (`trade-nexus-backend.whitecliff-*.azurecontainerapps.io`) defaults with `api-nexus.lona.agency` across 7 files
- Add `docs/ops/RESOURCE_MAP.md` — full domain map, DNS records, Azure resources, Vercel projects, certificates
- Add `docs/ops/ENV_MATRIX.md` — complete env var inventory for frontend, backend, CLI, and CI/CD
- Add `docs/ops/IAM_SECRETS_OWNERSHIP.md` — SP, managed identity, Key Vault, secret rotation status, break-glass procedures

## Validation evidence

| Domain | HTTPS | Status |
|--------|-------|--------|
| `trade-nexus.lona.agency` | HTTP/2 200 | Vercel auto TLS |
| `api-nexus.lona.agency` | `{"status":"healthy"}` | Azure managed cert (SNI) |
| `docs-nexus.lona.agency` | HTTP/2 200 | Vercel auto TLS |

## Files changed

**Domain alignment (7 files):**
- `.ops/scripts/smoke-check.sh` — default URL
- `.ops/scripts/ops-drill.sh` — FQDN variable
- `.ops/scripts/rollback.sh` — FQDN variable
- `sdk/typescript/src/runtime.ts` — BASE_PATH
- `docs/architecture/specs/platform-api.openapi.yaml` — server URL
- `contracts/schemas/risk-policy.v1.schema.json` — $id
- `docs/architecture.md` — backend URL

**New ops docs (3 files):**
- `docs/ops/RESOURCE_MAP.md`
- `docs/ops/ENV_MATRIX.md`
- `docs/ops/IAM_SECRETS_OWNERSHIP.md`

## Test plan
- [x] DNS resolves for all 3 domains (`dig +short`)
- [x] HTTPS 200 on `trade-nexus.lona.agency`
- [x] HTTPS healthy on `api-nexus.lona.agency/health`
- [x] HTTPS 200 on `docs-nexus.lona.agency`
- [x] No stale `trade-nexus.io` defaults in deployment config
- [ ] Clerk auth callback verification (needs dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation and default URL updates; runtime impact is limited to ops scripts pointing at a new domain (risk is misconfiguration rather than code/logic changes).
> 
> **Overview**
> Migrates hardcoded domain defaults from the Azure Container Apps FQDN / `trade-nexus.io` to the canonical `*.lona.agency` set, including ops scripts (`ops-drill.sh`, `rollback.sh`, `smoke-check.sh`), architecture docs, OpenAPI examples (CDN download URLs), and JSON Schema `$id` values.
> 
> Expands ops documentation to include a consolidated environment variable/secret contract and a detailed resource/IAM inventory (domains + DNS records, Container App configuration/secrets including `LIVE_ENGINE_SERVICE_API_KEY`, service principal/managed identity details, rotation status, and break-glass procedures).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a0c751eabd10a7c4cc8fdf96b5e0abab2539402. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the domain migration from `api.trade-nexus.io` and Azure-generated FQDN to the custom `lona.agency` domain family and adds comprehensive operational documentation.

**Domain alignment (7 files):**
- Ops scripts (smoke-check, ops-drill, rollback) now default to `api-nexus.lona.agency`
- TypeScript SDK `BASE_PATH` updated to match new domain
- OpenAPI spec production server URL aligned
- JSON schema `$id` migrated to `trade-nexus.lona.agency`
- Architecture docs reference updated

**New ops documentation (3 files):**
- `RESOURCE_MAP.md` — complete domain map, DNS records, Azure resource inventory, certificate bindings, external service endpoints
- `ENV_MATRIX.md` — environment variable catalog for frontend (Vercel), backend (Azure Container Apps), CLI, and CI/CD with canonical domain references
- `IAM_SECRETS_OWNERSHIP.md` — service principal, managed identity, Key Vault status, secret ownership matrix, rotation policies, break-glass procedures, open security items

**Other changes:**
- Gate5 runbook entry criteria updated to allow explicit waiver of #80 dependency
- LLM documentation metadata regenerated to reflect runbook changes

All domain references are consistent. The old domains (`api.trade-nexus.io`, Azure FQDN) only appear in ENV_MATRIX.md and RESOURCE_MAP.md as historical references in migration tables.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — documentation and configuration updates with thorough validation evidence
- All changes are non-breaking configuration updates and new documentation. Domain migration is complete and consistent across all 7 updated files. The new custom domain is already live and validated per the PR description. The three new ops docs provide valuable operational context with no code execution risk.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .ops/scripts/smoke-check.sh | Updated default URL to new custom domain `api-nexus.lona.agency` |
| .ops/scripts/ops-drill.sh | Replaced Azure FQDN with custom domain for ops drill validations |
| .ops/scripts/rollback.sh | Updated FQDN variable to use custom domain for rollback operations |
| sdk/typescript/src/runtime.ts | Changed BASE_PATH from `api.trade-nexus.io` to `api-nexus.lona.agency` |
| docs/architecture/specs/platform-api.openapi.yaml | Updated production server URL to new custom domain |
| contracts/schemas/risk-policy.v1.schema.json | Updated JSON schema $id to use `trade-nexus.lona.agency` domain |
| docs/ops/RESOURCE_MAP.md | New comprehensive resource map documenting domains, DNS, Azure resources, certificates |
| docs/ops/ENV_MATRIX.md | New environment variable inventory for frontend, backend, CLI, and CI/CD |
| docs/ops/IAM_SECRETS_OWNERSHIP.md | New IAM documentation with secret ownership, rotation policies, break-glass procedures |

</details>


</details>


<sub>Last reviewed commit: f8ffab8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->