### PR TITLE
fix(cli): post-merge remediation for moltbook replicate

### DIFF
--- a/frontend/cli/commands/__tests__/moltbook.test.ts
+++ b/frontend/cli/commands/__tests__/moltbook.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+import { spinner } from '../../lib/output';
+import { extractStrategyIdFromOutput, runStrategyCreateCommand } from '../moltbook';
+
+class FakeStrategyCreateProcess extends EventEmitter {
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+}
+
+describe('moltbook strategy creation helpers', () => {
+  let stdoutWriteSpy: ReturnType<typeof spyOn> | null = null;
+  let consoleLogSpy: ReturnType<typeof spyOn> | null = null;
+
+  afterEach(() => {
+    stdoutWriteSpy?.mockRestore();
+    consoleLogSpy?.mockRestore();
+    stdoutWriteSpy = null;
+    consoleLogSpy = null;
+  });
+
+  test('extracts strategy ID from ANSI-colored command output (#363)', () => {
+    const strategyId = '123e4567-e89b-12d3-a456-426614174000';
+    const ansiOutput = [
+      '\u001b[32m✓\u001b[0m Strategy created!',
+      `\u001b[1mID:\u001b[0m \u001b[36m${strategyId}\u001b[0m`,
+    ].join('\n');
+
+    expect(extractStrategyIdFromOutput(ansiOutput)).toBe(strategyId);
+  });
+
+  test('keeps spinner output responsive while strategy creation command is running (#362)', async () => {
+    stdoutWriteSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+    consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
+
+    const strategyId = '123e4567-e89b-12d3-a456-426614174000';
+    const delayedSpawn: NonNullable<
+      Parameters<typeof runStrategyCreateCommand>[2]
+    >['spawnCommand'] = () => {
+      const child = new FakeStrategyCreateProcess();
+      setTimeout(() => {
+        child.stdout.write(`\u001b[1mID:\u001b[0m \u001b[36m${strategyId}\u001b[0m\n`);
+        child.stdout.end();
+        child.stderr.end();
+        child.emit('close', 0, null);
+      }, 220);
+      return child;
+    };
+
+    const spin = spinner('Creating strategy on Lona (this takes ~5 min)...');
+    const commandPromise = runStrategyCreateCommand('desc', 'name', {
+      cwd: '.',
+      spawnCommand: delayedSpawn,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 130));
+
+    expect(stdoutWriteSpy.mock.calls.length).toBeGreaterThan(0);
+
+    const output = await commandPromise;
+    spin.stop('Strategy created');
+
+    expect(extractStrategyIdFromOutput(output)).toBe(strategyId);
+  });
+});

