### PR TITLE
feat: improve invite/revoke and shared-run permission UX (#345)

### DIFF
--- a/frontend/src/lib/validation/__tests__/shared-permissions.test.ts
+++ b/frontend/src/lib/validation/__tests__/shared-permissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  describeSharedValidationPermission,
   hasSharedValidationPermission,
   resolveSharedValidationCapabilities,
 } from '../shared-permissions';
@@ -24,5 +25,18 @@ describe('shared validation permissions', () => {
     expect(hasSharedValidationPermission('decide', 'view')).toBe(true);
     expect(hasSharedValidationPermission('decide', 'comment')).toBe(true);
     expect(hasSharedValidationPermission('decide', 'decide')).toBe(true);
+  });
+
+  test('describeSharedValidationPermission exposes clear UI metadata', () => {
+    const viewDescriptor = describeSharedValidationPermission('view');
+    expect(viewDescriptor.label).toBe('View only');
+    expect(viewDescriptor.summary).toContain('inspect artifact');
+    expect(viewDescriptor.canComment).toBe(false);
+
+    const decideDescriptor = describeSharedValidationPermission('decide');
+    expect(decideDescriptor.label).toBe('Decide');
+    expect(decideDescriptor.canView).toBe(true);
+    expect(decideDescriptor.canComment).toBe(true);
+    expect(decideDescriptor.canDecide).toBe(true);
   });
 });

--- a/frontend/src/lib/validation/__tests__/shared-run-visibility.test.ts
+++ b/frontend/src/lib/validation/__tests__/shared-run-visibility.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 
-import { filterRunsSharedWithMe } from '../shared-run-visibility';
+import {
+  DEFAULT_SHARED_RUN_LIST_FILTERS,
+  filterRunsSharedWithMe,
+  filterSharedRunsForDisplay,
+} from '../shared-run-visibility';
 import type { ValidationSharedRunSummary } from '../types';
 
 function run(
@@ -32,5 +36,30 @@ describe('filterRunsSharedWithMe', () => {
       'valrun-002',
       'valrun-003',
     ]);
+  });
+
+  test('filterSharedRunsForDisplay applies query and facet filters', () => {
+    const input = [
+      run('valrun-001', 'user-owner', '2026-02-21T10:00:00Z'),
+      run('valrun-002', 'user-other', '2026-02-21T11:00:00Z'),
+      run('valrun-003', undefined, '2026-02-21T12:00:00Z'),
+    ];
+    const visible = filterRunsSharedWithMe(input, 'user-owner');
+    visible[0] = {
+      ...visible[0],
+      permission: 'decide',
+      status: 'running',
+      finalDecision: 'conditional_pass',
+    };
+
+    const filtered = filterSharedRunsForDisplay(visible, {
+      ...DEFAULT_SHARED_RUN_LIST_FILTERS,
+      query: '002',
+      permission: 'decide',
+      status: 'running',
+      decision: 'conditional_pass',
+    });
+
+    expect(filtered.map((item) => item.runId)).toEqual(['valrun-002']);
   });
 });

