### PR TITLE
fix(cloudops): provision Clerk JWKS auth for validation proxy (#334)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,6 +39,18 @@ MAX_DRAWDOWN_PCT=15.0
 # Bot Registration (partner-key bootstrap path)
 PARTNER_BOOTSTRAP_SECRET=
 
+# Platform Auth — Clerk JWKS (RS256) bearer-token verification
+# REQUIRED in production for /v1 and /v2 authenticated routes.
+# Set CLERK_ISSUER to the Clerk instance issuer URL; the JWKS endpoint
+# is auto-derived as {CLERK_ISSUER}/.well-known/jwks.json.
+CLERK_ISSUER=
+# Optional overrides (mutually exclusive with auto-derived JWKS URL):
+# PLATFORM_AUTH_JWKS_URL=
+# PLATFORM_AUTH_JWKS_JSON=
+# PLATFORM_AUTH_JWT_ISSUER=
+# PLATFORM_AUTH_JWT_AUDIENCE=
+# PLATFORM_AUTH_JWT_HS256_SECRET=
+
 # Server
 HOST=0.0.0.0
 PORT=8000


### PR DESCRIPTION
## Summary
- Documents `CLERK_ISSUER` and Platform Auth env vars in `backend/.env.example`
- Azure Container App secret `clerk-issuer` set to `https://clerk.trading-nexus.lona.agency`
- Env var `CLERK_ISSUER=secretref:clerk-issuer` bound to revision `trade-nexus-backend--0000069`

## Ops Evidence (no repo artifacts — infra-only)

### Config keys set (values redacted)
```
az containerapp secret list → clerk-issuer ✅
az containerapp env → CLERK_ISSUER=secretref:clerk-issuer ✅
Revision: trade-nexus-backend--0000069 (Running)
```

### Smoke results (authenticated Clerk RS256 session from trade-nexus.lona.agency)
| Endpoint | Before | After | Meaning |
|---|---|---|---|
| `POST /api/validation/runs` | **401** AUTH_UNAUTHORIZED | **422** (payload validation) | Auth passed ✅ |
| `GET /api/validation/runs/{id}` | **401** AUTH_UNAUTHORIZED | **404** (run not found) | Auth passed ✅ |
| `GET /api/validation/runs/{id}/artifact` | **401** AUTH_UNAUTHORIZED | **404** (run not found) | Auth passed ✅ |

### Root cause
The Azure Container App had zero auth env vars. The backend's `auth_identity.py` (PR #335) supports Clerk RS256 JWKS verification, but `_jwt_signing_key()` returned `None` because neither `CLERK_ISSUER`, `PLATFORM_AUTH_JWKS_URL`, nor `PLATFORM_AUTH_JWKS_JSON` was set. Setting `CLERK_ISSUER=https://clerk.trading-nexus.lona.agency` auto-derives the JWKS URL and issuer for claim validation.

### Key discovery
Production Clerk uses a custom domain (`clerk.trading-nexus.lona.agency`, kid `ins_39UHSbv0qu3cvemcsSs4KHUEbwh`) — different from the dev instance (`summary-hare-66.clerk.accounts.dev`, kid `ins_2r7igjzHBSMV3RihbdXXlTjpLyu`).

## Test plan
- [x] Health endpoint returns 200
- [x] POST /api/validation/runs returns non-401 (422 = auth passed, payload invalid)
- [x] GET /api/validation/runs/{id} returns non-401 (404 = auth passed, run not found)
- [x] GET /api/validation/runs/{id}/artifact returns non-401 (404 = auth passed, run not found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the example env file; no behavior or security logic is modified in code.
> 
> **Overview**
> Updates `backend/.env.example` to document and surface the env vars needed for **Clerk RS256 JWKS bearer-token verification**, including the required `CLERK_ISSUER` and optional `PLATFORM_AUTH_*` overrides for JWKS URL/JSON, issuer, audience, and HS256 secret.
> 
> No runtime code changes; this PR is purely configuration documentation to ensure production deployments set the auth-related variables expected by the backend.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a1ee1a23e80845adf31103c1e85b56fe2ac44c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documents Clerk JWKS authentication environment variables in `backend/.env.example`. Adds `CLERK_ISSUER` (required for production auth) plus optional `PLATFORM_AUTH_*` overrides for JWKS URL/JSON, issuer, audience, and HS256 secret. These variables enable RS256 bearer token verification for `/v1` and `/v2` authenticated routes, as implemented in `auth_identity.py` (PR #335).

The documented variables align with the code implementation:
- `CLERK_ISSUER` auto-derives JWKS URL as `{CLERK_ISSUER}/.well-known/jwks.json`
- Optional overrides provide flexibility for custom JWKS endpoints or testing scenarios
- Production deployment tested with `https://clerk.trading-nexus.lona.agency`

No code changes; purely configuration documentation to guide proper environment setup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - documentation-only change with no runtime code modifications
- Score reflects that this is purely a documentation update to `.env.example` template file. No executable code is changed, no new dependencies introduced, no logic modified. The documented variables match the existing implementation in `auth_identity.py` from PR #335. Production smoke tests confirm the configuration works correctly.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/.env.example | Adds documentation for Clerk JWKS auth environment variables - `CLERK_ISSUER` (required) and optional `PLATFORM_AUTH_*` overrides |

</details>


</details>


<sub>Last reviewed commit: 3a1ee1a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->