### PR TITLE
docs: canonicalize shared validation permissions and write routes

### DIFF
--- a/docs/llm/chunks/portal_validation_review_api_semantics_v1.md
+++ b/docs/llm/chunks/portal_validation_review_api_semantics_v1.md
@@ -77,14 +77,19 @@ Validation review APIs are defined in `/docs/architecture/specs/platform-api.ope
 ## Run-Level Sharing Semantics
 
 1. Sharing scope is run-level only:
-   - all invite routes are under `/v2/validation-sharing/...`.
-2. Invite targeting is email-only:
+   - all shared routes (invite lifecycle + shared review writes) are under `/v2/validation-sharing/...`.
+2. Permission model is canonicalized to `ValidationSharePermission = view | review`:
+   - `view` is read-only shared access.
+   - `review` permits shared review writes through `POST /v2/validation-sharing/runs/{runId}/review`.
+3. Backward compatibility:
+   - legacy permission aliases (`comment`, `decide`) normalize to `review`.
+4. Invite targeting is email-only:
    - `CreateValidationInviteRequest` requires `email` and does not include `userId`.
-3. Invite lifecycle states:
+5. Invite lifecycle states:
    - `pending`, `accepted`, `revoked`, `expired`.
-4. Granted share lifecycle states:
+6. Granted share lifecycle states:
    - `active`, `revoked` (`ValidationRunShare`).
-5. Invite acceptance:
+7. Invite acceptance:
    - `AcceptValidationInviteRequest` requires `acceptedEmail`.
    - response includes both updated `invite` and created/updated `share`.
 

--- a/docs/llm/chunks/portal_validation_review_incident_runbook_v1.md
+++ b/docs/llm/chunks/portal_validation_review_incident_runbook_v1.md
@@ -8,7 +8,7 @@ Stable ID: `portal_validation_review_incident_runbook_v1`
 
 ## Objective
 
-Provide deterministic incident handling for the validation review web program across bot identity, run-level sharing, and replay gate failure classes in scope for `#283`.
+Provide deterministic incident handling for the validation review web program across bot identity, run-level sharing, shared-review write paths, and replay gate failure classes in scope for `#283`.
 
 ## Incident Class A: Render Failures (`/render`)
 
@@ -192,6 +192,60 @@ curl -i -sS "$API_BASE/v2/validation-sharing/invites/$INVITE_ID/accept" \
 2. Confirm invite status using `GET /v2/validation-sharing/runs/{runId}/invites`.
 3. Reissue invite when state is `revoked`/`expired` and review must proceed.
 
+## Incident Class G: Shared Review Write Path Failures
+
+### Trigger
+
+Shared reviewers cannot submit review writes, or receive `403`/`404`/`409` from shared review submit path.
+
+### Expected Contract Behavior
+
+1. Shared review writes must use `POST /v2/validation-sharing/runs/{runId}/review`.
+2. Shared permission model is `view | review`:
+   - `view` does not allow writes.
+   - `review` allows shared write submission.
+3. Legacy aliases `comment` and `decide` normalize to `review` for backward compatibility.
+
+### Triage Commands
+
+```bash
+API_BASE="https://api-nexus.lona.agency"
+TOKEN="<bearer-token>"
+RUN_ID="<shared-run-id>"
+REQUEST_ID="req-shared-review-$(date +%s)"
+IDEM_KEY="idem-shared-review-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+curl -sS "$API_BASE/v2/validation-sharing/runs/shared-with-me?permission=review" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Request-Id: req-shared-list-001"
+
+curl -i -sS "$API_BASE/v2/validation-sharing/runs/$RUN_ID/review" \
+  -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Request-Id: $REQUEST_ID" \
+  -H "Idempotency-Key: $IDEM_KEY" \
+  -d '{
+    "reviewerType":"trader",
+    "decision":"pass",
+    "summary":"Shared reviewer incident probe"
+  }'
+```
+
+### Common Failure Cases
+
+1. `400`: malformed review payload (`reviewerType`/`decision` invalid).
+2. `401`: missing/expired auth session.
+3. `403`: share permission resolved to `view` or share access revoked.
+4. `404`: run not found in invitee scope or invalid `runId`.
+5. `409`: run/share state conflict prevents update.
+
+### Containment And Recovery
+
+1. Confirm invite/share permission resolves to `review` for the affected user.
+2. If share is missing or stale, reissue invite via `POST /v2/validation-sharing/runs/{runId}/invites` and re-accept.
+3. Ensure web proxy writes stay on `/v2/validation-sharing/...` routes only (no owner-scoped or removed alias routes).
+
 ## Secret Handling And Key Rotation Playbook
 
 ### Rules
