### PR TITLE
docs(portal): add CLI auth quickstart and operator runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ This index is the canonical navigation entry point for Gate-based documentation 
 ## Audience Lanes
 
 - End users: workflow and troubleshooting guides in `/docs/portal/cli/` and `/docs/portal/operations/`.
+- CLI auth quickstart: `/docs/portal/cli/authenticate-cli.md`.
+- CLI auth operator runbook: `/docs/portal/operations/cli-auth-operator-runbook.md`.
 - API consumers: contract and integration docs in `/docs/architecture/INTERFACES.md` and `/docs/portal/api/`.
 - Operators: deployment and operational docs in `/docs/architecture/DEPLOYMENT.md` and `/docs/portal/operations/`.
 - Internal developers: architecture boundaries and gate playbooks in `/docs/architecture/`.

--- a/docs/portal/cli/authenticate-cli.md
+++ b/docs/portal/cli/authenticate-cli.md
@@ -1,0 +1,100 @@
+---
+title: Authenticate CLI
+summary: End-user quickstart for human and bot authentication in trading-cli.
+owners:
+  - Gate1 Docs Team
+updated: 2026-03-02
+---
+
+# Authenticate CLI
+
+Use this guide to establish and validate `trading-cli` authentication before running strategy, backtest, deployment, or validation workflows.
+
+## Quickstart
+
+### Login (human auth)
+
+```bash
+export PLATFORM_API_BASE_URL="https://api-nexus.lona.agency"
+export PLATFORM_API_BEARER_TOKEN="<jwt-access-token>"
+trading-cli health get
+```
+
+### Whoami (identity/scope check)
+
+```bash
+trading-cli bot list
+```
+
+### Logout
+
+```bash
+unset PLATFORM_API_BEARER_TOKEN PLATFORM_API_TOKEN PLATFORM_API_KEY
+```
+
+## Bot Auth vs Human Auth
+
+| Use case | Credential | Env var | Notes |
+| --- | --- | --- | --- |
+| Human operator in terminal or CI job with user identity | JWT bearer token | `PLATFORM_API_BEARER_TOKEN` | Preferred for user-scoped operations and invite acceptance flows. |
+| Runtime bot automation | Runtime bot key (`tnx.bot.<botId>.<keyId>.<secret>`) | `PLATFORM_API_KEY` | Works for bot actor requests while preserving owner scope in validation flows. |
+| Backward compatibility | Bearer token alias | `PLATFORM_API_TOKEN` | Alias for bearer auth; prefer `PLATFORM_API_BEARER_TOKEN` for new setups. |
+
+## Failure Troubleshooting
+
+### Expired Token
+
+Expected error shape:
+- `httpStatus: 401`
+- `code: "AUTH_UNAUTHORIZED"`
+
+Recovery:
+1. Mint a fresh bearer token from your identity provider.
+2. Re-export `PLATFORM_API_BEARER_TOKEN`.
+3. Re-run:
+
+```bash
+trading-cli health get
+```
+
+### Revoked Token (Bot Key)
+
+Expected error shape:
+- `httpStatus: 401`
+- `code: "BOT_API_KEY_REVOKED"`
+
+Recovery:
+1. Rotate the bot key:
+
+```bash
+trading-cli key rotate --bot-id <bot-id> --reason "replace revoked key"
+```
+
+2. Update secret storage with the newly issued key.
+3. Retry the failed command with the new `PLATFORM_API_KEY`.
+
+### Unauthorized (Missing/Invalid Credential)
+
+Expected error shape:
+- `httpStatus: 401`
+- `code: "AUTH_UNAUTHORIZED"` or `code: "BOT_API_KEY_INVALID"`
+
+Recovery:
+1. Check auth vars:
+
+```bash
+env | rg '^PLATFORM_API_(BEARER_TOKEN|TOKEN|KEY)='
+```
+
+2. Ensure `PLATFORM_API_BASE_URL` is set to platform host or local loopback.
+3. Retry with request correlation:
+
+```bash
+trading-cli bot list --request-id req-cli-auth-check-001
+```
+
+## Related Docs
+
+- [CLI Common Workflows](./workflows.md)
+- [Operator Runbook: CLI Auth Sessions](../operations/cli-auth-operator-runbook.md)
+- [Operations Troubleshooting](../operations/troubleshooting.md)

--- a/docs/portal/cli/workflows.md
+++ b/docs/portal/cli/workflows.md
@@ -20,6 +20,7 @@ updated: 2026-02-14
 
 ## Usage References
 
