### PR TITLE
feat(web): improve bot registry and key lifecycle UX

### DIFF
--- a/frontend/src/lib/validation/__tests__/bot-ux-state.test.ts
+++ b/frontend/src/lib/validation/__tests__/bot-ux-state.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  applyValidationBotKeyRevocation,
+  applyValidationBotKeyRotation,
+  filterValidationBots,
+  formatValidationBotTimestamp,
+  mapValidationBotListResponse,
+  mergeValidationBotSummary,
+  normalizeValidationBotSummary,
+  resolveValidationBotKeyStateCounts,
+  resolveValidationBotRegistrationPathLabel,
+  toValidationBotUsageLabel,
+} from '../bot-ux-state';
+import type {
+  ValidationBotKeyMetadata,
+  ValidationBotKeyMetadataResponse,
+  ValidationBotKeyRotationResponse,
+  ValidationBotRegistrationResponse,
+  ValidationBotSummary,
+} from '../types';
+
+function makeKey(
+  id: string,
+  status: ValidationBotKeyMetadata['status'],
+  createdAt: string,
+): ValidationBotKeyMetadata {
+  return {
+    id,
+    botId: 'bot-001',
+    keyPrefix: `tnx.bot.${id}`,
+    status,
+    createdAt,
+    lastUsedAt: null,
+    revokedAt: status === 'revoked' ? createdAt : null,
+  };
+}
+
+function makeBot(
+  id: string,
+  status: ValidationBotSummary['status'],
+  createdAt: string,
+  ownerUserId: string,
+  keys: ValidationBotKeyMetadata[] = [],
+): ValidationBotSummary {
+  return normalizeValidationBotSummary({
+    id,
+    tenantId: 'tenant-001',
+    ownerUserId,
+    name: `Bot ${id}`,
+    status,
+    registrationPath: 'invite_code_trial',
+    trialExpiresAt: null,
+    metadata: { source: 'test' },
+    createdAt,
+    updatedAt: createdAt,
+    keys,
+    usage: {
+      totalRequests: 0,
+      lastSeenAt: null,
+    },
+  });
+}
+
+describe('bot ux state helpers', () => {
+  test('mapValidationBotListResponse normalizes and sorts active-first deterministically', () => {
+    const mapped = mapValidationBotListResponse({
+      items: [
+        makeBot('bot-revoked', 'revoked', '2026-02-20T10:00:00Z', 'user-3'),
+        makeBot('bot-active-new', 'active', '2026-02-20T13:00:00Z', 'user-2', [
+          makeKey('key-rotated', 'rotated', '2026-02-20T09:00:00Z'),
+          makeKey('key-active', 'active', '2026-02-20T11:00:00Z'),
+        ]),
+        makeBot('bot-active-old', 'active', '2026-02-20T08:00:00Z', 'user-1'),
+      ],
+    });
+
+    expect(mapped.map((bot) => bot.id)).toEqual([
+      'bot-active-new',
+      'bot-active-old',
+      'bot-revoked',
+    ]);
+    expect(mapped[0]?.keys.map((key) => key.id)).toEqual(['key-active', 'key-rotated']);
+  });
+
+  test('mergeValidationBotSummary upserts bot and keeps deterministic ordering', () => {
+    const current = [
+      makeBot('bot-002', 'active', '2026-02-20T12:00:00Z', 'user-2'),
+      makeBot('bot-001', 'active', '2026-02-20T10:00:00Z', 'user-1'),
+    ];
+    const registration: ValidationBotRegistrationResponse = {
+      requestId: 'req-registration-001',
+      bot: {
+        id: 'bot-003',
+        tenantId: 'tenant-001',
+        ownerUserId: 'user-3',
+        name: 'Bot bot-003',
+        status: 'active',
+        registrationPath: 'invite_code_trial',
+        trialExpiresAt: null,
+        metadata: { source: 'test' },
+        createdAt: '2026-02-20T13:00:00Z',
+        updatedAt: '2026-02-20T13:00:00Z',
+      },
+      registration: {
+        id: 'reg-001',
+        botId: 'bot-003',
+        registrationPath: 'invite_code_trial',
+        status: 'completed',
+        createdAt: '2026-02-20T13:00:00Z',
+      },
+      issuedKey: {
+        rawKey: 'tnx.bot.bot-003.key-001.secret',
+        key: {
+          id: 'key-001',
+          botId: 'bot-003',
+          keyPrefix: 'tnx.bot.key-001',
+          status: 'active',
+          createdAt: '2026-02-20T13:00:00Z',
+        },
+      },
+    };
+
+    const merged = mergeValidationBotSummary(current, registration);
+    expect(merged.map((bot) => bot.id)).toEqual(['bot-003', 'bot-002', 'bot-001']);
+    expect(merged[0]?.keys[0]?.id).toBe('key-001');
+  });
+
+  test('applyValidationBotKeyRotation marks previous active keys as rotated', () => {
+    const current = [
+      makeBot('bot-001', 'active', '2026-02-20T10:00:00Z', 'user-1', [
+        makeKey('key-001', 'active', '2026-02-20T10:00:00Z'),
+        makeKey('key-000', 'revoked', '2026-02-19T10:00:00Z'),
+      ]),
+    ];
+
+    const rotation: ValidationBotKeyRotationResponse = {
+      requestId: 'req-rotation-001',
+      botId: 'bot-001',
+      issuedKey: {
+        rawKey: 'tnx.bot.bot-001.key-002.secret',
+        key: {
+          id: 'key-002',
+          botId: 'bot-001',
+          keyPrefix: 'tnx.bot.key-002',
+          status: 'active',
+          createdAt: '2026-02-20T12:00:00Z',
+        },
+      },
+    };
+
+    const updated = applyValidationBotKeyRotation(current, 'bot-001', rotation.issuedKey.key);
+    expect(updated[0]?.keys.map((key) => `${key.id}:${key.status}`)).toEqual([
+      'key-002:active',
+      'key-001:rotated',
+      'key-000:revoked',
+    ]);
+  });
+
+  test('applyValidationBotKeyRevocation updates only the targeted key metadata', () => {
+    const current = [
+      makeBot('bot-001', 'active', '2026-02-20T10:00:00Z', 'user-1', [
+        makeKey('key-001', 'active', '2026-02-20T10:00:00Z'),
+        makeKey('key-002', 'rotated', '2026-02-20T09:00:00Z'),
+      ]),
+    ];
+    const revoked: ValidationBotKeyMetadataResponse = {
+      requestId: 'req-revoke-001',
+      botId: 'bot-001',
+      key: {
+        id: 'key-001',
+        botId: 'bot-001',
+        keyPrefix: 'tnx.bot.key-001',
+        status: 'revoked',
+        createdAt: '2026-02-20T10:00:00Z',
+        revokedAt: '2026-02-20T12:30:00Z',
+      },
+    };
+
+    const updated = applyValidationBotKeyRevocation(current, 'bot-001', revoked.key);
+    expect(updated[0]?.keys.find((key) => key.id === 'key-001')?.status).toBe('revoked');
+    expect(updated[0]?.keys.find((key) => key.id === 'key-002')?.status).toBe('rotated');
+  });
+
+  test('filterValidationBots filters by lifecycle status and search terms', () => {
+    const bots = [
+      makeBot('bot-001', 'active', '2026-02-20T10:00:00Z', 'owner-alpha'),
+      makeBot('bot-002', 'revoked', '2026-02-20T11:00:00Z', 'owner-beta'),
+    ];
+
+    expect(filterValidationBots(bots, 'revoked', '').map((bot) => bot.id)).toEqual(['bot-002']);
+    expect(filterValidationBots(bots, 'all', 'owner-alpha').map((bot) => bot.id)).toEqual([
+      'bot-001',
+    ]);
+  });
+
+  test('resolveValidationBotKeyStateCounts returns lifecycle totals', () => {
+    const bot = makeBot('bot-001', 'active', '2026-02-20T10:00:00Z', 'user-1', [
+      makeKey('key-active', 'active', '2026-02-20T10:00:00Z'),
+      makeKey('key-rotated', 'rotated', '2026-02-20T09:00:00Z'),
+      makeKey('key-revoked', 'revoked', '2026-02-20T08:00:00Z'),
+    ]);
+
+    expect(resolveValidationBotKeyStateCounts(bot)).toEqual({
+      active: 1,
+      rotated: 1,
+      revoked: 1,
+    });
+  });
+
+  test('format and label helpers remain deterministic', () => {
+    expect(formatValidationBotTimestamp('2026-02-20T13:14:15Z')).toBe('2026-02-20 13:14:15 UTC');
+    expect(
+      toValidationBotUsageLabel({ totalRequests: 1250, lastSeenAt: '2026-02-20T13:14:15Z' }),
+    ).toBe('1,250 total requests, last seen 2026-02-20 13:14:15 UTC');
+    expect(resolveValidationBotRegistrationPathLabel('invite_code_trial')).toBe(
+      'Invite Code Trial',
+    );
+    expect(resolveValidationBotRegistrationPathLabel('partner_bootstrap')).toBe(
+      'Partner Bootstrap',
+    );
+  });
+});