@@ -229,7 +283,7 @@ Use this template in child issue `#313` and mirror summary in parent `#310`.
 Validation Review incident update:
 - Parent: #310
 - Child: #313
-- Incident class: render_failure | auth_failure | regression_failure | invite_rate_limit | invite_acceptance | key_compromise
+- Incident class: render_failure | auth_failure | regression_failure | invite_rate_limit | invite_acceptance | shared_review_write | key_compromise
 - Run ID / Replay ID: <id>
 - Request IDs: <list>
 - Impact: <scope + user effect>

--- a/docs/llm/index.json
+++ b/docs/llm/index.json
@@ -544,7 +544,7 @@
   },
   {
     "chunk": "docs/llm/chunks/portal_validation_review_api_semantics_v1.md",
-    "chunk_hash": "2a75b394eded8a32ff6a7669be58e6c090b906d447ce12b702cc709188753bc7",
+    "chunk_hash": "df5e69873b4b507eadd1a487942bdfacd14cca1ac6e577b42be0ff76c2fd28ed",
     "concepts": [
       "validation_api",
       "response_semantics",
@@ -557,6 +557,10 @@
       "/v2/validation-runs/{runId}/artifact",
       "/v2/validation-runs/{runId}/review",
       "/v2/validation-runs/{runId}/render",
+      "/v2/validation-sharing/runs/{runId}/invites",
+      "/v2/validation-sharing/invites/{inviteId}/revoke",
+      "/v2/validation-sharing/invites/{inviteId}/accept",
+      "/v2/validation-sharing/runs/{runId}/review",
       "/v2/validation-baselines",
       "/v2/validation-regressions/replay"
     ],
@@ -566,7 +570,7 @@
       "Validation Review Web Docs"
     ],
     "source": "docs/portal/api/validation-review-api-semantics.md",
-    "source_hash": "8947a765bc45642e93565f2a4a2e648a67498315b3bb4672ca05fbd0b6a5a6af",
+    "source_hash": "1066cf2048f278dd80e3c9448ab3edbf5dcac3b1f82be76f600793fc5f0c4a6d",
     "title": "Validation Review API Contracts And Response Semantics",
     "topic": "api",
     "workflows": [
@@ -576,7 +580,7 @@
   },
   {
     "chunk": "docs/llm/chunks/portal_validation_review_incident_runbook_v1.md",
-    "chunk_hash": "05d3e58f18fee78e8b3ea6134249a81b243887e42c5da882b33db7076d39c5a3",
+    "chunk_hash": "bdf900e131d0db898e79d937b0500b3572bb48d09500012c4b6e1905ba7a6641",
     "concepts": [
       "incident_runbook",
       "render_failure",
@@ -587,6 +591,10 @@
       "/v1/health",
       "/v2/validation-runs/{runId}/artifact",
       "/v2/validation-runs/{runId}/render",
+      "/v2/validation-sharing/invites/{inviteId}/accept",
+      "/v2/validation-sharing/runs/{runId}/invites",
+      "/v2/validation-sharing/runs/shared-with-me",
+      "/v2/validation-sharing/runs/{runId}/review",
       "/v2/validation-regressions/replay"
     ],
     "id": "portal_validation_review_incident_runbook_v1",
@@ -596,7 +604,7 @@
       "Team F"
     ],
     "source": "docs/portal/operations/validation-review-incident-runbook.md",
