### PR TITLE
feat(ops): add credentialed validation proxy smoke for web proxy routes

### DIFF
--- a/.github/workflows/validation-proxy-smoke.yml
+++ b/.github/workflows/validation-proxy-smoke.yml
@@ -1,0 +1,70 @@
+name: validation-proxy-smoke
+
+on:
+  workflow_dispatch:
+
+jobs:
+  validation-proxy-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      VALIDATION_PROXY_SMOKE_BASE_URL: ${{ secrets.VALIDATION_PROXY_SMOKE_BASE_URL }}
+      VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY: ${{ secrets.VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY }}
+      VALIDATION_PROXY_SMOKE_CLERK_USER_ID: ${{ secrets.VALIDATION_PROXY_SMOKE_CLERK_USER_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run validation proxy smoke
+        run: |
+          mkdir -p .ops/artifacts
+          RUN_STAMP="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(date -u +%Y%m%dT%H%M%SZ)"
+          SMOKE_JSON_PATH=".ops/artifacts/validation-proxy-smoke-${RUN_STAMP}.json"
+          SMOKE_TSV_PATH=".ops/artifacts/validation-proxy-smoke-${RUN_STAMP}.tsv"
+          SMOKE_TXT_PATH=".ops/artifacts/validation-proxy-smoke-${RUN_STAMP}.txt"
+          echo "SMOKE_JSON_PATH=${SMOKE_JSON_PATH}" >> "$GITHUB_ENV"
+          echo "SMOKE_TSV_PATH=${SMOKE_TSV_PATH}" >> "$GITHUB_ENV"
+          echo "SMOKE_TXT_PATH=${SMOKE_TXT_PATH}" >> "$GITHUB_ENV"
+
+          set +e
+          python3 .ops/scripts/validation-proxy-smoke.py \
+            --output-json "${SMOKE_JSON_PATH}" \
+            --output-tsv "${SMOKE_TSV_PATH}" \
+            --output-text "${SMOKE_TXT_PATH}"
+          SMOKE_EXIT_CODE=$?
+          set -e
+
+          echo "SMOKE_EXIT_CODE=${SMOKE_EXIT_CODE}" >> "$GITHUB_ENV"
+          exit "${SMOKE_EXIT_CODE}"
+
+      - name: Summarize smoke report
+        if: always()
+        run: |
+          echo "### Validation Proxy Smoke" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f "${SMOKE_TXT_PATH}" ]]; then
+            cat "${SMOKE_TXT_PATH}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Smoke summary file missing: ${SMOKE_TXT_PATH}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifact name: validation-proxy-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-proxy-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ env.SMOKE_JSON_PATH }}
+            ${{ env.SMOKE_TSV_PATH }}
+            ${{ env.SMOKE_TXT_PATH }}
+          if-no-files-found: error

--- a/.ops/runbooks/secret-rotation.md
+++ b/.ops/runbooks/secret-rotation.md
@@ -14,6 +14,9 @@
 | `lona-agent-token` | Azure + Vercel | 30 days (TTL) | Auto-renew | Gateway token, auto-renews |
 | `supabase-key` | Azure + Vercel | On compromise | CloudOps | Service role key |
 | `live-engine-service-api-key` | Azure + Vercel | 90 days | CloudOps | Execution bridge |
+| `VALIDATION_PROXY_SMOKE_BASE_URL` | GitHub Actions | On endpoint change | CloudOps | Validation proxy smoke target URL |
+| `VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY` | GitHub Actions | On compromise | CloudOps | Credentialed validation proxy smoke auth |
+| `VALIDATION_PROXY_SMOKE_CLERK_USER_ID` | GitHub Actions | On account rotation | CloudOps | Dedicated smoke account identity |
 | `CLERK_SECRET_KEY` | Vercel only | On compromise | Dev Team | Auth provider |
 | `UPSTASH_REDIS_REST_TOKEN` | Vercel only | On compromise | Dev Team | Cache |
 | `SUPABASE_SERVICE_ROLE_KEY` | Vercel only | On compromise | CloudOps | DB admin access |