--- a/frontend/src/lib/validation/invite-lifecycle.ts
+++ b/frontend/src/lib/validation/invite-lifecycle.ts
@@ -1,4 +1,23 @@
-import type { ValidationShareInvite } from '@/lib/validation/types';
+import type {
+  ValidationInviteStatus,
+  ValidationShareInvite,
+  ValidationSharePermission,
+} from '@/lib/validation/types';
+
+export type InviteStatusFilter = ValidationInviteStatus | 'all';
+export type InvitePermissionFilter = ValidationSharePermission | 'all';
+
+export interface InviteListFilters {
+  query: string;
+  status: InviteStatusFilter;
+  permission: InvitePermissionFilter;
+}
+
+export const DEFAULT_INVITE_LIST_FILTERS = {
+  query: '',
+  status: 'all',
+  permission: 'all',
+} as const satisfies InviteListFilters;
 
 function toTimestamp(value: string): number {
   const parsed = Date.parse(value);
@@ -28,4 +47,40 @@ export function markInviteRevoked(
 
 export function inviteActionLabel(invite: ValidationShareInvite): string {
   return invite.status === 'accepted' ? 'Revoke Access' : 'Revoke Invite';
+}
+
+export function filterInvites(
+  invites: ValidationShareInvite[],
+  filters: InviteListFilters,
+): ValidationShareInvite[] {
+  const query = filters.query.trim().toLowerCase();
+  return invites.filter((invite) => {
+    if (filters.status !== 'all' && invite.status !== filters.status) {
+      return false;
+    }
+    if (filters.permission !== 'all' && invite.permission !== filters.permission) {
+      return false;
+    }
+    if (query.length > 0) {
+      return invite.email.toLowerCase().includes(query) || invite.id.toLowerCase().includes(query);
+    }
+    return true;
+  });
+}
+
+export function summarizeInvitesByStatus(
+  invites: ValidationShareInvite[],
+): Record<ValidationInviteStatus, number> {
+  const summary: Record<ValidationInviteStatus, number> = {
+    pending: 0,
+    accepted: 0,
+    revoked: 0,
+    expired: 0,
+  };
+
+  for (const invite of invites) {
+    summary[invite.status] += 1;
+  }
+
+  return summary;
 }

--- a/frontend/src/lib/validation/shared-permissions.ts
+++ b/frontend/src/lib/validation/shared-permissions.ts
@@ -12,6 +12,32 @@ export interface SharedValidationCapabilities {
   canDecide: boolean;
 }
 
+interface SharedPermissionMetadata {
+  label: string;
+  summary: string;
+}
+
+export interface SharedValidationPermissionDescriptor
+  extends SharedValidationCapabilities,
+    SharedPermissionMetadata {
+  permission: ValidationSharePermission;
+}
+
+const SHARED_PERMISSION_METADATA: Record<ValidationSharePermission, SharedPermissionMetadata> = {
+  view: {
+    label: 'View only',
+    summary: 'Can open the run and inspect artifact data.',
+  },
+  comment: {
+    label: 'Comment',
+    summary: 'Includes view access and can submit review comments.',
+  },
+  decide: {
+    label: 'Decide',
+    summary: 'Includes comment access and can submit final decisions.',
+  },
+};
+
 export function hasSharedValidationPermission(
   permission: ValidationSharePermission,
   required: ValidationSharePermission,
@@ -26,5 +52,15 @@ export function resolveSharedValidationCapabilities(
     canView: hasSharedValidationPermission(permission, 'view'),
     canComment: hasSharedValidationPermission(permission, 'comment'),
     canDecide: hasSharedValidationPermission(permission, 'decide'),
+  };
+}
+
+export function describeSharedValidationPermission(
+  permission: ValidationSharePermission,
+): SharedValidationPermissionDescriptor {
+  return {
+    permission,
+    ...SHARED_PERMISSION_METADATA[permission],
+    ...resolveSharedValidationCapabilities(permission),
   };
 }

--- a/frontend/src/lib/validation/shared-run-visibility.ts
+++ b/frontend/src/lib/validation/shared-run-visibility.ts
@@ -1,4 +1,27 @@
-import type { ValidationSharedRunSummary } from '@/lib/validation/types';
+import type {
+  ValidationDecision,
+  ValidationRunStatus,
+  ValidationSharePermission,
+  ValidationSharedRunSummary,
+} from '@/lib/validation/types';
+
+export type SharedRunPermissionFilter = ValidationSharePermission | 'all';
+export type SharedRunStatusFilter = ValidationRunStatus | 'all';
+export type SharedRunDecisionFilter = ValidationDecision | 'all';
+
+export interface SharedRunListFilters {
+  query: string;
+  permission: SharedRunPermissionFilter;
+  status: SharedRunStatusFilter;
+  decision: SharedRunDecisionFilter;
+}
+
+export const DEFAULT_SHARED_RUN_LIST_FILTERS = {
+  query: '',
+  permission: 'all',
+  status: 'all',
+  decision: 'all',
+} as const satisfies SharedRunListFilters;
 
 export function filterRunsSharedWithMe(
   runs: ValidationSharedRunSummary[],
@@ -9,5 +32,28 @@ export function filterRunsSharedWithMe(
       return true;
     }
     return run.ownerUserId !== currentUserId;
+  });
+}
+
+export function filterSharedRunsForDisplay(
+  runs: ValidationSharedRunSummary[],
+  filters: SharedRunListFilters,
+): ValidationSharedRunSummary[] {
+  const query = filters.query.trim().toLowerCase();
+
+  return runs.filter((run) => {
+    if (filters.permission !== 'all' && run.permission !== filters.permission) {
+      return false;
+    }
+    if (filters.status !== 'all' && run.status !== filters.status) {
+      return false;
+    }
+    if (filters.decision !== 'all' && run.finalDecision !== filters.decision) {
+      return false;
+    }
+    if (query.length > 0) {
+      return run.runId.toLowerCase().includes(query);
+    }
+    return true;
   });
 }


### PR DESCRIPTION
## Summary
- improve owner-side invite lifecycle UX with local validation, filtering, and status summaries
- improve shared-runs list UX with query + permission/status/decision filters and result counts
- improve permission visibility for `view` / `comment` / `decide` using shared descriptors in both lanes

