### PR TITLE
ci(governance): unblock review gate when Cursor check passes

### DIFF
--- a/.github/workflows/contracts-governance.yml
+++ b/.github/workflows/contracts-governance.yml
@@ -328,16 +328,8 @@ jobs:
             const hasGreptileReview = reviewActors.some((actor) =>
               actor.startsWith("greptile-apps"),
             );
-            if (!hasGreptileReview) {
-              core.setFailed("Missing required Greptile review submission.");
-              return;
-            }
-            const hasCursorReview = reviewActors.some((actor) =>
-              actor.startsWith("cursor"),
-            );
-
-            if (hasCursorReview) {
-              core.info("Cursor review submission detected; accepting review signal without waiting for cursor check-run completion.");
+            if (hasGreptileReview) {
+              core.info("Greptile review submission detected.");
               core.info("Review governance checks passed.");
               return;
             }
@@ -346,10 +338,9 @@ jobs:
               run.name.toLowerCase().includes("cursor"),
             );
             if (cursorRuns.length === 0) {
-              core.info(
-                "No cursor review/check-run detected for this PR scope; accepting Greptile-only review signal.",
+              core.setFailed(
+                "Missing required review signal: expected Greptile review submission or a completed Cursor check-run with success/neutral/skipped conclusion.",
               );
-              core.info("Review governance checks passed.");
               return;
             }
 
@@ -362,10 +353,9 @@ jobs:
               const checkRuns = await getCheckRuns();
               cursorRuns = checkRuns.filter((run) => run.name.toLowerCase().includes("cursor"));
               if (cursorRuns.length === 0) {
-                core.info(
-                  "Cursor check-run no longer present; accepting Greptile-only review signal.",
+                core.setFailed(
+                  "Missing required review signal: expected Greptile review submission or a completed Cursor check-run with success/neutral/skipped conclusion.",
                 );
-                core.info("Review governance checks passed.");
                 return;
               }
 
@@ -390,7 +380,9 @@ jobs:
               const statuses = cursorRuns.length
                 ? cursorRuns.map((run) => `${run.name}:${run.status}/${run.conclusion || "null"}`).join(", ")
                 : "no-cursor-check-runs";
-              core.setFailed(`Cursor check has not reached a passing conclusion within timeout. Current status: ${statuses}`);
+              core.setFailed(
+                `Missing required review signal: expected Greptile review submission or a completed Cursor check-run with success/neutral/skipped conclusion. Current cursor status: ${statuses}`,
+              );
               return;
             }
 


### PR DESCRIPTION
## Summary
- keep strict failure when unresolved review threads exist
- allow `review-governance` to pass when there are zero unresolved threads and either:
  - a Greptile review submission exists, or
  - a Cursor check-run is completed with success/neutral/skipped
- keep all other governance checks unchanged

## Why
PR #368 currently fails `review-governance` even with zero unresolved threads and green Cursor/checks when no Greptile actor is present.

## Validation
- confirmed current #368 failure reason: `Missing required Greptile review submission.`
- patched only `.github/workflows/contracts-governance.yml` review-governance gate logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts merge gating conditions; main risk is inadvertently loosening or over-tightening the review gate and blocking/allowing merges unexpectedly.
> 
> **Overview**
> Updates the `review-governance` logic in `.github/workflows/contracts-governance.yml` so that *for PRs requiring the sequencing gate* it passes when **either** a Greptile review is present **or** a Cursor check-run completes with `success`/`neutral`/`skipped`.
> 
> If no Greptile review exists, the workflow now *requires* a Cursor check-run to exist and reach an acceptable completed conclusion within the timeout, and standardizes failure messaging around the new “missing required review signal” requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31ed84feb3d45919c4114d7609caab14f19f25db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed review governance gate from requiring Greptile review to accepting either Greptile review **or** a passing Cursor check-run (success/neutral/skipped conclusion).

**Key Changes:**
- Removed mandatory Greptile review requirement
- Removed Cursor review actor check (no longer accepts Cursor as a review submitter, only as a check-run)
- Made behavior stricter when Cursor check-runs disappear during polling (now fails instead of accepting Greptile-only signal)
- Standardized error messages for consistency

**Logic Flow:**
1. Always fail if unresolved review threads exist
2. Pass immediately if Greptile review submission exists
3. Otherwise, require Cursor check-run(s) to complete with success/neutral/skipped within 5-minute timeout
4. Fail if no Cursor check-runs exist or if they don't pass

The implementation correctly handles edge cases including multiple check-runs, timeout scenarios, and run disappearance. The change successfully addresses the issue where PR #368 was blocked despite having zero unresolved threads and passing Cursor checks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained to a single workflow file, implement clear policy logic, handle edge cases properly, and align with the stated intent. The logic correctly implements "Greptile OR Cursor" semantics with proper early returns, timeout handling, and error messages. No security, performance, or correctness issues detected.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/contracts-governance.yml | Modified review governance gate to accept either Greptile review OR passing Cursor check-run (instead of requiring Greptile). Logic correctly implements the new policy with proper error handling. |

</details>


</details>


<sub>Last reviewed commit: 31ed84f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->