--- a/.ops/scripts/validation-proxy-smoke.py
+++ b/.ops/scripts/validation-proxy-smoke.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""Credentialed smoke for validation web proxy routes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_CLERK_API_BASE = "https://api.clerk.com/v1"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+DEFAULT_SESSION_TOKEN_TTL_SECONDS = 300
+
+
+@dataclass
+class HttpResult:
+    status: int
+    latency_ms: int | None
+    json_payload: dict[str, Any] | None
+    text_payload: str
+    error: str | None = None
+
+
+@dataclass
+class RouteCheck:
+    name: str
+    method: str
+    route: str
+    status: int
+    non401: bool
+    expected_status: bool
+    ok: bool
+    request_id: str | None
+    run_id: str | None
+    latency_ms: int | None
+    error: str | None
+
+
+def utc_now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def normalize_base_url(value: str) -> str:
+    trimmed = value.strip()
+    if not trimmed:
+        return ""
+    return trimmed[:-1] if trimmed.endswith("/") else trimmed
+
+
+def parse_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def mkdir_parent(path: str) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_text(path: str, content: str) -> None:
+    mkdir_parent(path)
+    Path(path).write_text(content, encoding="utf-8")
+
+
+def write_json(path: str, payload: dict[str, Any]) -> None:
+    mkdir_parent(path)
+    Path(path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_tsv(path: str, checks: list[RouteCheck]) -> None:
+    mkdir_parent(path)
+    lines = [
+        "name\tmethod\troute\tstatus\tnon401\texpectedStatus\tok\trunId\trequestId\tlatencyMs\terror",
+    ]
+    for check in checks:
+        lines.append(
+            "\t".join(
+                [
+                    check.name,
+                    check.method,
+                    check.route,
+                    str(check.status),
+                    str(check.non401).lower(),
+                    str(check.expected_status).lower(),
+                    str(check.ok).lower(),
+                    check.run_id or "",
+                    check.request_id or "",
+                    "" if check.latency_ms is None else str(check.latency_ms),
+                    (check.error or "").replace("\t", " "),
+                ]
+            )
+        )
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def http_json_request(
+    *,
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    timeout_seconds: float,
+    payload: dict[str, Any] | None = None,
+) -> HttpResult:
+    body = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+
+    request = urllib.request.Request(url=url, method=method, headers=headers, data=body)
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            raw = response.read()
+            status = int(response.status)
+    except urllib.error.HTTPError as http_error:
+        raw = http_error.read()
+        status = int(http_error.code)
+    except Exception as exc:  # noqa: BLE001
+        return HttpResult(
+            status=0,
+            latency_ms=None,
+            json_payload=None,
+            text_payload="",
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    elapsed_ms = int((time.perf_counter() - start) * 1000)
+    text_payload = raw.decode("utf-8", errors="replace")
+    json_payload: dict[str, Any] | None = None
+    if text_payload:
+        try:
+            maybe_json = json.loads(text_payload)
+            if isinstance(maybe_json, dict):
+                json_payload = maybe_json
+        except json.JSONDecodeError:
+            json_payload = None
+
+    return HttpResult(
+        status=status,
+        latency_ms=elapsed_ms,
+        json_payload=json_payload,
+        text_payload=text_payload,
+        error=None,
+    )
+
+
+def get_request_id(payload: dict[str, Any] | None) -> str | None:
+    if not payload:
+        return None
+    for key in ("requestId", "request_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def get_run_id(payload: dict[str, Any] | None) -> str | None:
+    if not payload:
+        return None
+    direct = payload.get("runId")
+    if isinstance(direct, str) and direct:
+        return direct
+    run = payload.get("run")
+    if isinstance(run, dict):
+        run_id = run.get("id")
+        if isinstance(run_id, str) and run_id:
+            return run_id
+    artifact = payload.get("artifact")
+    if isinstance(artifact, dict):
+        artifact_run_id = artifact.get("runId")
+        if isinstance(artifact_run_id, str) and artifact_run_id:
+            return artifact_run_id
+    return None
+
+
+def get_error_summary(result: HttpResult) -> str | None:
+    if result.error:
+        return result.error
+    payload = result.json_payload
+    if isinstance(payload, dict):
+        error_payload = payload.get("error")
+        if isinstance(error_payload, dict):
+            code = error_payload.get("code")
+            message = error_payload.get("message")
+            if isinstance(code, str) and isinstance(message, str):
+                return f"{code}: {message}"
+            if isinstance(message, str):
+                return message
+            if isinstance(code, str):
+                return code
+        if isinstance(error_payload, str):
+            return error_payload
+    if result.status >= 400 and result.text_payload:
+        compact = " ".join(result.text_payload.split())
+        if compact.startswith("<"):
+            return f"HTTP {result.status} response body omitted (non-JSON)."
+        return compact[:180]
+    return None
+
+
+def build_route_check(
+    *,
+    name: str,
+    method: str,
+    route: str,
+    result: HttpResult,
+    expected_statuses: set[int],
+    default_run_id: str | None = None,
+) -> RouteCheck:
+    payload = result.json_payload
+    status = result.status
+    non401 = status != 401 and status != 0
+    expected = status in expected_statuses
+    request_id = get_request_id(payload)
+    run_id = get_run_id(payload) or default_run_id
+    ok = non401 and expected
+    return RouteCheck(
+        name=name,
+        method=method,
+        route=route,
+        status=status,
+        non401=non401,
+        expected_status=expected,
+        ok=ok,
+        request_id=request_id,
+        run_id=run_id,
+        latency_ms=result.latency_ms,
+        error=get_error_summary(result),
+    )
+
+
+def require_non_empty(value: str, name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} is required.")
+    return normalized
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("VALIDATION_PROXY_SMOKE_BASE_URL", ""),
+        help="Frontend base URL (for example: https://trade-nexus.lona.agency).",
+    )
+    parser.add_argument(
+        "--clerk-secret-key",
+        default=os.getenv("VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY", ""),
+        help="Clerk backend secret key (sk_*).",
+    )
+    parser.add_argument(
+        "--clerk-user-id",
+        default=os.getenv("VALIDATION_PROXY_SMOKE_CLERK_USER_ID", ""),
+        help="Dedicated Clerk smoke user id (user_*).",
+    )
+    parser.add_argument(
+        "--clerk-api-base",
+        default=os.getenv("VALIDATION_PROXY_SMOKE_CLERK_API_BASE", DEFAULT_CLERK_API_BASE),
+        help="Clerk Backend API base URL.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=float(
+            os.getenv("VALIDATION_PROXY_SMOKE_TIMEOUT_SECONDS", str(DEFAULT_TIMEOUT_SECONDS))
+        ),
+        help="HTTP timeout in seconds.",
+    )
+    parser.add_argument(
+        "--session-token-ttl-seconds",
+        type=int,
+        default=int(
+            os.getenv(
+                "VALIDATION_PROXY_SMOKE_SESSION_TOKEN_TTL_SECONDS",
+                str(DEFAULT_SESSION_TOKEN_TTL_SECONDS),
+            )
+        ),
+        help="Session token TTL in seconds when minting Clerk token.",
+    )
+    parser.add_argument(
+        "--strategy-id",
+        default=os.getenv("VALIDATION_PROXY_SMOKE_STRATEGY_ID", "strat-smoke-proxy-001"),
+        help="Synthetic strategyId for smoke create-run payload.",
+    )
+    parser.add_argument(
+        "--provider-ref-id",
+        default=os.getenv("VALIDATION_PROXY_SMOKE_PROVIDER_REF_ID", "lona-smoke-proxy"),
+        help="Synthetic providerRefId for smoke create-run payload.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=os.getenv(
+            "VALIDATION_PROXY_SMOKE_PROMPT",
+            "Validation proxy credentialed smoke run via GitHub Actions.",
+        ),
+        help="Prompt field for create-run payload.",
+    )
+    parser.add_argument(
+        "--requested-indicators",
+        default=os.getenv("VALIDATION_PROXY_SMOKE_REQUESTED_INDICATORS", "zigzag,ema"),
+        help="Comma-separated requested indicators.",
+    )
+    parser.add_argument(
+        "--dataset-ids",
+        default=os.getenv("VALIDATION_PROXY_SMOKE_DATASET_IDS", "dataset-btc-1h-2025"),
+        help="Comma-separated dataset IDs.",
+    )
+    parser.add_argument(
+        "--backtest-report-ref",
+        default=os.getenv(
+            "VALIDATION_PROXY_SMOKE_BACKTEST_REPORT_REF",
+            "blob://validation/smoke/proxy-backtest-report.json",
+        ),
+        help="Backtest report reference for create-run payload.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default=os.getenv(
+            "VALIDATION_PROXY_SMOKE_OUTPUT_JSON",
+            ".ops/artifacts/validation-proxy-smoke.json",
+        ),
+        help="Output path for machine-readable JSON report.",
+    )
+    parser.add_argument(
+        "--output-tsv",
+        default=os.getenv(
+            "VALIDATION_PROXY_SMOKE_OUTPUT_TSV",
+            ".ops/artifacts/validation-proxy-smoke.tsv",
+        ),
+        help="Output path for concise TSV route summary.",
+    )
+    parser.add_argument(
+        "--output-text",
+        default=os.getenv(
+            "VALIDATION_PROXY_SMOKE_OUTPUT_TEXT",
+            ".ops/artifacts/validation-proxy-smoke.txt",
+        ),
+        help="Output path for concise text summary.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    started_at = utc_now()
+    checks: list[RouteCheck] = []
+    fatal_error: str | None = None
+    session_id: str | None = None
+    run_id: str | None = None
+    artifact_type: str | None = None
+    session_revoke_status: int | None = None
+    auth_bootstrap: dict[str, Any] = {}
+
+    normalized_base_url = normalize_base_url(args.base_url)
+    normalized_clerk_api_base = normalize_base_url(args.clerk_api_base)
+
+    try:
+        base_url = require_non_empty(normalized_base_url, "VALIDATION_PROXY_SMOKE_BASE_URL")
+        clerk_secret_key = require_non_empty(
+            args.clerk_secret_key, "VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY"
+        )
+        clerk_user_id = require_non_empty(args.clerk_user_id, "VALIDATION_PROXY_SMOKE_CLERK_USER_ID")
+        clerk_api_base = require_non_empty(
+            normalized_clerk_api_base, "VALIDATION_PROXY_SMOKE_CLERK_API_BASE"
+        )
+
+        requested_indicators = parse_csv(args.requested_indicators)
+        dataset_ids = parse_csv(args.dataset_ids)
+        if not requested_indicators:
+            raise ValueError("VALIDATION_PROXY_SMOKE_REQUESTED_INDICATORS must not be empty.")
+        if not dataset_ids:
+            raise ValueError("VALIDATION_PROXY_SMOKE_DATASET_IDS must not be empty.")
+
+        clerk_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {clerk_secret_key}",
+        }
+        session_create_result = http_json_request(
+            method="POST",
+            url=f"{clerk_api_base}/sessions",
+            headers=clerk_headers,
+            timeout_seconds=args.timeout_seconds,
+            payload={"user_id": clerk_user_id},
+        )
+        auth_bootstrap["sessionCreateStatus"] = session_create_result.status
+        if session_create_result.status not in {200, 201}:
+            raise RuntimeError(
+                f"Clerk session create failed with status {session_create_result.status}: "
+                f"{get_error_summary(session_create_result) or 'unknown error'}"
+            )
+
+        session_id_value = session_create_result.json_payload.get("id") if session_create_result.json_payload else None
+        if not isinstance(session_id_value, str) or not session_id_value:
+            raise RuntimeError("Clerk session create response did not include a session id.")
+        session_id = session_id_value
+
+        token_result = http_json_request(
+            method="POST",
+            url=f"{clerk_api_base}/sessions/{session_id}/tokens",
+            headers=clerk_headers,
+            timeout_seconds=args.timeout_seconds,
+            payload={"expires_in_seconds": args.session_token_ttl_seconds},
+        )
+        auth_bootstrap["sessionTokenStatus"] = token_result.status
+        if token_result.status not in {200, 201}:
+            raise RuntimeError(
+                f"Clerk session token mint failed with status {token_result.status}: "
+                f"{get_error_summary(token_result) or 'unknown error'}"
+            )
+        jwt_value = token_result.json_payload.get("jwt") if token_result.json_payload else None
+        if not isinstance(jwt_value, str) or not jwt_value:
+            raise RuntimeError("Clerk token response did not include jwt.")
+
+        smoke_payload = {
+            "strategyId": args.strategy_id,
+            "providerRefId": args.provider_ref_id,
+            "prompt": args.prompt,
+            "requestedIndicators": requested_indicators,
+            "datasetIds": dataset_ids,
+            "backtestReportRef": args.backtest_report_ref,
+            "policy": {
+                "profile": "STANDARD",
+                "blockMergeOnFail": True,
+                "blockReleaseOnFail": True,
+                "blockMergeOnAgentFail": True,
+                "blockReleaseOnAgentFail": False,
+                "requireTraderReview": False,
+                "hardFailOnMissingIndicators": True,
+                "failClosedOnEvidenceUnavailable": True,
+            },
+        }
+
+        proxy_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {jwt_value}",
+            "Cookie": f"__session={jwt_value}",
+            "Idempotency-Key": f"idem-validation-proxy-smoke-{uuid.uuid4()}",
+            "User-Agent": "trade-nexus-validation-proxy-smoke/1.0",
+        }
+
+        create_path = "/api/validation/runs"
+        create_result = http_json_request(
+            method="POST",
+            url=f"{base_url}{create_path}",
+            headers=proxy_headers,
+            timeout_seconds=args.timeout_seconds,
+            payload=smoke_payload,
+        )
+        create_check = build_route_check(
+            name="create-run",
+            method="POST",
+            route=create_path,
+            result=create_result,
+            expected_statuses={200, 201, 202},
+        )
+        checks.append(create_check)
+        run_id = create_check.run_id
+
+        if run_id:
+            run_path = f"/api/validation/runs/{run_id}"
+            get_run_result = http_json_request(
+                method="GET",
+                url=f"{base_url}{run_path}",
+                headers={
+                    "Accept": "application/json",
+                    "Authorization": f"Bearer {jwt_value}",
+                    "Cookie": f"__session={jwt_value}",
+                    "User-Agent": "trade-nexus-validation-proxy-smoke/1.0",
+                },
+                timeout_seconds=args.timeout_seconds,
+            )
+            checks.append(
+                build_route_check(
+                    name="get-run",
+                    method="GET",
+                    route=run_path,
+                    result=get_run_result,
+                    expected_statuses={200},
+                    default_run_id=run_id,
+                )
+            )
+
+            artifact_path = f"/api/validation/runs/{run_id}/artifact"
+            get_artifact_result = http_json_request(
+                method="GET",
+                url=f"{base_url}{artifact_path}",
+                headers={
+                    "Accept": "application/json",
+                    "Authorization": f"Bearer {jwt_value}",
+                    "Cookie": f"__session={jwt_value}",
+                    "User-Agent": "trade-nexus-validation-proxy-smoke/1.0",
+                },
+                timeout_seconds=args.timeout_seconds,
+            )
+            artifact_payload = get_artifact_result.json_payload
+            if isinstance(artifact_payload, dict):
+                maybe_artifact_type = artifact_payload.get("artifactType")
+                if isinstance(maybe_artifact_type, str):
+                    artifact_type = maybe_artifact_type
+            checks.append(
+                build_route_check(
+                    name="get-artifact",
+                    method="GET",
+                    route=artifact_path,
+                    result=get_artifact_result,
+                    expected_statuses={200},
+                    default_run_id=run_id,
+                )
+            )
+        else:
+            checks.extend(
+                [
+                    RouteCheck(
+                        name="get-run",
+                        method="GET",
+                        route="/api/validation/runs/{runId}",
+                        status=0,
+                        non401=False,
+                        expected_status=False,
+                        ok=False,
+                        request_id=None,
+                        run_id=None,
+                        latency_ms=None,
+                        error="Skipped because create-run did not return runId.",
+                    ),
+                    RouteCheck(
+                        name="get-artifact",
+                        method="GET",
+                        route="/api/validation/runs/{runId}/artifact",
+                        status=0,
+                        non401=False,
+                        expected_status=False,
+                        ok=False,
+                        request_id=None,
+                        run_id=None,
+                        latency_ms=None,
+                        error="Skipped because create-run did not return runId.",
+                    ),
+                ]
+            )
+
+    except Exception as exc:  # noqa: BLE001
+        fatal_error = f"{type(exc).__name__}: {exc}"
+
+    finally:
+        if session_id:
+            revoke_result = http_json_request(
+                method="POST",
+                url=f"{normalize_base_url(args.clerk_api_base)}/sessions/{session_id}/revoke",
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {args.clerk_secret_key}",
+                },
+                timeout_seconds=args.timeout_seconds,
+            )
+            session_revoke_status = revoke_result.status
+
+    all_non401 = all(check.non401 for check in checks) if checks else False
+    all_expected_status = all(check.expected_status for check in checks) if checks else False
+    status_value = "pass" if checks and all(check.ok for check in checks) and not fatal_error else "fail"
+
+    report = {
+        "schemaVersion": "validation-proxy-smoke.v1",
+        "generatedAt": utc_now(),
+        "startedAt": started_at,
+        "status": status_value,
+        "fatalError": fatal_error,
+        "target": {
+            "baseUrl": normalized_base_url,
+            "routes": [
+                "/api/validation/runs",
+                "/api/validation/runs/{runId}",
+                "/api/validation/runs/{runId}/artifact",
+            ],
+        },
+        "auth": {
+            "mode": "clerk_backend_session_token",
+            "clerkApiBase": normalized_clerk_api_base,
+            "clerkUserId": args.clerk_user_id,
+            "sessionId": session_id,
+            "tokenTtlSeconds": args.session_token_ttl_seconds,
+            "tokenRedacted": True,
+            "bootstrap": auth_bootstrap,
+            "revokeStatus": session_revoke_status,
+        },
+        "result": {
+            "allNon401": all_non401,
+            "allExpectedStatus": all_expected_status,
+            "runId": run_id,
+            "artifactType": artifact_type,
+            "requestIds": {
+                check.name: check.request_id for check in checks if check.request_id is not None
+            },
+            "github": {
+                "repository": os.getenv("GITHUB_REPOSITORY"),
+                "runId": os.getenv("GITHUB_RUN_ID"),
+                "runAttempt": os.getenv("GITHUB_RUN_ATTEMPT"),
+            },
+        },
+        "checks": [asdict(check) for check in checks],
+    }
+
+    write_json(args.output_json, report)
+    write_tsv(args.output_tsv, checks)
+
+    summary_lines = [
+        f"VALIDATION_PROXY_SMOKE status={status_value.upper()} all_non401={str(all_non401).lower()} "
+        f"all_expected_status={str(all_expected_status).lower()}",
+        f"RUN_ID {run_id or 'n/a'}",
+        "ROUTE_SUMMARY",
+    ]
+    for check in checks:
+        summary_lines.append(
+            " ".join(
+                [
+                    f"- name={check.name}",
+                    f"method={check.method}",
+                    f"route={check.route}",
+                    f"status={check.status}",
+                    f"request_id={check.request_id or 'n/a'}",
+                    f"latency_ms={check.latency_ms if check.latency_ms is not None else 'n/a'}",
+                    f"ok={str(check.ok).lower()}",
+                ]
+            )
+        )
+    if fatal_error:
+        summary_lines.append(f"FATAL_ERROR {fatal_error}")
+    summary_lines.append(f"ARTIFACT_JSON {args.output_json}")
+    summary_lines.append(f"ARTIFACT_TSV {args.output_tsv}")
+    write_text(args.output_text, "\n".join(summary_lines) + "\n")
+
+    print(summary_lines[0])
+    print(f"Smoke report: {args.output_json}")
+    print(f"Smoke summary: {args.output_text}")
+    return 0 if status_value == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ops/ENV_MATRIX.md
+++ b/docs/ops/ENV_MATRIX.md
@@ -1,7 +1,7 @@
 # Trade Nexus — Environment Variable Contract
 
 > **Owner**: Team VOps
