### PR TITLE
fix(frontend): canonical shared permission semantics (view|review)

### DIFF
--- a/frontend/src/app/(dashboard)/validation/page.tsx
+++ b/frontend/src/app/(dashboard)/validation/page.tsx
@@ -47,7 +47,10 @@ import {
   type ValidationTimelineEvent,
   resolveValidationRunTimeline,
 } from '@/lib/validation/review-run-timeline';
-import { describeSharedValidationPermission } from '@/lib/validation/shared-permissions';
+import {
+  describeSharedValidationPermission,
+  normalizeSharedValidationPermission,
+} from '@/lib/validation/shared-permissions';
 import {
   type CreateValidationRunRequestPayload,
   type CreateValidationShareInvitePayload,
@@ -206,11 +209,8 @@ function resolveTimelineIcon(tone: ValidationTimelineEvent['tone']) {
 }
 
 function sharePermissionToBadgeVariant(permission: ValidationSharePermission) {
-  if (permission === 'decide') {
+  if (permission === 'review') {
     return 'default';
-  }
-  if (permission === 'comment') {
-    return 'secondary';
   }
   return 'outline';
 }
@@ -236,7 +236,7 @@ function normalizeInvite(
 ): ValidationShareInvite {
   return {
     ...invite,
-    permission: invite.permission ?? fallbackPermission,
+    permission: normalizeSharedValidationPermission(invite.permission, fallbackPermission),
   };
 }
 
@@ -1145,8 +1145,7 @@ export default function ValidationPage() {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="view">view</SelectItem>
-                      <SelectItem value="comment">comment</SelectItem>
-                      <SelectItem value="decide">decide</SelectItem>
+                      <SelectItem value="review">review</SelectItem>
                     </SelectContent>
                   </Select>
                   <p className="text-xs text-muted-foreground">
@@ -1242,8 +1241,7 @@ export default function ValidationPage() {
                     <SelectContent>
                       <SelectItem value="all">all permissions</SelectItem>
                       <SelectItem value="view">view</SelectItem>
-                      <SelectItem value="comment">comment</SelectItem>
-                      <SelectItem value="decide">decide</SelectItem>
+                      <SelectItem value="review">review</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/frontend/src/app/api/validation/runs/[runId]/invites/route.ts
+++ b/frontend/src/app/api/validation/runs/[runId]/invites/route.ts
@@ -4,6 +4,7 @@ import {
   isValidValidationRunId,
   proxyValidationPlatformCallWithFallback,
 } from '@/lib/validation/server/platform-api';
+import { normalizeSharedValidationPermission } from '@/lib/validation/shared-permissions';
 import type { CreateValidationShareInvitePayload } from '@/lib/validation/types';
 import { NextResponse } from 'next/server';
 
@@ -48,6 +49,14 @@ export async function POST(request: Request, { params }: { params: Promise<{ run
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
+  const normalizedPayload: CreateValidationShareInvitePayload = {
+    ...payload,
+    permission: normalizeSharedValidationPermission(
+      (payload as { permission?: string }).permission,
+      'review',
+    ),
+  };
+
   return proxyValidationPlatformCallWithFallback({
     method: 'POST',
     paths: [
@@ -55,7 +64,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ run
       `/v2/shared-validation/runs/${runId}/invites`,
     ],
     access: accessResult.access,
-    body: payload,
+    body: normalizedPayload,
     idempotencyKey:
       request.headers.get('Idempotency-Key') ?? buildValidationIdempotencyKey('share-invite'),
   });

--- a/frontend/src/lib/validation/__tests__/invite-lifecycle.test.ts
+++ b/frontend/src/lib/validation/__tests__/invite-lifecycle.test.ts
@@ -19,7 +19,7 @@ function invite(
     id,
     runId: 'valrun-001',
     email: `${id}@example.com`,
-    permission: 'comment',
+    permission: 'review',
     status,
     invitedByUserId: 'user-1',
     invitedByActorType: 'user',
@@ -63,7 +63,7 @@ describe('invite lifecycle helpers', () => {
     const base = [
       invite('inv-001', 'pending', '2026-02-20T10:00:00Z'),
       { ...invite('inv-002', 'accepted', '2026-02-20T11:00:00Z'), permission: 'view' as const },
-      { ...invite('inv-003', 'revoked', '2026-02-20T12:00:00Z'), permission: 'decide' as const },
+      { ...invite('inv-003', 'revoked', '2026-02-20T12:00:00Z'), permission: 'review' as const },
     ];
 
     const filtered = filterInvites(base, {

--- a/frontend/src/lib/validation/__tests__/shared-run-visibility.test.ts
+++ b/frontend/src/lib/validation/__tests__/shared-run-visibility.test.ts
@@ -14,7 +14,7 @@ function run(
 ): ValidationSharedRunSummary {
   return {
     runId: id,
-    permission: 'comment',
+    permission: 'review',
     status: 'completed',
     profile: 'STANDARD',
     finalDecision: 'pass',
@@ -47,7 +47,7 @@ describe('filterRunsSharedWithMe', () => {
     const visible = filterRunsSharedWithMe(input, 'user-owner');
     visible[0] = {
       ...visible[0],
-      permission: 'decide',
+      permission: 'review',
       status: 'running',
       finalDecision: 'conditional_pass',
     };
@@ -55,7 +55,7 @@ describe('filterRunsSharedWithMe', () => {
     const filtered = filterSharedRunsForDisplay(visible, {
       ...DEFAULT_SHARED_RUN_LIST_FILTERS,
       query: '002',
-      permission: 'decide',
+      permission: 'review',
       status: 'running',
       decision: 'conditional_pass',
     });

--- a/frontend/src/lib/validation/types.ts
+++ b/frontend/src/lib/validation/types.ts
@@ -220,7 +220,7 @@ export function isValidationRunArtifact(
   );
 }
 
-export type ValidationSharePermission = 'view' | 'comment' | 'decide';
+export type ValidationSharePermission = 'view' | 'review';
 export type ValidationInviteStatus = 'pending' | 'accepted' | 'revoked' | 'expired';
 export type ValidationShareStatus = 'active' | 'revoked';
 export type ValidationBotStatus = 'active' | 'suspended' | 'revoked';


### PR DESCRIPTION
## Summary
- canonicalize frontend shared permission model to `view|review`
- add deterministic legacy alias normalization (`comment|decide -> review`) at ingestion/proxy boundaries
- update shared validation + invite UI selectors/metadata and regression tests for canonical + legacy compatibility

## Validation
- `bun test src/lib/validation/__tests__/shared-permissions.test.ts src/lib/validation/__tests__/shared-run-visibility.test.ts src/lib/validation/__tests__/invite-lifecycle.test.ts`

Closes #353
Refs #343

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared-run/invite permission semantics and normalization across UI and API proxying; mismatches could unintentionally grant/deny comment/decision capabilities until fully aligned with backend data.
> 
> **Overview**
> Standardizes the frontend shared-validation permission model from `view|comment|decide` to **canonical** `view|review`, updating the type definition and all UI selectors/badges/help text to only expose `review` for non-read-only access.
> 
> Adds `normalizeSharedValidationPermission()` and routes all permission checks/metadata through it so legacy backend values (`comment`/`decide`) are deterministically treated as `review`; this normalization is applied when ingesting shared run lists/details and when proxying invite creation (`POST /api/validation/runs/[runId]/invites`).
> 
> Updates unit tests to cover the new `review` semantics and verify legacy alias compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fae748c532436e9a8387aa1b04b25a1e4450cee7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Canonicalizes frontend shared validation permissions from 3-tier (`view|comment|decide`) to 2-tier (`view|review`) model with deterministic legacy alias normalization.

**Key Changes:**
- Consolidated `comment` and `decide` permissions into single `review` permission for simplified UX
- Added `normalizeSharedValidationPermission()` with legacy alias mapping (`comment|decide` → `review`)
- Updated type definitions, UI selectors, badge variants, and help text across validation pages
- Applied normalization at data ingestion boundaries (shared run lists/details) and API proxying layer
- Comprehensive test updates cover canonical semantics and legacy compatibility

**Issue Found:**
- API route fallback defaults to `review` (more permissive) instead of `view` (safer default) when permission is invalid/missing

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the permission fallback in the API route
- Well-structured refactoring with comprehensive test coverage, but contains a logical security issue where invalid permissions default to `review` instead of `view`, violating least privilege principle
- `frontend/src/app/api/validation/runs/[runId]/invites/route.ts` needs fallback changed from `review` to `view` for security

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/validation/types.ts | Simple type change from 3-tier (`view|comment|decide`) to 2-tier (`view|review`) permission model |
| frontend/src/lib/validation/shared-permissions.ts | Adds well-structured normalization logic for legacy aliases, updates permission ranking and metadata to canonical model |
| frontend/src/app/api/validation/runs/[runId]/invites/route.ts | Normalizes permissions before proxying to backend; fallback grants `review` instead of safer `view` default (see comment) |
| frontend/src/app/(dashboard)/validation/page.tsx | Updates UI selectors and badge logic to use canonical `view|review` permissions, normalizes invite permissions |
| frontend/src/app/(dashboard)/shared-validation/page.tsx | Normalizes permissions when ingesting shared run lists/details, updates UI text and selectors for canonical model |

</details>


</details>


<sub>Last reviewed commit: fae748c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->