--- a/frontend/cli/commands/moltbook.ts
+++ b/frontend/cli/commands/moltbook.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -75,6 +75,127 @@ function sanitizeStrategySegment(value: string): string {
     .replace(/[^a-zA-Z0-9]/g, '_')
     .replace(/_+/g, '_')
     .replace(/^_+|_+$/g, '');
+}
+
+type StrategyCreateSpawnResult = {
+  stdout: NodeJS.ReadableStream | null;
+  stderr: NodeJS.ReadableStream | null;
+  on(event: 'error', listener: (error: Error) => void): StrategyCreateSpawnResult;
+  on(
+    event: 'close',
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): StrategyCreateSpawnResult;
+};
+
+type StrategyCreateSpawn = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    stdio: 'pipe';
+    timeout: number;
+  },
+) => StrategyCreateSpawnResult;
+
+function stripAnsi(value: string): string {
+  let sanitized = '';
+  let i = 0;
+
+  while (i < value.length) {
+    if (value[i] !== '\u001b') {
+      sanitized += value[i];
+      i += 1;
+      continue;
+    }
+
+    i += 1;
+    if (value[i] !== '[') {
+      continue;
+    }
+
+    i += 1;
+    while (i < value.length) {
+      const code = value.charCodeAt(i);
+      if (code >= 0x40 && code <= 0x7e) {
+        i += 1;
+        break;
+      }
+      i += 1;
+    }
+  }
+
+  return sanitized;
+}
+
+function toTextChunk(chunk: unknown): string {
+  if (typeof chunk === 'string') return chunk;
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString('utf-8');
+  return String(chunk);
+}
+
+export function extractStrategyIdFromOutput(commandOutput: string): string | null {
+  const output = stripAnsi(commandOutput);
+  const strategyIdMatch = output.match(/\bID:\s*([a-f0-9-]+)/i);
+  return strategyIdMatch ? strategyIdMatch[1] : null;
+}
+
+export async function runStrategyCreateCommand(
+  strategyDesc: string,
+  strategyName: string,
+  options?: {
+    cwd?: string;
+    spawnCommand?: StrategyCreateSpawn;
+  },
+): Promise<string> {
+  const cwd = options?.cwd ?? '.';
+  const spawnCommand = options?.spawnCommand ?? spawn;
+
+  return await new Promise((resolve, reject) => {
+    let child: StrategyCreateSpawnResult;
+    try {
+      child = spawnCommand(
+        'bun',
+        [
+          'run',
+          'nexus',
+          'strategy',
+          'create',
+          '--description',
+          strategyDesc,
+          '--name',
+          strategyName,
+        ],
+        {
+          cwd,
+          stdio: 'pipe',
+          timeout: 310000,
+        },
+      );
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    let commandOutput = '';
+    child.stdout?.on('data', (chunk) => {
+      commandOutput += toTextChunk(chunk);
+    });
+    child.stderr?.on('data', (chunk) => {
+      commandOutput += toTextChunk(chunk);
+    });
+
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve(commandOutput);
+        return;
+      }
+
+      const signalPart = signal ? ` (signal ${signal})` : '';
+      const fallback = `Command failed with exit code ${code ?? 'unknown'}${signalPart}`;
+      reject(new Error(commandOutput || fallback));
+    });
+  });
 }
 
 export async function moltbookCommand(args: string[]) {
@@ -276,30 +397,12 @@ async function replicateStrategy(args: string[]) {
 
   try {
     const strategyName = `${sanitizeStrategySegment(post.author.name)}_${sanitizeStrategySegment(post.title).substring(0, 30)}`;
-    const result = spawnSync(
-      'bun',
-      ['run', 'nexus', 'strategy', 'create', '--description', strategyDesc, '--name', strategyName],
-      {
-        cwd: process.env.TRADE_NEXUS_PATH || '.',
-        encoding: 'utf-8',
-        timeout: 310000,
-      },
-    );
-
-    if (result.error) {
-      throw result.error;
-    }
-
-    const commandOutput = `${result.stdout ?? ''}${result.stderr ?? ''}`;
-    if (result.status !== 0) {
-      throw new Error(
-        commandOutput || `Command failed with exit code ${result.status ?? 'unknown'}`,
-      );
-    }
+    const commandOutput = await runStrategyCreateCommand(strategyDesc, strategyName, {
+      cwd: process.env.TRADE_NEXUS_PATH || '.',
+    });
 
     // Extract strategy ID
-    const strategyIdMatch = commandOutput.match(/ID: ([a-f0-9-]+)/i);
-    const strategyId = strategyIdMatch ? strategyIdMatch[1] : null;
+    const strategyId = extractStrategyIdFromOutput(commandOutput);
 
     if (!strategyId) {
       throw new Error('Could not extract strategy ID from output');


### PR DESCRIPTION
## Summary
- make strategy ID extraction ANSI-safe in `nexus moltbook replicate`
- replace blocking sync strategy-create execution with async child process execution
- add regressions for colored output parsing and non-blocking spinner responsiveness

## Validation
- `./node_modules/.bin/biome check cli/commands/moltbook.ts cli/commands/__tests__/moltbook.test.ts`
- `bun test cli/commands/__tests__/moltbook.test.ts`
- `bun test cli/commands/__tests__/strategy.test.ts cli/commands/__tests__/backtest.test.ts`
- `bun run nexus moltbook replicate --help`

closes #362
closes #363

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `nexus moltbook replicate` executes the long-running `strategy create` command (sync -> async) and how it parses command output, which could affect error handling, timeouts, and output capture across environments.
> 
> **Overview**
> Fixes `nexus moltbook replicate` strategy creation by replacing the blocking `spawnSync` call with an async `spawn`-based helper (`runStrategyCreateCommand`) that streams stdout/stderr while the spinner remains responsive.
> 
> Makes strategy ID parsing robust to ANSI-colored output via `extractStrategyIdFromOutput` (strips ANSI before matching), and adds regression tests covering ANSI parsing and spinner responsiveness during delayed child-process output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c98024a9c95c992796478730fbd595365f9bb31d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two post-merge bugs in the `nexus moltbook replicate` command:

- **ANSI-safe strategy ID extraction (#363)**: Implemented `stripAnsi` function to remove ANSI color codes before parsing strategy ID from CLI output. The custom implementation correctly handles CSI (Control Sequence Introducer) escape sequences (e.g., `\u001b[32m` for colors) by detecting the ESC character (`\u001b[`), scanning until the terminator byte (0x40-0x7e range), and stripping the entire sequence.

- **Non-blocking async execution (#362)**: Replaced `spawnSync` with `spawn` to prevent blocking the event loop during the ~5 minute strategy creation command. This allows the spinner to remain responsive and provide user feedback during long-running operations.

Both fixes include targeted regression tests that verify ANSI parsing and spinner responsiveness with appropriate mocking and timing assertions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-isolated bug fixes with comprehensive test coverage. The implementation correctly handles ANSI escape sequences and async process management. Both issues are addressed with targeted solutions that don't affect other parts of the codebase. Tests verify the fixes work as expected.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/cli/commands/moltbook.ts | Replaced synchronous spawnSync with async spawn for strategy creation, added stripAnsi function for ANSI-safe ID extraction, and exported helper functions for testability |
| frontend/cli/commands/__tests__/moltbook.test.ts | Added regression tests for ANSI color code handling (#363) and non-blocking spinner responsiveness (#362) with proper mocking and timing assertions |

</details>


</details>


<sub>Last reviewed commit: c98024a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->