-> **Last updated**: 2026-02-21
+> **Last updated**: 2026-02-24
 > **Purpose**: Handoff document for dev lanes. Defines what environment variables are available per deployment target.
 
 ## For Dev Teams
@@ -73,6 +73,9 @@
 | `ACR_USERNAME` | `backend-deploy.yml` | ACR admin user (**remove after MI migration**) |
 | `ACR_PASSWORD` | `backend-deploy.yml` | ACR admin password (**remove after MI migration**) |
 | `NPM_TOKEN` | `publish-sdk.yml` | npm publishing |
+| `VALIDATION_PROXY_SMOKE_BASE_URL` | `validation-proxy-smoke.yml` | Frontend proxy base URL (for example `https://trade-nexus.lona.agency`) |
+| `VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY` | `validation-proxy-smoke.yml` | Clerk Backend API secret key for non-interactive smoke auth |
+| `VALIDATION_PROXY_SMOKE_CLERK_USER_ID` | `validation-proxy-smoke.yml` | Dedicated Clerk smoke user id |
 
 ## Domain References — Canonical Values
 
@@ -98,3 +101,4 @@
 | #229 | Baseline replay + gates | No new env vars | **N/A** |
 | #230 | Web review lane | Frontend Supabase vars | **Available** |
 | #231 | CLI validation commands | Backend env vars | **Available** |