+- CLI authentication quickstart: [Authenticate CLI](./authenticate-cli.md)
 - CLI interface model: `/docs/architecture/CLI_INTERFACE.md`
 - Delivery topology: `/docs/architecture/DELIVERY_PLAN_AND_TEAM_TOPOLOGY.md`
 - Platform API contract: `/docs/architecture/specs/platform-api.openapi.yaml`

--- a/docs/portal/getting-started/quickstart.md
+++ b/docs/portal/getting-started/quickstart.md
@@ -36,6 +36,7 @@ This quickstart covers the baseline Gate0 + Gate1 user journey: research, strate
 
 ## Next Steps
 
+- Authentication quickstart: [Authenticate CLI](../cli/authenticate-cli.md)
 - Detailed CLI flow: [CLI Common Workflows](../cli/workflows.md)
 - Contract boundaries: [Platform API Contract](../api/platform-api.md)
 - Troubleshooting: [Troubleshooting](../operations/troubleshooting.md)

--- a/docs/portal/operations/cli-auth-operator-runbook.md
+++ b/docs/portal/operations/cli-auth-operator-runbook.md
@@ -1,0 +1,136 @@
+---
+title: CLI Auth Operator Runbook
+summary: Incident and operations runbook for CLI auth revocation, token TTL policy, and audit tracing.
+owners:
+  - Gate1 Docs Team
+updated: 2026-03-02
+---
+
+# CLI Auth Operator Runbook
+
+This runbook covers credential incidents and governance for CLI authentication paths used by `trading-cli`.
+
+## Revoke Compromised CLI Sessions
+
+### 1. Classify the compromised credential
+
+1. Human session token (JWT bearer).
+2. Runtime bot key (`tnx.bot.<botId>.<keyId>.<secret>`).
+
+### 2. Revoke compromised runtime bot key
+
+If `botId` and `keyId` are known:
+
+```bash
+trading-cli key revoke \
+  --bot-id <bot-id> \
+  --key-id <key-id> \
+  --reason "compromised credential" \
+  --request-id req-cli-auth-revoke-001
+```
+
+If only `botId` is known and any active key may be compromised, rotate immediately:
+
+```bash
+trading-cli key rotate \
+  --bot-id <bot-id> \
+  --reason "emergency rotation" \
+  --request-id req-cli-auth-rotate-001
+```
+
+Then:
+1. Update downstream secret stores with the new key.
+2. Restart affected automation workers.
+3. Verify old key now fails with `BOT_API_KEY_REVOKED`.
+
+### 3. Revoke compromised human session token
+
+1. Revoke the session/token in the identity provider (Clerk/JWT issuer).
+2. Force re-authentication for affected users.
+3. Validate old token is rejected (`AUTH_UNAUTHORIZED`).
+
+### 4. Post-incident validation
+
+```bash
+trading-cli bot list --request-id req-cli-auth-postcheck-001
+trading-cli health get
+```
+
+## Token TTL Policy
+
+| Credential / token type | Enforcement source | Current behavior | Operator policy |
+| --- | --- | --- | --- |
+| Human bearer JWT | JWT issuer + Platform API claim validation | `exp` is required and validated; 15-second leeway is allowed for clock skew. | Keep short-lived access tokens (recommended: 15-60 minutes) and force refresh on sensitive environments. |
+| Runtime bot key | Platform API validation identity service | No built-in expiration; key remains valid until rotated/revoked. | Rotate at least every 30 days and immediately on any compromise signal. |
+| Bot invite code | Validation identity service | Invite code TTL defaults to 3600 seconds. | Keep at 1 hour or less; regenerate on expiry. |
+| Lona gateway token | Backend env (`LONA_TOKEN_TTL_DAYS`) | Default is `30` days. | Keep minimum viable TTL for integrations and rotate on ownership changes. |
+
+## Audit and Event Tracing Fields
+
+### Request-level correlation
+
+Use request IDs on all incident actions:
+
+```bash
+trading-cli key revoke --bot-id <bot-id> --key-id <key-id> --request-id req-cli-auth-audit-001
+```
+
+`trading-cli` surfaces `requestId` in responses and error envelopes for correlation.
+
+### Validation identity audit event schema
+
+| Field | Description |
+| --- | --- |
+| `id` | Audit event record ID. |
+| `event_type` | `register`, `rotate`, `revoke`, `share`, or `accept`. |
+| `request_id` | Correlation ID from request header/CLI flag. |
+| `tenant_id` | Tenant scope for event. |
+| `owner_user_id` | Owner user identity scope. |
+| `actor_type` | `user` or `bot`. |
+| `actor_id` | Acting user ID or bot ID. |
+| `metadata` | Event-specific fields (see below). |
+| `created_at` | UTC event timestamp. |
+
+### Metadata keys by event type
+
+| Event type | Metadata keys |
+| --- | --- |
+| `register` | `botId`, `keyId`, `method` |
+| `rotate` | `botId`, `rotatedKeyIds`, `issuedKeyId` |
+| `revoke` (bot key) | `botId`, `revokedKeyIds` |
+| `share` | `runId`, `inviteId`, `inviteeEmail`, `permission` |
+| `accept` | `runId`, `inviteId`, `acceptedEmail`, `permission` |
+
+### Structured request log fields
+
+Platform API structured logs include:
+- `requestId`
+- `tenantId`
+- `userId`
+- `component`
+- `operation`
+- optional `resourceType`, `resourceId`, `statusCode`
+
+Use these fields to stitch CLI request IDs to backend events during incident review.
+
+## OPEN/MERGED Evidence Comment Templates
+
+### OPEN
+
+```text
+Status: OPEN
+- Parent: <parent-link>
+- Child: <child-link>
+- Incident/Task: CLI auth rollout
+- Evidence: requestId=<request-id>, command=<command>, result=<result>
+```
+
+### MERGED
+
+```text
+Status: MERGED
+- Parent: <parent-link>
+- Child: <child-link>
+- PR: <merged-pr-link>
+- Evidence: requestId=<request-id>, command=<command>, result=<result>
+```