-    "source_hash": "16bd6fbc9f0fdb77ceaef9953def71f03ad3d46e4d3072b18b5237e8ab0841f9",
+    "source_hash": "f52f90ecee08e7f4ab280ccf59bf3d1945ffd837c638787dec6791accb8b447b",
     "title": "Validation Review Incident Runbook",
     "topic": "operations",
     "workflows": [
@@ -606,7 +614,7 @@
   },
   {
     "chunk": "docs/llm/chunks/portal_validation_reviewer_workflow_v1.md",
-    "chunk_hash": "aa7a9a4b47bc01cb2c47db28bc8ceac93cc4cef7932adfd366601b79efca1c52",
+    "chunk_hash": "ef1ea46583cb6682fe70711d6b705d1be2e1f53028e061a88d3a51a047a1e5fa",
     "concepts": [
       "reviewer_workflow",
       "web_lane",
@@ -618,7 +626,13 @@
       "/v2/validation-runs/{runId}",
       "/v2/validation-runs/{runId}/artifact",
       "/v2/validation-runs/{runId}/review",
-      "/v2/validation-runs/{runId}/render"
+      "/v2/validation-runs/{runId}/render",
+      "/v2/validation-sharing/runs/{runId}/invites",
+      "/v2/validation-sharing/invites/{inviteId}/revoke",
+      "/v2/validation-sharing/invites/{inviteId}/accept",
+      "/v2/validation-sharing/runs/{runId}",
+      "/v2/validation-sharing/runs/{runId}/artifact",
+      "/v2/validation-sharing/runs/{runId}/review"
     ],
     "id": "portal_validation_reviewer_workflow_v1",
     "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/313",
@@ -626,7 +640,7 @@
       "Validation Review Web Docs"
     ],
     "source": "docs/portal/platform/validation-reviewer-workflow.md",
-    "source_hash": "8d60424331ea71c1c3563cc433dd88934a182f8e6e7bb9e4aff02a0905d369e7",
+    "source_hash": "3a96eb41181fb8337981fcfc3eb072676b33675e94bf480ddea21334a8cc5ae7",
     "title": "Validation Review Web Reviewer Workflow",
     "topic": "platform",
     "workflows": [

--- a/docs/llm/manifest.json
+++ b/docs/llm/manifest.json
@@ -2,5 +2,5 @@
   "entry_count": 23,
   "schema_version": "1.0",
   "source_map": "docs/llm/source-map.json",
-  "source_map_hash": "c0a179eadb688436026fbf0e360c286002f27c71b1280e1bb360b21ab8f99058"
+  "source_map_hash": "68e2f0ada5bc99751896d9c38160963bffe474d7382356c052227b99dfa08825"
 }

--- a/docs/llm/source-map.json
+++ b/docs/llm/source-map.json
@@ -227,7 +227,7 @@
       "source": "docs/portal/api/validation-review-api-semantics.md",
       "topic": "api",
       "concepts": ["validation_api", "response_semantics", "auth_derived_identity", "idempotency"],
-      "endpoints": ["/v2/validation-runs", "/v2/validation-runs/{runId}", "/v2/validation-runs/{runId}/artifact", "/v2/validation-runs/{runId}/review", "/v2/validation-runs/{runId}/render", "/v2/validation-baselines", "/v2/validation-regressions/replay"],
+      "endpoints": ["/v2/validation-runs", "/v2/validation-runs/{runId}", "/v2/validation-runs/{runId}/artifact", "/v2/validation-runs/{runId}/review", "/v2/validation-runs/{runId}/render", "/v2/validation-sharing/runs/{runId}/invites", "/v2/validation-sharing/invites/{inviteId}/revoke", "/v2/validation-sharing/invites/{inviteId}/accept", "/v2/validation-sharing/runs/{runId}/review", "/v2/validation-baselines", "/v2/validation-regressions/replay"],
       "workflows": ["validation_review_web", "contract_first_review"],
       "owners": ["Validation Review Web Docs"],
       "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/313"
@@ -238,7 +238,7 @@
       "source": "docs/portal/operations/validation-review-incident-runbook.md",
       "topic": "operations",
       "concepts": ["incident_runbook", "render_failure", "auth_failure", "regression_failure"],