+| #333 | Credentialed validation proxy smoke | `VALIDATION_PROXY_SMOKE_BASE_URL`, `VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY`, `VALIDATION_PROXY_SMOKE_CLERK_USER_ID` | **Available** |

--- a/docs/ops/IAM_SECRETS_OWNERSHIP.md
+++ b/docs/ops/IAM_SECRETS_OWNERSHIP.md
@@ -1,7 +1,7 @@
 # Trade Nexus — IAM & Secrets Ownership
 
 > **Owner**: Team VOps
-> **Last updated**: 2026-02-21
+> **Last updated**: 2026-02-24
 > **Governance**: Only VOps provisions, rotates, or modifies secrets and IAM roles.
 
 ## Service Principal
@@ -60,6 +60,9 @@
 | ACR_USERNAME | GitHub Actions secret | VOps | **Remove after MI migration** | Registry (legacy) |
 | ACR_PASSWORD | GitHub Actions secret | VOps | **Remove after MI migration** | Registry (legacy) |
 | NPM_TOKEN | GitHub Actions secret | VOps | Annual | SDK publishing |
+| VALIDATION_PROXY_SMOKE_BASE_URL | GitHub Actions secret | VOps | On endpoint change | Smoke routing target |
+| VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY | GitHub Actions secret | VOps | On compromise | Credentialed smoke auth |
+| VALIDATION_PROXY_SMOKE_CLERK_USER_ID | GitHub Actions secret | VOps | On account rotation | Dedicated smoke identity |
 | CLERK_SECRET_KEY | Vercel env var | VOps | On compromise | Auth |
 | NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY | Vercel env var | VOps | Static | Auth (public) |
 | SUPABASE_SERVICE_ROLE_KEY | Vercel env var | VOps | On compromise | DB admin |
