### PR TITLE
fix(auth): enforce runtime-key namespace on validation auth

### DIFF
--- a/backend/src/platform_api/auth_identity.py
+++ b/backend/src/platform_api/auth_identity.py
@@ -16,6 +16,7 @@ from src.platform_api.errors import PlatformAPIError
 
 _JWT_SECRET_ENV = "PLATFORM_AUTH_JWT_HS256_SECRET"
 _JWT_TIME_LEEWAY_SECONDS = 15
+_RUNTIME_BOT_KEY_PREFIX = "tnx.bot"
 
 
 def _non_empty(value: str | None) -> str | None:
@@ -206,7 +207,9 @@ def _claim_value(payload: dict[str, Any], *, keys: tuple[str, ...]) -> str | Non
     return None
 
 
-def _identity_from_api_key(api_key: str) -> AuthenticatedIdentity:
+def _identity_from_api_key(api_key: str) -> AuthenticatedIdentity | None:
+    if not api_key.startswith(f"{_RUNTIME_BOT_KEY_PREFIX}."):
+        return None
     digest = hashlib.sha256(api_key.encode("utf-8")).hexdigest()
     return AuthenticatedIdentity(
         tenant_id=f"tenant-apikey-{digest[:12]}",

--- a/backend/tests/contracts/test_platform_api_v2_handlers.py
+++ b/backend/tests/contracts/test_platform_api_v2_handlers.py
@@ -521,6 +521,32 @@ def test_validation_v2_requires_authentication() -> None:
     assert payload["error"]["code"] == "AUTH_UNAUTHORIZED"
 
 
+def test_validation_v2_rejects_arbitrary_non_runtime_api_key() -> None:
+    client = _client()
+    response = client.get(
+        "/v2/validation-runs",
+        headers={
+            "X-Request-Id": "req-v2-validation-random-key-001",
+            "X-API-Key": "totally-random-key",
+        },
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "AUTH_UNAUTHORIZED"
+
+
+def test_validation_v2_rejects_malformed_runtime_api_key() -> None:
+    client = _client()
+    response = client.get(
+        "/v2/validation-runs",
+        headers={
+            "X-Request-Id": "req-v2-validation-malformed-runtime-key-001",
+            "X-API-Key": "tnx.bot.invalid",
+        },
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "BOT_API_KEY_INVALID"
+
+
 def test_validation_v2_rejects_unsigned_jwt_claims() -> None:
     client = _client()
     unsigned_token = (

--- a/backend/tests/contracts/test_runtime_openapi_contract_v2.py
+++ b/backend/tests/contracts/test_runtime_openapi_contract_v2.py
@@ -398,10 +398,15 @@ def test_openapi_v2_runtime_status_codes() -> None:
 
 def test_validation_v2_write_routes_require_idempotency_key_header() -> None:
     client = TestClient(app)
+    validation_headers = _auth_headers(
+        request_id="req-runtime-v2-idempotency-missing-001",
+        tenant_id="tenant-runtime-v2-idempotency-missing",
+        user_id="user-runtime-v2-idempotency-missing",
+    )
 
     create_run = client.post(
         "/v2/validation-runs",
-        headers=HEADERS,
+        headers=validation_headers,
         json={
             "strategyId": "strat-001",
             "providerRefId": "lona-strategy-123",
@@ -425,7 +430,7 @@ def test_validation_v2_write_routes_require_idempotency_key_header() -> None:
 
     review = client.post(
         "/v2/validation-runs/valrun-missing/review",
-        headers=HEADERS,
+        headers=validation_headers,
         json={
             "reviewerType": "agent",
             "decision": "pass",
@@ -438,21 +443,21 @@ def test_validation_v2_write_routes_require_idempotency_key_header() -> None:
 
     render = client.post(
         "/v2/validation-runs/valrun-missing/render",
-        headers=HEADERS,
+        headers=validation_headers,
         json={"format": "html"},
     )
     assert render.status_code == 422
 
     review_comment = client.post(
         "/v2/validation-review/runs/valrun-missing/comments",
-        headers=HEADERS,
+        headers=validation_headers,
         json={"body": "Missing idempotency key should fail."},
     )
     assert review_comment.status_code == 422
 
     review_decision = client.post(
         "/v2/validation-review/runs/valrun-missing/decisions",
-        headers=HEADERS,
+        headers=validation_headers,
         json={
             "action": "reject",
             "decision": "fail",
@@ -463,21 +468,21 @@ def test_validation_v2_write_routes_require_idempotency_key_header() -> None:
 
     review_render = client.post(
         "/v2/validation-review/runs/valrun-missing/renders",
-        headers=HEADERS,
+        headers=validation_headers,
         json={"format": "html"},
     )
     assert review_render.status_code == 422
 
     baseline = client.post(
         "/v2/validation-baselines",
-        headers=HEADERS,
+        headers=validation_headers,
         json={"runId": "valrun-missing", "name": "missing"},
     )
     assert baseline.status_code == 422
 
     replay = client.post(
         "/v2/validation-regressions/replay",
-        headers=HEADERS,
+        headers=validation_headers,
         json={
             "baselineId": "valbase-missing",
             "candidateRunId": "valrun-missing",
@@ -487,14 +492,14 @@ def test_validation_v2_write_routes_require_idempotency_key_header() -> None:
 
     register_invite = client.post(
         "/v2/validation-bots/registrations/invite-code",
-        headers=HEADERS,
+        headers=validation_headers,
         json={"inviteCode": "INV-TRIAL-00000001", "botName": "missing"},
     )
     assert register_invite.status_code == 422
 
     register_partner = client.post(
         "/v2/validation-bots/registrations/partner-bootstrap",
-        headers=HEADERS,
+        headers=validation_headers,
         json={
             "partnerKey": "pk_live_partner_01234567",
             "partnerSecret": "ps_live_partner_89abcdef",
@@ -506,34 +511,34 @@ def test_validation_v2_write_routes_require_idempotency_key_header() -> None:
 
     rotate_bot_key = client.post(
         "/v2/validation-bots/bot-missing/keys/rotate",
-        headers=HEADERS,
+        headers=validation_headers,
         json={"reason": "missing idempotency key"},
     )
     assert rotate_bot_key.status_code == 422
 
     revoke_bot_key = client.post(
         "/v2/validation-bots/bot-missing/keys/botkey-missing/revoke",
-        headers=HEADERS,
+        headers=validation_headers,
         json={"reason": "missing idempotency key"},
     )
     assert revoke_bot_key.status_code == 422
 
     create_share_invite = client.post(
         "/v2/validation-sharing/runs/valrun-missing/invites",
-        headers=HEADERS,
+        headers=validation_headers,
         json={"email": "reviewer@example.com"},
     )
     assert create_share_invite.status_code == 422
 
     revoke_share_invite = client.post(
         "/v2/validation-sharing/invites/vinvite-missing/revoke",
-        headers=HEADERS,
+        headers=validation_headers,
     )
     assert revoke_share_invite.status_code == 422
 
     accept_share_invite = client.post(
         "/v2/validation-sharing/invites/vinvite-missing/accept",
-        headers=HEADERS,
+        headers=validation_headers,
         json={"acceptedEmail": "reviewer@example.com"},
     )
     assert accept_share_invite.status_code == 422


### PR DESCRIPTION
## Summary
- enforce runtime API-key namespace gating in validation identity resolution (only `tnx.bot.*` qualifies for API-key auth fallback)
- keep verified JWT identity canonical and API key secondary
- reject arbitrary non-runtime API keys on validation endpoints with `401 AUTH_UNAUTHORIZED`
- keep malformed runtime key path explicit (`401 BOT_API_KEY_INVALID`)

## Why
Issue #319 shows a P0 auth bypass path where arbitrary non-empty API keys were accepted on validation endpoints.

## Changes
- `backend/src/platform_api/auth_identity.py`
  - `_identity_from_api_key` now returns identity only for `tnx.bot.*` namespace keys
- `backend/tests/contracts/test_auth_identity_runtime.py`
  - added unit regressions for namespace gating + JWT precedence
- `backend/tests/contracts/test_platform_api_v2_handlers.py`
  - added runtime regressions for non-runtime key rejection and malformed runtime key rejection
- `backend/tests/contracts/test_runtime_openapi_contract_v2.py`
  - updated idempotency contract test to use verified validation auth headers (still asserts missing idempotency => 422)

## Validation
- `uv run --extra dev pytest tests/contracts/test_auth_identity_runtime.py tests/contracts/test_platform_api_v2_handlers.py`
- `uv run --extra dev pytest tests/contracts/test_runtime_openapi_contract_v2.py tests/contracts/test_validation_identity_sharing_runtime.py tests/contracts/test_auth_identity_runtime.py tests/contracts/test_platform_api_v2_handlers.py`
- `uv run --extra dev pytest tests/contracts/test_validation_identity_sharing_migration_parity_contract.py`
- manual reproduction from #319 now returns:
  - `api-key-status 401 AUTH_UNAUTHORIZED`
  - `unsigned-jwt-status 401 AUTH_UNAUTHORIZED`

Fixes #319
Refs #320

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validation authentication/identity resolution; while the change is small and well-tested, mistakes could inadvertently block legitimate runtime API-key access or alter error semantics.
> 
> **Overview**
> Fixes an auth bypass on validation endpoints by gating API-key-derived identities to the runtime bot namespace only (API keys must start with `tnx.bot.`), otherwise treating the request as unauthenticated.
> 
> Adds contract/regression coverage to ensure arbitrary API keys return `401 AUTH_UNAUTHORIZED`, malformed runtime bot keys continue to raise `401 BOT_API_KEY_INVALID`, and verified JWT identity remains preferred over API-key fallback. Updates the v2 idempotency-key contract test to use verified validation auth headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bdd0490e222f08fa915c7853d8637a39725a1d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a P0 authentication bypass where arbitrary non-empty API keys were incorrectly accepted on validation endpoints. The fix enforces runtime bot namespace gating by requiring API keys to start with `tnx.bot.` prefix in `_identity_from_api_key`, returning `None` for non-runtime keys (which triggers `401 AUTH_UNAUTHORIZED`). Verified JWT identity remains preferred over API key fallback.

**Key changes:**
- `backend/src/platform_api/auth_identity.py:210-212` - Added namespace check returning `None` for non-`tnx.bot.*` keys
- Added comprehensive regression tests covering arbitrary key rejection, runtime key acceptance, and JWT precedence
- Updated idempotency contract test to use verified auth headers instead of relying on API key fallback
- Malformed runtime keys (e.g., `tnx.bot.invalid`) still correctly return `401 BOT_API_KEY_INVALID` via downstream validation service

**Security impact:**
The fix properly gates API key authentication to runtime bot keys only, closing the bypass path while maintaining backward compatibility for legitimate runtime bot access.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a critical auth bypass with proper namespace gating and comprehensive test coverage
- The fix is minimal, well-targeted, and thoroughly tested. The change enforces runtime bot namespace (`tnx.bot.`) on API key authentication, preventing arbitrary keys from being accepted. All edge cases are covered by new regression tests, and the idempotency test was updated to use proper auth. No breaking changes to legitimate runtime bot keys.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/platform_api/auth_identity.py | Added runtime bot namespace validation (`tnx.bot.` prefix) to prevent arbitrary API key acceptance |
| backend/tests/contracts/test_auth_identity_runtime.py | Added three new regression tests for non-runtime key rejection, runtime key acceptance, and JWT precedence |
| backend/tests/contracts/test_platform_api_v2_handlers.py | Added integration tests verifying 401 AUTH_UNAUTHORIZED for arbitrary keys and BOT_API_KEY_INVALID for malformed runtime keys |
| backend/tests/contracts/test_runtime_openapi_contract_v2.py | Updated idempotency contract test to use proper auth headers instead of relying on unverified API key fallback |

</details>


</details>


<sub>Last reviewed commit: 5bdd049</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->