--- a/docs/portal/operations/troubleshooting.md
+++ b/docs/portal/operations/troubleshooting.md
@@ -27,3 +27,12 @@ updated: 2026-02-14
   - `python3 scripts/docs/check_links.py`
   - `python3 scripts/docs/check_stale_references.py`
   - `npm --prefix docs/portal-site run build`
+
+## Auth Failures (CLI)
+
+- Quickstart + auth mode selection: [Authenticate CLI](../cli/authenticate-cli.md)
+- Operator incident response and audit fields: [CLI Auth Operator Runbook](./cli-auth-operator-runbook.md)
+- Common 401 patterns:
+  - `AUTH_UNAUTHORIZED`: missing/expired/invalid bearer credentials.
+  - `BOT_API_KEY_INVALID`: malformed or unknown runtime bot key.
+  - `BOT_API_KEY_REVOKED`: runtime bot key was revoked.


### PR DESCRIPTION
## Summary
- add end-user CLI authentication quickstart with login/whoami/logout examples
- add bot-vs-human auth decision table and auth failure troubleshooting
- add operator runbook for compromised-session revocation, token TTL policy, and audit/event tracing fields
- wire new docs into quickstart/workflows/troubleshooting indexes

## Validation
- npm --prefix docs/portal-site run ci
- python3 scripts/docs/generate_llm_package.py
- python3 scripts/docs/check_llm_package.py

## PR Linking
- Parent PR: this PR
- Child PR: https://github.com/iamtxena/trading-cli/pull/46

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive CLI authentication documentation for `trading-cli`, introducing two new major documents: an end-user quickstart (`authenticate-cli.md`) with login/logout examples and bot vs human auth comparison, and an operator runbook (`cli-auth-operator-runbook.md`) covering credential revocation procedures, token TTL policies, and audit tracing fields.

The changes systematically wire these new docs into the existing documentation structure by adding navigation links in `docs/README.md`, the CLI workflows page, the quickstart guide, and the troubleshooting page. All internal documentation links are valid and properly formatted, and the content follows consistent markdown standards with proper YAML frontmatter.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only changes with no runtime code modifications. All internal links verified to exist, markdown formatting is correct, content is comprehensive and well-structured, and YAML frontmatter follows existing patterns.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/README.md | Added two navigation bullets for new CLI auth docs in the audience lanes section |
| docs/portal/cli/authenticate-cli.md | New comprehensive authentication quickstart with login/logout examples, bot vs human auth table, and failure troubleshooting |
| docs/portal/cli/workflows.md | Added link to new authentication quickstart in usage references section |
| docs/portal/getting-started/quickstart.md | Added authentication quickstart link to next steps section |
| docs/portal/operations/cli-auth-operator-runbook.md | New operator runbook covering credential revocation, TTL policies, audit tracing fields, and evidence templates |
| docs/portal/operations/troubleshooting.md | Added new auth failures section with common 401 error codes and links to auth docs |

</details>


</details>


<sub>Last reviewed commit: 031daff</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->