@@ -88,6 +91,8 @@
 | langsmith-api-key | Unknown | TBD | Document initial rotation |
 | lona-agent-token | Auto (TTL) | 30-day cycle | Self-rotating via TTL |
 | live-engine-service-api-key | 2026-02-21 | On compromise | Just provisioned |
+| VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY | 2026-02-24 | On compromise | CloudOps-owned smoke credential |
+| VALIDATION_PROXY_SMOKE_CLERK_USER_ID | 2026-02-24 | On account rotation | CloudOps-owned smoke identity |
 
 ## Break-Glass Procedures
 

--- a/docs/ops/RESOURCE_MAP.md
+++ b/docs/ops/RESOURCE_MAP.md
@@ -1,7 +1,7 @@
 # Trade Nexus — Resource Map
 
 > **Owner**: Team VOps (Cloud DevOps)
-> **Last updated**: 2026-02-21
+> **Last updated**: 2026-02-24
 > **Scope**: All cloud resources for the trade-nexus platform
 
 ## Domain Map
@@ -116,6 +116,9 @@
 | ACR_USERNAME | Registry service account | **Remove after MI migration** |
 | ACR_PASSWORD | Registry access token | **Remove after MI migration** |
 | NPM_TOKEN | npm publishing (SDK) | Annual |
