### PR TITLE
fix(frontend): allow route-level smoke auth on validation proxy endpoints

### DIFF
--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -2,7 +2,6 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
 
 import { PROTECTED_ROUTE_PATTERNS } from '@/lib/auth/protected-routes';
-import { hasValidValidationSmokeSharedKey } from '@/lib/validation/server/smoke-auth';
 
 const isProtectedRoute = createRouteMatcher(PROTECTED_ROUTE_PATTERNS);
 
@@ -18,10 +17,7 @@ function isValidationProxySmokeRoute(pathname: string): boolean {
 
 const clerkProtectedMiddleware = clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) {
-    if (
-      isValidationProxySmokeRoute(req.nextUrl.pathname) &&
-      hasValidValidationSmokeSharedKey(req.headers)
-    ) {
+    if (isValidationProxySmokeRoute(req.nextUrl.pathname)) {
       return;
     }
     await auth.protect();


### PR DESCRIPTION
## Summary
- stop enforcing Clerk middleware on the three smoke-target validation proxy routes
- keep auth enforcement in route handlers, where Clerk session OR shared smoke key is validated
- unblock non-interactive smoke requests that were still failing at middleware with 401

## Validation
- `bun test src/lib/validation/server/__tests__/auth.test.ts src/lib/validation/server/__tests__/platform-api.test.ts`

Refs #333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request authentication behavior for specific API endpoints; misclassification of routes or missing handler-side checks could unintentionally widen access.
> 
> **Overview**
> Removes shared-key validation from `frontend/src/proxy.ts`’s Clerk middleware and instead **always bypasses** `auth.protect()` for the three validation proxy smoke routes (`/api/validation/runs`, `/api/validation/runs/:id`, and `/api/validation/runs/:id/artifact`).
> 
> This shifts enforcement for those endpoints away from middleware (avoiding 401s on smoke traffic) and leaves authentication to the route handlers’ logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 503074a3f608a5462302bcfd3f937de89bab98b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces Clerk session token authentication with shared-key authentication for validation proxy smoke tests. The three validation proxy routes (`/api/validation/runs`, `/api/validation/runs/{runId}`, `/api/validation/runs/{runId}/artifact`) now bypass Clerk middleware and accept either Clerk session auth OR a shared smoke key via the `X-Validation-Smoke-Key` header.

## Key Changes
- Created new `smoke-auth.ts` module that validates a shared key from request headers against a server environment variable
- Updated `resolveValidationAccess` to check for smoke key auth before falling back to Clerk session auth
- Modified Clerk middleware to skip `auth.protect()` for the three validation proxy routes, deferring auth to route handlers
- Route handlers now conditionally send `X-Tenant-Id`/`X-User-Id` headers (Clerk auth) or `X-API-Key` header (smoke auth) to backend
- Updated GitHub Actions workflow and Python smoke script to use shared key + runtime bot API key instead of minting Clerk session tokens
- Comprehensive test coverage added for both auth modes

## Security Considerations
- Middleware bypass is limited to exactly three routes with route-level validation
- Smoke key must match server environment variable for auth to succeed
- Routes still enforce authorization, just with dual auth paths (Clerk OR smoke key)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with careful post-deployment verification of smoke workflow
- The implementation is well-structured with comprehensive test coverage for both auth paths. The middleware bypass is precisely scoped to three routes with route-level validation enforced. However, the change introduces a new authentication mechanism that bypasses the primary auth layer, requiring careful configuration of the shared key environment variable in production. Score reflects the inherent risk in authentication flow changes and the need to verify the GitHub Actions workflow succeeds post-deployment.
- frontend/src/proxy.ts requires verification that the route pattern matching correctly identifies only the intended three routes

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/validation/server/smoke-auth.ts | New smoke authentication module validates shared keys from headers and normalizes runtime bot API keys |
| frontend/src/lib/validation/server/auth.ts | Updated auth resolver to support optional smoke-key path alongside Clerk session auth |
| frontend/src/proxy.ts | Middleware now bypasses Clerk protection for three validation proxy routes, deferring to route-level auth |
| frontend/src/lib/validation/server/platform-api.ts | Platform API client now conditionally sends tenant/user headers and supports X-API-Key header for bot auth |
| .ops/scripts/validation-proxy-smoke.py | Removed Clerk session minting, now sends X-Validation-Smoke-Key and X-API-Key headers instead |

</details>


</details>


<sub>Last reviewed commit: 503074a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->