## Scope and constraints
- frontend-only changes; no API contract changes introduced (dependency #346 remains source for any contract delta)
- fail-closed permission behavior preserved
- run-level sharing model and email invite flow preserved

## Validation
- `bun test src/lib/validation/__tests__/invite-lifecycle.test.ts src/lib/validation/__tests__/shared-permissions.test.ts src/lib/validation/__tests__/shared-run-visibility.test.ts`
- `bun test src/lib/validation`
- `bunx biome check 'src/app/(dashboard)/validation/page.tsx' 'src/app/(dashboard)/shared-validation/page.tsx' src/lib/validation/invite-lifecycle.ts src/lib/validation/shared-permissions.ts src/lib/validation/shared-run-visibility.ts src/lib/validation/__tests__/invite-lifecycle.test.ts src/lib/validation/__tests__/shared-permissions.test.ts src/lib/validation/__tests__/shared-run-visibility.test.ts`
- `bun run typecheck` (fails on pre-existing baseline errors outside this scope)

Closes #345
Refs #343

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only UX and client-side filtering/validation changes with no API/permission enforcement logic changes; primary risk is subtle UI/filter correctness regressions.
> 
> **Overview**
> Improves the *run sharing + shared validation* UX by adding client-side filtering and clearer permission messaging.
> 
> In `SharedValidation`, the runs list now supports query + permission/status/decision facets, shows result counts, and differentiates between “no runs shared” vs “no runs match filters”; permission summaries are also shown in both the list and active run detail via a new `describeSharedValidationPermission` descriptor.
> 
> In the owner `Validation` page, share invites now validate email format before submit, disable the invite button until inputs are valid, show permission summaries for selected invite permissions, and add an invite lifecycle header with per-status counts plus query/status/permission filters and invite result counts.
> 
> Adds reusable helpers (`filterSharedRunsForDisplay`, `filterInvites`, `summarizeInvitesByStatus`, default filter objects) with new unit tests to cover the filtering/summarization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81bd135d81d1e31069ad26e08be58eae61a0f0b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the invite/revoke and shared-run UX with filtering, status summaries, and shared permission descriptors across both owner and reviewer lanes.

**Key improvements:**
- Added multi-faceted filtering for invites (status/permission/query) with visual status summaries showing pending/accepted/expired/revoked counts
- Added multi-faceted filtering for shared runs (permission/status/decision/query) with result count display
- Introduced shared permission descriptor utility (`describeSharedValidationPermission`) providing consistent UI metadata (label, summary, capabilities) used in both validation and shared-validation pages
- All utilities have comprehensive test coverage validating filtering logic, hierarchical permissions, and invite lifecycle operations
- Frontend-only changes preserve fail-closed permission behavior and existing API contracts

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues
- Frontend-only changes with comprehensive test coverage, no API contract changes, well-structured utilities, and consistent patterns following existing codebase conventions
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/validation/invite-lifecycle.ts | Added filtering, sorting, and status summary utilities for invite lifecycle management with comprehensive test coverage |
| frontend/src/lib/validation/shared-permissions.ts | Added permission descriptor utility with hierarchical permission metadata for consistent UI display across both lanes |
| frontend/src/lib/validation/shared-run-visibility.ts | Added multi-faceted filtering (permission, status, decision, query) for shared run visibility with well-tested helpers |
| frontend/src/app/(dashboard)/validation/page.tsx | Enhanced owner-side UI with invite filtering (status/permission/query), status badge summaries, and shared permission descriptors |
| frontend/src/app/(dashboard)/shared-validation/page.tsx | Enhanced reviewer-side UI with multi-filter support (permission/status/decision/query) and result count display using shared descriptors |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Owner: Validation Page] -->|Creates invite| B[Invite Lifecycle Utils]
    B -->|filterInvites| C{Apply Filters}
    C -->|status filter| D[pending/accepted/revoked/expired]
    C -->|permission filter| E[view/comment/decide]
    C -->|query filter| F[email or invite ID]
    
    B -->|summarizeInvitesByStatus| G[Status Badge Counts]
    B -->|describeSharedValidationPermission| H[Permission Descriptor]
    
    I[Reviewer: Shared Validation Page] -->|Views shared runs| J[Shared Run Visibility Utils]
    J -->|filterRunsSharedWithMe| K{Exclude Owner Runs}
    J -->|filterSharedRunsForDisplay| L{Apply Filters}
    L -->|permission filter| E
    L -->|status filter| M[queued/running/completed/failed]
    L -->|decision filter| N[pass/conditional_pass/fail]
    L -->|query filter| O[run ID]
    
    J -->|describeSharedValidationPermission| H
    
    H -->|Provides| P[label + summary + capabilities]
    P -->|Used in| A
    P -->|Used in| I
```

<sub>Last reviewed commit: 81bd135</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=38ac846b-d2f5-429f-9d04-7bacd2646df5))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=25f54c50-3527-4a10-bf07-61cb309d8da3))

<!-- /greptile_comment -->