+| VALIDATION_PROXY_SMOKE_BASE_URL | Frontend smoke target URL | On endpoint change |
+| VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY | Credentialed smoke auth secret | On compromise |
+| VALIDATION_PROXY_SMOKE_CLERK_USER_ID | Credentialed smoke user identity | On account rotation |
 
 ## CI/CD Workflows
 
@@ -126,6 +129,7 @@
 | docs-governance.yml | All `pull_request` events; push to `main` when docs paths change | Docusaurus build, link validation |
 | llm-package-governance.yml | All `pull_request` events; push to `main` when docs/scripts paths change | LLM package generation and drift check |
 | publish-sdk.yml | Manual or sdk-v* tag | SDK regeneration and npm publish |
+| validation-proxy-smoke.yml | Manual (`workflow_dispatch`) | Non-interactive credentialed smoke through validation web proxy routes |
 
 ## Operational Scripts
 
@@ -135,6 +139,7 @@
 | ops-drill.sh | 5-scenario operational readiness | .ops/scripts/ |
 | rollback.sh | Revision rollback with validation | .ops/scripts/ |
 | fix-kv-rbac.sh | Key Vault RBAC remediation | .ops/scripts/ |
+| validation-proxy-smoke.py | Credentialed validation proxy smoke + artifact generation | .ops/scripts/ |
 
 ## Managed Identity
 