-      "endpoints": ["/v1/health", "/v2/validation-runs/{runId}/artifact", "/v2/validation-runs/{runId}/render", "/v2/validation-regressions/replay"],
+      "endpoints": ["/v1/health", "/v2/validation-runs/{runId}/artifact", "/v2/validation-runs/{runId}/render", "/v2/validation-sharing/invites/{inviteId}/accept", "/v2/validation-sharing/runs/{runId}/invites", "/v2/validation-sharing/runs/shared-with-me", "/v2/validation-sharing/runs/{runId}/review", "/v2/validation-regressions/replay"],
       "workflows": ["incident_response", "findings_disposition"],
       "owners": ["Validation Review Web Docs", "Team F"],
       "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/313"
@@ -249,7 +249,7 @@
       "source": "docs/portal/platform/validation-reviewer-workflow.md",
       "topic": "platform",
       "concepts": ["reviewer_workflow", "web_lane", "json_canonical", "status_reporting"],
-      "endpoints": ["/v2/validation-runs", "/v2/validation-runs/{runId}", "/v2/validation-runs/{runId}/artifact", "/v2/validation-runs/{runId}/review", "/v2/validation-runs/{runId}/render"],
+      "endpoints": ["/v2/validation-runs", "/v2/validation-runs/{runId}", "/v2/validation-runs/{runId}/artifact", "/v2/validation-runs/{runId}/review", "/v2/validation-runs/{runId}/render", "/v2/validation-sharing/runs/{runId}/invites", "/v2/validation-sharing/invites/{inviteId}/revoke", "/v2/validation-sharing/invites/{inviteId}/accept", "/v2/validation-sharing/runs/{runId}", "/v2/validation-sharing/runs/{runId}/artifact", "/v2/validation-sharing/runs/{runId}/review"],
       "workflows": ["reviewer_decision_flow", "issue_status_reporting"],
       "owners": ["Validation Review Web Docs"],
       "owner_issue": "https://github.com/iamtxena/trade-nexus/issues/313"

--- a/docs/llm/traceability.json
+++ b/docs/llm/traceability.json
@@ -141,23 +141,23 @@
   },
   {
     "chunk": "docs/llm/chunks/portal_validation_review_api_semantics_v1.md",
-    "chunk_hash": "2a75b394eded8a32ff6a7669be58e6c090b906d447ce12b702cc709188753bc7",
+    "chunk_hash": "df5e69873b4b507eadd1a487942bdfacd14cca1ac6e577b42be0ff76c2fd28ed",
     "id": "portal_validation_review_api_semantics_v1",
     "source": "docs/portal/api/validation-review-api-semantics.md",
-    "source_hash": "8947a765bc45642e93565f2a4a2e648a67498315b3bb4672ca05fbd0b6a5a6af"
+    "source_hash": "1066cf2048f278dd80e3c9448ab3edbf5dcac3b1f82be76f600793fc5f0c4a6d"
   },
   {
     "chunk": "docs/llm/chunks/portal_validation_review_incident_runbook_v1.md",
-    "chunk_hash": "05d3e58f18fee78e8b3ea6134249a81b243887e42c5da882b33db7076d39c5a3",
+    "chunk_hash": "bdf900e131d0db898e79d937b0500b3572bb48d09500012c4b6e1905ba7a6641",
     "id": "portal_validation_review_incident_runbook_v1",
     "source": "docs/portal/operations/validation-review-incident-runbook.md",
-    "source_hash": "16bd6fbc9f0fdb77ceaef9953def71f03ad3d46e4d3072b18b5237e8ab0841f9"
+    "source_hash": "f52f90ecee08e7f4ab280ccf59bf3d1945ffd837c638787dec6791accb8b447b"
   },
   {
     "chunk": "docs/llm/chunks/portal_validation_reviewer_workflow_v1.md",
-    "chunk_hash": "aa7a9a4b47bc01cb2c47db28bc8ceac93cc4cef7932adfd366601b79efca1c52",
+    "chunk_hash": "ef1ea46583cb6682fe70711d6b705d1be2e1f53028e061a88d3a51a047a1e5fa",
     "id": "portal_validation_reviewer_workflow_v1",
     "source": "docs/portal/platform/validation-reviewer-workflow.md",
-    "source_hash": "8d60424331ea71c1c3563cc433dd88934a182f8e6e7bb9e4aff02a0905d369e7"
+    "source_hash": "3a96eb41181fb8337981fcfc3eb072676b33675e94bf480ddea21334a8cc5ae7"
   }
 ]