--- a/frontend/src/lib/validation/bot-ux-state.ts
+++ b/frontend/src/lib/validation/bot-ux-state.ts
@@ -1,0 +1,233 @@
+import type {
+  ValidationBotKeyMetadata,
+  ValidationBotKeyStatus,
+  ValidationBotRegistrationPath,
+  ValidationBotRegistrationResponse,
+  ValidationBotStatus,
+  ValidationBotSummary,
+  ValidationBotUsageMetadata,
+} from '@/lib/validation/types';
+
+const BOT_STATUS_WEIGHT: Record<ValidationBotStatus, number> = {
+  active: 0,
+  suspended: 1,
+  revoked: 2,
+};
+
+const KEY_STATUS_WEIGHT: Record<ValidationBotKeyStatus, number> = {
+  active: 0,
+  rotated: 1,
+  revoked: 2,
+};
+
+const REQUEST_COUNT_FORMATTER = new Intl.NumberFormat('en-US');
+
+function toTimestamp(value: string | null | undefined): number {
+  if (!value) {
+    return 0;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function sortValidationBotKeys(keys: ValidationBotKeyMetadata[]): ValidationBotKeyMetadata[] {
+  return [...keys].sort((left, right) => {
+    const statusDelta = KEY_STATUS_WEIGHT[left.status] - KEY_STATUS_WEIGHT[right.status];
+    if (statusDelta !== 0) {
+      return statusDelta;
+    }
+
+    const createdAtDelta = toTimestamp(right.createdAt) - toTimestamp(left.createdAt);
+    if (createdAtDelta !== 0) {
+      return createdAtDelta;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function normalizeValidationBotSummary(bot: ValidationBotSummary): ValidationBotSummary {
+  return {
+    ...bot,
+    keys: sortValidationBotKeys(bot.keys ?? []),
+  };
+}
+
+export function sortValidationBotSummaries(bots: ValidationBotSummary[]): ValidationBotSummary[] {
+  return [...bots].sort((left, right) => {
+    const statusDelta = BOT_STATUS_WEIGHT[left.status] - BOT_STATUS_WEIGHT[right.status];
+    if (statusDelta !== 0) {
+      return statusDelta;
+    }
+
+    const createdAtDelta = toTimestamp(right.createdAt) - toTimestamp(left.createdAt);
+    if (createdAtDelta !== 0) {
+      return createdAtDelta;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function mapValidationBotListResponse(payload: unknown): ValidationBotSummary[] {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const value = payload as { bots?: ValidationBotSummary[]; items?: ValidationBotSummary[] };
+  const entries = Array.isArray(value.bots)
+    ? value.bots
+    : Array.isArray(value.items)
+      ? value.items
+      : [];
+
+  return sortValidationBotSummaries(entries.map(normalizeValidationBotSummary));
+}
+
+export function mergeValidationBotSummary(
+  current: ValidationBotSummary[],
+  registration: ValidationBotRegistrationResponse,
+): ValidationBotSummary[] {
+  const incoming: ValidationBotSummary = normalizeValidationBotSummary({
+    ...registration.bot,
+    keys: [registration.issuedKey.key],
+  });
+  const filtered = current.filter((bot) => bot.id !== incoming.id);
+  return sortValidationBotSummaries([incoming, ...filtered]);
+}
+
+export function applyValidationBotKeyRotation(
+  current: ValidationBotSummary[],
+  botId: string,
+  issuedKey: ValidationBotKeyMetadata,
+): ValidationBotSummary[] {
+  const updated = current.map((bot) => {
+    if (bot.id !== botId) {
+      return bot;
+    }
+    const normalizedExisting = bot.keys.map((key) =>
+      key.status === 'active' ? { ...key, status: 'rotated' as const } : key,
+    );
+    return normalizeValidationBotSummary({
+      ...bot,
+      keys: [issuedKey, ...normalizedExisting],
+    });
+  });
+
+  return sortValidationBotSummaries(updated);
+}
+
+export function applyValidationBotKeyRevocation(
+  current: ValidationBotSummary[],
+  botId: string,
+  revokedKey: ValidationBotKeyMetadata,
+): ValidationBotSummary[] {
+  const updated = current.map((bot) => {
+    if (bot.id !== botId) {
+      return bot;
+    }
+    return normalizeValidationBotSummary({
+      ...bot,
+      keys: bot.keys.map((key) => (key.id === revokedKey.id ? revokedKey : key)),
+    });
+  });
+
+  return sortValidationBotSummaries(updated);
+}
+
+export interface ValidationBotKeyStateCounts {
+  active: number;
+  rotated: number;
+  revoked: number;
+}
+
+export function resolveValidationBotKeyStateCounts(
+  bot: Pick<ValidationBotSummary, 'keys'>,
+): ValidationBotKeyStateCounts {
+  const totals: ValidationBotKeyStateCounts = { active: 0, rotated: 0, revoked: 0 };
+  for (const key of bot.keys) {
+    if (key.status === 'active') {
+      totals.active += 1;
+      continue;
+    }
+    if (key.status === 'rotated') {
+      totals.rotated += 1;
+      continue;
+    }
+    totals.revoked += 1;
+  }
+  return totals;
+}
+
+export type ValidationBotListFilter = 'all' | ValidationBotStatus;
+
+export function filterValidationBots(
+  bots: ValidationBotSummary[],
+  filter: ValidationBotListFilter,
+  query: string,
+): ValidationBotSummary[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return bots.filter((bot) => {
+    if (filter !== 'all' && bot.status !== filter) {
+      return false;
+    }
+    if (!normalizedQuery) {
+      return true;
+    }
+
+    const searchable = [
+      bot.name,
+      bot.id,
+      bot.ownerUserId,
+      bot.registrationPath,
+      ...bot.keys.map((key) => key.keyPrefix),
+    ]
+      .join(' ')
+      .toLowerCase();
+
+    return searchable.includes(normalizedQuery);
+  });
+}
+
+export function resolveValidationBotOwnershipLabel(
+  bot: Pick<ValidationBotSummary, 'ownerUserId'>,
+): string {
+  return bot.ownerUserId?.trim() ? bot.ownerUserId : 'owner-unavailable';
+}
+
+export function resolveValidationBotRegistrationPathLabel(
+  registrationPath: ValidationBotRegistrationPath,
+): string {
+  if (registrationPath === 'invite_code_trial') {
+    return 'Invite Code Trial';
+  }
+  return 'Partner Bootstrap';
+}
+
+export function formatValidationBotTimestamp(value: string | null | undefined): string {
+  if (!value) {
+    return 'Unknown';
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return 'Unknown';
+  }
+  const iso = new Date(timestamp).toISOString();
+  return `${iso.slice(0, 19).replace('T', ' ')} UTC`;
+}
+
+export function toValidationBotUsageLabel(usage: ValidationBotUsageMetadata | undefined): string {
+  if (!usage) {
+    return 'No usage telemetry yet';
+  }
+
+  const requests =
+    usage.totalRequests !== undefined
+      ? `${REQUEST_COUNT_FORMATTER.format(usage.totalRequests)} total requests`
+      : '';
+  const lastSeen = usage.lastSeenAt
+    ? `last seen ${formatValidationBotTimestamp(usage.lastSeenAt)}`
+    : 'never used';
+  return requests ? `${requests}, ${lastSeen}` : lastSeen;
+}


### PR DESCRIPTION
## Summary
- improve bot registry UX with deterministic filtering/sorting and key lifecycle counters
- improve key lifecycle UX for create/rotate/revoke with deterministic state transitions
- add explicit owner visibility (`ownerUserId`) and single-owner scope messaging for future multi-user clarity
- keep fail-closed frontend behavior on permission/auth errors (401/403 clears in-memory bot/key state)
- add dedicated bot UX state helper module and unit tests

## Validation
- `cd frontend && bunx biome check 'src/app/(dashboard)/bots/page.tsx' src/lib/validation/bot-ux-state.ts src/lib/validation/__tests__/bot-ux-state.test.ts`
- `cd frontend && bun test src/lib/validation/__tests__/bot-ux-state.test.ts src/lib/validation/server/__tests__/platform-api.test.ts`
- `cd frontend && bun run typecheck` *(fails on pre-existing unrelated baseline errors in `cli/commands/__tests__/strategy.test.ts` and `src/lib/validation/__tests__/review-run-timeline.test.ts`)*

## Issue Links
Closes #344
Refs #343

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches key-rotation/revocation state transitions and bot list normalization/filtering, so UI can misrepresent lifecycle state if helper logic is wrong. No backend/auth changes, but the new fail-closed behavior on `401/403` could affect perceived data availability.
> 
> **Overview**
> Improves the Bots dashboard with **deterministic bot/key state handling** by centralizing normalization, sorting, lifecycle transitions (rotate/revoke), timestamp/usage formatting, and list filtering/search into a new `bot-ux-state` helper module.
> 
> Updates the UI to add status filter buttons + free-text search, per-bot and aggregate key lifecycle counters, explicit owner (`ownerUserId`) display with a new ownership-scope explainer, and more consistent one-time key reveal metadata (prefix + issued time). The page now also *fails closed* on `401/403` responses by clearing in-memory bot/key state.
> 
> Adds Bun unit tests covering mapping/ordering, merge/upsert behavior, rotate/revoke state transitions, filtering, counters, and deterministic labels/formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70522ccb76b0a8e0ff90c7af543b13b455fd35db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored bot registry UI and extracted state management logic into a dedicated helper module with comprehensive test coverage.

**Major changes:**
- Created `bot-ux-state.ts` helper module with deterministic sorting (active-first by creation time), filtering, and formatting utilities
- Added filtering/search UI with status filters (all/active/suspended/revoked) and text search across bot properties
- Displayed key lifecycle counters (active/rotated/revoked) at both list and individual bot levels
- Added explicit `ownerUserId` visibility with "Ownership Scope" messaging for future multi-user support
- Implemented fail-closed behavior on 401/403 errors (clears in-memory bot/key state)
- Replaced inline formatting logic (`toUsageLabel`, `mergeBotSummary`, `mapBotListResponse`) with tested helper functions
- Enhanced timestamp formatting with consistent UTC display format
- Disabled key rotation/revocation buttons when bot status is not active

**Code quality:**
- Well-organized separation of concerns (UI component vs state helpers)
- Comprehensive unit tests verify deterministic ordering and state transitions
- Type-safe implementations with proper TypeScript usage
- Follows project conventions for naming and structure

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested refactoring with improved UX and security posture
- Clean refactoring with comprehensive test coverage, deterministic state management, improved security (fail-closed auth errors), and no breaking changes. All logic is well-tested and follows TypeScript best practices.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/validation/bot-ux-state.ts | New helper module for bot state management with deterministic sorting, filtering, and formatting functions. Well-structured with comprehensive unit test coverage. |
| frontend/src/lib/validation/__tests__/bot-ux-state.test.ts | Comprehensive test suite covering all helper functions with deterministic sorting, state transitions, filtering, and formatting logic. |
| frontend/src/app/(dashboard)/bots/page.tsx | Refactored bot registry UI with filtering/search, key lifecycle counters, explicit ownership display, and fail-closed auth error handling. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Action] --> B{Action Type}
    B -->|Load Bots| C[fetch /api/validation/bots]
    B -->|Create Bot| D[POST registration endpoint]
    B -->|Rotate Key| E[POST /api/validation/bots/:id/keys/rotate]
    B -->|Revoke Key| F[POST /api/validation/bots/:id/keys/:id/revoke]
    B -->|Filter/Search| G[filterValidationBots]
    
    C --> H{Response OK?}
    D --> H
    E --> H
    F --> H
    
    H -->|401/403| I[applyFailClosedOnAccessError]
    I --> J[Clear bots and keys from state]
    
    H -->|Success| K[Process Response]
    K -->|Load| L[mapValidationBotListResponse]
    K -->|Register| M[mergeValidationBotSummary]
    K -->|Rotate| N[applyValidationBotKeyRotation]
    K -->|Revoke| O[applyValidationBotKeyRevocation]
    
    L --> P[sortValidationBotSummaries]
    M --> P
    N --> P
    O --> P
    
    P --> Q[normalizeValidationBotSummary]
    Q --> R[sortValidationBotKeys]
    R --> S[Update UI State]
    
    G --> S
    
    S --> T[visibleBots useMemo]
    T --> U[visibleBotKeyTotals useMemo]
    U --> V[Render Bot List with Filters]
```

<sub>Last reviewed commit: 70522cc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->