--- a/docs/ops/runbook-333-validation-proxy-smoke.md
+++ b/docs/ops/runbook-333-validation-proxy-smoke.md
@@ -1,0 +1,97 @@
+# Runbook: Credentialed Validation Proxy Smoke (Issue #333)
+
+| Field | Value |
+|-------|-------|
+| Issue | #333 (follow-up to #325) |
+| Owner | CloudOps |
+| Service | `trade-nexus` frontend web proxy |
+| Coverage | `POST /api/validation/runs`, `GET /api/validation/runs/{runId}`, `GET /api/validation/runs/{runId}/artifact` |
+
+## Purpose
+
+Provide a repeatable, non-interactive smoke that validates authenticated traffic through the **web proxy routes** (not direct backend routes), while keeping credentials out of repository history and logs.
+
+## CI Entrypoint
+
+- Workflow: `.github/workflows/validation-proxy-smoke.yml`
+- Trigger: `workflow_dispatch` (manual run)
+- Script: `.ops/scripts/validation-proxy-smoke.py`
+- Artifacts per run:
+  - `validation-proxy-smoke-<run-stamp>.json`
+  - `validation-proxy-smoke-<run-stamp>.tsv`
+  - `validation-proxy-smoke-<run-stamp>.txt`
+
+## Required Secrets
+
+Set these in GitHub repository settings:
+
+| Secret | Required | Example | Purpose |
+|--------|----------|---------|---------|
+| `VALIDATION_PROXY_SMOKE_BASE_URL` | Yes | `https://trade-nexus.lona.agency` | Frontend base URL for proxy route calls |
+| `VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY` | Yes | `sk_live_...` | Clerk Backend API key used to mint a short-lived session token |
+| `VALIDATION_PROXY_SMOKE_CLERK_USER_ID` | Yes | `user_...` | Dedicated smoke account identity |
+
+Optional environment overrides are supported by the script, but are not required for standard runs.
+
+## Controlled Credential Model
+
+1. Workflow uses `VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY` + dedicated smoke `user_id` (controlled identity).
+2. Script creates a short-lived Clerk session and session JWT non-interactively.
+3. Script calls proxy routes with bearer + `__session` cookie auth.
+4. Script revokes the temporary Clerk session after execution.
+5. Script never writes token material into artifacts.
+
+## Rotation & Ownership
+
+- **Rotation owner**: CloudOps
+- **Rotation trigger**: on compromise, role handoff, or scheduled key hygiene.
+
+Rotation procedure:
+
+1. Rotate Clerk backend secret key in Clerk Dashboard.
+2. Update GitHub secret `VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY`.
+3. If smoke user changes, update `VALIDATION_PROXY_SMOKE_CLERK_USER_ID`.
+4. Trigger `validation-proxy-smoke` workflow manually.
+5. Verify artifact result is `PASS` and all three routes are non-401.
+
+## Logging / Secret Hygiene
+
+- Do not run with shell tracing (`set -x`) in CI steps handling secrets.
+- Do not paste auth headers, tokens, or full secret values into issues/PR comments.
+- Evidence comments should include only:
+  - workflow run URL,
+  - artifact name/link,
+  - `runId`,
+  - route `requestId` values.
+
+## Evidence Extraction
+
+From uploaded artifacts:
+
+- `*.txt`: concise pass/fail summary and request IDs.
+- `*.tsv`: route-level status table for quick scanning.
+- `*.json`: machine-readable full result for automation and audits.
+
+## Issue Hygiene Templates
+
+### OPEN Status Comment (#333)
+
+```text
+Status: OPEN (issue #333)
+- Workflow run: <actions-run-url>
+- Artifact: <artifact-name-or-run-url>
+- Result: <PASS/FAIL>
+- runId: <runId>
+- requestIds: <create-run>, <get-run>, <get-artifact>
+```
+
+### MERGED Evidence Comment (#333)
+
+```text
+Status: MERGED
+- PR: <pr-url> (closes #333)
+- Workflow run: <actions-run-url>
+- Artifact: <artifact-name-or-run-url>
+- runId: <runId>
+- requestIds: <create-run>, <get-run>, <get-artifact>
+```


### PR DESCRIPTION
## Summary
- add non-interactive credentialed smoke runner at `.ops/scripts/validation-proxy-smoke.py`
- validate only via web proxy routes:
  - `POST /api/validation/runs`
  - `GET /api/validation/runs/{runId}`
  - `GET /api/validation/runs/{runId}/artifact`