--- a/docs/portal/api/validation-review-api-semantics.md
+++ b/docs/portal/api/validation-review-api-semantics.md
@@ -3,7 +3,7 @@ title: Validation Review API Contracts And Response Semantics
 summary: Contract-first endpoint and payload semantics for validation review, bot identity, and run-level sharing integrations.
 owners:
   - Validation Review Web Docs
-updated: 2026-02-21
+updated: 2026-02-25
 ---
 
 # Validation Review API Contracts And Response Semantics
@@ -79,14 +79,19 @@ Validation review APIs are defined in `/docs/architecture/specs/platform-api.ope
 ## Run-Level Sharing Semantics
 
 1. Sharing scope is run-level only:
-   - all invite routes are under `/v2/validation-sharing/...`.
-2. Invite targeting is email-only:
+   - all shared routes (invite lifecycle + shared review writes) are under `/v2/validation-sharing/...`.
+2. Permission model is canonicalized to `ValidationSharePermission = view | review`:
+   - `view` is read-only shared access.
+   - `review` permits shared review writes through `POST /v2/validation-sharing/runs/{runId}/review`.
+3. Backward compatibility:
+   - legacy permission aliases (`comment`, `decide`) normalize to `review`.
+4. Invite targeting is email-only:
    - `CreateValidationInviteRequest` requires `email` and does not include `userId`.
-3. Invite lifecycle states:
+5. Invite lifecycle states:
    - `pending`, `accepted`, `revoked`, `expired`.
-4. Granted share lifecycle states:
+6. Granted share lifecycle states:
    - `active`, `revoked` (`ValidationRunShare`).
-5. Invite acceptance:
+7. Invite acceptance:
    - `AcceptValidationInviteRequest` requires `acceptedEmail`.
    - response includes both updated `invite` and created/updated `share`.
 

--- a/docs/portal/platform/validation-reviewer-workflow.md
+++ b/docs/portal/platform/validation-reviewer-workflow.md
@@ -3,7 +3,7 @@ title: Validation Review Web Reviewer Workflow
 summary: Web-first workflow for validation runs, bot identity onboarding, and run-level Shared Validation access.
 owners:
   - Validation Review Web Docs
-updated: 2026-02-21
+updated: 2026-02-25
 ---
 
 # Validation Review Web Reviewer Workflow
@@ -85,14 +85,19 @@ Define the production flow for validation decisions, bot onboarding, and run-lev
    - `POST /v2/validation-sharing/invites/{inviteId}/accept`
    - request includes `acceptedEmail`
 5. Permission boundary:
-   - owner-scoped invite management and run-share mutation
-   - accepted invite grants `ValidationRunShare` for that run only
+   - canonical shared permission enum is `view | review`.
+   - `view` grants shared read access only (`GET /v2/validation-sharing/runs/{runId}` and `/artifact`).
+   - `review` grants shared read access plus shared write via `POST /v2/validation-sharing/runs/{runId}/review`.
+   - owner-scoped invite management and run-share mutation stay owner-only.
+6. Backward-compatibility note:
+   - legacy alias permissions (`comment`, `decide`) normalize to `review`; newly authored docs and clients should only emit `view | review`.
 
 ## Dedicated Shared Validation UX Surface
 
 1. Shared users enter through the Shared Validation reviewer flow (current web lane route `/validation`).
 2. Shared run access is established only through invite acceptance path; no ambient cross-run access.
 3. Shared users review canonical JSON first and request HTML/PDF only as derived outputs.
+4. Shared review submissions must target `POST /v2/validation-sharing/runs/{runId}/review` (not owner-scoped `/v2/validation-runs/{runId}/review`).
 
 ## Deep-Link Flow (`#279`)
 
@@ -146,6 +151,20 @@ curl -sS "$API_BASE/v2/validation-runs" \
       "failClosedOnEvidenceUnavailable":true
     }
   }'