- emit machine-readable artifacts per run (`json`, `tsv`, concise `txt`)
- add manual CI entrypoint in `.github/workflows/validation-proxy-smoke.yml` with artifact upload
- add CloudOps runbook + secret ownership/env matrix updates for setup and rotation handoff

## Validation
- `python3 -m py_compile .ops/scripts/validation-proxy-smoke.py`
- dry-run with invalid creds to verify fail-path artifact generation

Closes #333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new credentialed GitHub Actions workflow and smoke script that mints/revokes Clerk sessions and hits production proxy endpoints; primary risk is misconfiguration or unintended auth/API traffic, though changes are isolated to ops tooling and docs.
> 
> **Overview**
> Adds a manual `validation-proxy-smoke` GitHub Actions workflow that runs a new Python smoke test against authenticated validation *web proxy* routes and uploads per-run artifacts (JSON/TSV/text) while surfacing the text summary in the job summary.
> 
> Introduces `.ops/scripts/validation-proxy-smoke.py`, which mints a short-lived Clerk session JWT for a dedicated smoke user, calls `POST /api/validation/runs` and follow-up `GET` routes, records status/latency/request IDs, and revokes the Clerk session before emitting reports.
> 
> Updates ops documentation to register the new GitHub secrets, ownership/rotation guidance, and adds a dedicated runbook for issue #333.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 061d7099c829e4178bb2045231fcb74156746288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds non-interactive credentialed smoke testing for validation proxy web routes with comprehensive documentation and CI integration.

**Key Changes:**
- Introduced `.ops/scripts/validation-proxy-smoke.py` that mints short-lived Clerk sessions, tests three validation proxy endpoints (`POST /api/validation/runs`, `GET /api/validation/runs/{runId}`, `GET /api/validation/runs/{runId}/artifact`), and revokes sessions after completion
- Added manual GitHub Actions workflow `.github/workflows/validation-proxy-smoke.yml` that runs smoke tests and uploads JSON/TSV/text artifacts with job summaries
- Created comprehensive runbook at `docs/ops/runbook-333-validation-proxy-smoke.md` documenting workflow usage, secret ownership, rotation procedures, and evidence extraction
- Updated five ops documentation files to register three new GitHub Actions secrets (`VALIDATION_PROXY_SMOKE_BASE_URL`, `VALIDATION_PROXY_SMOKE_CLERK_SECRET_KEY`, `VALIDATION_PROXY_SMOKE_CLERK_USER_ID`) with rotation policies and ownership assignments

**Issues Found:**
- Two potential `AttributeError` bugs in `.ops/scripts/validation-proxy-smoke.py` at lines 399 and 417 where `.get()` is called on potentially `None` JSON payloads after checking status codes but before null-checking the payload object

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor fixes recommended for error handling edge cases
- Score reflects well-designed ops tooling with comprehensive documentation and proper secret handling. Two potential `AttributeError` bugs exist in the Python script but are unlikely to occur in practice since status code checks precede the problematic lines. The smoke script properly revokes Clerk sessions in a finally block, artifacts exclude sensitive tokens, and documentation thoroughly covers rotation procedures and secret hygiene.
- `.ops/scripts/validation-proxy-smoke.py` needs null-checking fixes at lines 399 and 417

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .ops/scripts/validation-proxy-smoke.py | New smoke test script that authenticates via Clerk API, tests validation proxy routes, generates artifacts, and properly revokes sessions in finally block |
| .github/workflows/validation-proxy-smoke.yml | Manual workflow that runs smoke script with proper secret handling, artifact upload, and job summary generation |
| docs/ops/runbook-333-validation-proxy-smoke.md | Comprehensive runbook documenting smoke workflow usage, secret ownership, rotation procedures, and evidence extraction |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Script as validation-proxy-smoke.py
    participant Clerk as Clerk API
    participant Proxy as Validation Proxy
    participant Artifact as Artifacts

    GH->>Script: Run smoke test
    Script->>Clerk: POST /sessions (user_id)
    Clerk-->>Script: session_id
    Script->>Clerk: POST /sessions/{id}/tokens
    Clerk-->>Script: JWT token (5min TTL)
    
    Script->>Proxy: POST /api/validation/runs (Bearer + Cookie)
    Proxy-->>Script: 201 + runId
    
    Script->>Proxy: GET /api/validation/runs/{runId}
    Proxy-->>Script: 200 + run data
    
    Script->>Proxy: GET /api/validation/runs/{runId}/artifact
    Proxy-->>Script: 200 + artifact data
    
    Script->>Clerk: POST /sessions/{id}/revoke
    Clerk-->>Script: Session revoked
    
    Script->>Artifact: Write JSON/TSV/TXT reports
    Artifact-->>GH: Upload artifacts
    GH->>GH: Display summary
```

<sub>Last reviewed commit: 061d709</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->