+
+export RUN_ID="<shared-run-id>"
+export SHARED_REVIEW_IDEM_KEY="idem-shared-review-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+curl -sS "$API_BASE/v2/validation-sharing/runs/$RUN_ID/review" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Request-Id: req-shared-review-$(date +%s)" \
+  -H "Idempotency-Key: $SHARED_REVIEW_IDEM_KEY" \
+  -d '{
+    "reviewerType":"trader",
+    "decision":"pass",
+    "summary":"Shared review completed with no blocking findings."
+  }'
 ```
 
 ## Reviewer Evidence Checklist
@@ -181,5 +200,6 @@ Validation Review Web status:
 - Prior validation-review parent: [#288](https://github.com/iamtxena/trade-nexus/issues/288)
 - Web lane page: `/frontend/src/app/(dashboard)/validation/page.tsx`
 - Web API proxy: `/frontend/src/app/api/validation/runs/route.ts`
+- Shared web API proxy: `/frontend/src/app/api/shared-validation/runs/`
 - Contract source: `/docs/architecture/specs/platform-api.openapi.yaml`
 - Governance: `/.github/workflows/contracts-governance.yml`, `/.github/workflows/docs-governance.yml`, `/.github/workflows/llm-package-governance.yml`


### PR DESCRIPTION
closes #347 refs #343

## Summary
- update portal API semantics, reviewer workflow, and incident runbook docs to enforce canonical shared permission model (`view|review`)
- document canonical shared reviewer write path as `POST /v2/validation-sharing/runs/{runId}/review`
- add explicit backward-compatibility note for legacy aliases (`comment|decide -> review`)
- update LLM source-map endpoint metadata for the validation docs and regenerate `docs/llm` package artifacts (chunks/index/traceability/manifest)

## Checks
- `docs-governance` (local equivalent): `npm --prefix docs/portal-site run ci`
- `llm-package-governance` (local equivalent): `python3 scripts/docs/generate_llm_package.py` and `python3 scripts/docs/check_llm_package.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes plus regenerated LLM indexing metadata; no runtime behavior or API contract implementation is modified.
> 
> **Overview**
> **Canonicalizes Shared Validation permissions and write routing in the portal docs.** Shared access is now documented as `ValidationSharePermission = view | review`, with legacy aliases (`comment`, `decide`) explicitly normalizing to `review`.
> 
> Documents the canonical shared-review submission endpoint as `POST /v2/validation-sharing/runs/{runId}/review` and adds an incident runbook section for failures on this shared write path (expected behavior, triage commands, common errors, recovery steps).
> 
> Regenerates the `docs/llm` package artifacts (chunks + `index.json`/`source-map.json`/`traceability.json`/`manifest.json`) to include the updated endpoint metadata and hashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1799afc0a90433e66adf1a08642f883ddbac78c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Canonicalizes shared validation permissions (`view | review`) and documents the shared review write endpoint across portal documentation and LLM artifacts.

**Key Changes:**
- Permission model now explicitly defines `view` (read-only) and `review` (read + write via `POST /v2/validation-sharing/runs/{runId}/review`)
- Legacy permission aliases (`comment`, `decide`) documented to normalize to `review` for backward compatibility
- Added Incident Class G runbook section for shared review write path failures with triage commands and recovery steps
- All portal docs updated consistently across API semantics, incident runbook, and reviewer workflow
- LLM package artifacts regenerated with updated hashes and endpoint metadata

No runtime behavior changes—documentation-only clarification of existing API contracts.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only changes with properly synchronized LLM artifacts. All portal docs consistently updated, hashes correctly regenerated, and no code implementation modified.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/portal/api/validation-review-api-semantics.md | Canonicalizes shared permission model to `view | review` with backward-compatibility notes |
| docs/portal/operations/validation-review-incident-runbook.md | Adds Incident Class G for shared review write path failures with triage commands |
| docs/portal/platform/validation-reviewer-workflow.md | Documents canonical shared review write endpoint and adds curl example |
| docs/llm/index.json | Regenerated with updated hashes and new endpoint metadata |
| docs/llm/manifest.json | Updated source_map_hash to reflect regenerated artifacts |

</details>


</details>


<sub>Last reviewed commit: 1799afc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->