### PR TITLE
feat: expand CLI auth beyond validation-only with explicit v1 scope domains

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from typing import Any
 from uuid import uuid4
 
 from dotenv import load_dotenv
@@ -138,6 +139,32 @@ def _parse_bearer_token(authorization: str | None) -> str | None:
     return normalized if normalized else None
 
 
+def _resolve_cli_identity_from_bearer(*, request: Request, request_id: str) -> tuple[Any | None, PlatformAPIError | None]:
+    bearer_token = _parse_bearer_token(request.headers.get("Authorization"))
+    if not (isinstance(bearer_token, str) and bearer_token.startswith("tnx.cli.")):
+        return None, None
+    try:
+        cli_identity = router_v2_module.resolve_cli_access_token_identity(
+            access_token=bearer_token,
+            tenant_header=request.headers.get("X-Tenant-Id"),
+            user_header=request.headers.get("X-User-Id"),
+            request_id=request_id,
+        )
+    except PlatformAPIError as exc:
+        return None, exc
+    return cli_identity, None
+
+
+def _apply_cli_identity_to_request_state(*, request: Request, cli_identity: Any) -> None:
+    request.state.tenant_id = cli_identity.tenant_id
+    request.state.user_id = cli_identity.user_id
+    request.state.user_email_authenticated = False
+    request.state.user_email = None
+    request.state.auth_method = "cli_token"
+    request.state.cli_scopes = cli_identity.scopes
+    request.state.cli_session_id = cli_identity.session_id
+
+
 @app.middleware("http")
 async def platform_api_observability_context_middleware(request: Request, call_next):
     """Attach request correlation identifiers and emit structured request logs."""
@@ -156,31 +183,16 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                     request_id=request.state.request_id,
                 )
             except PlatformAPIError as exc:
-                bearer_token = _parse_bearer_token(request.headers.get("Authorization"))
+                final_exc = exc
                 cli_identity = None
-                if (
-                    exc.code == "AUTH_UNAUTHORIZED"
-                    and isinstance(bearer_token, str)
-                    and bearer_token.startswith("tnx.cli.")
-                ):
-                    try:
-                        cli_identity = router_v2_module._identity_service.resolve_cli_access_token(  # noqa: SLF001
-                            access_token=bearer_token,
-                            tenant_header=request.headers.get("X-Tenant-Id"),
-                            user_header=request.headers.get("X-User-Id"),
-                            request_id=request.state.request_id,
-                        )
-                    except PlatformAPIError as cli_exc:
-                        exc = cli_exc
-                if cli_identity is not None:
-                    request.state.tenant_id = cli_identity.tenant_id
-                    request.state.user_id = cli_identity.user_id
-                    request.state.user_email_authenticated = False
-                    request.state.user_email = None
-                    request.state.auth_method = "cli_token"
-                    request.state.cli_scopes = cli_identity.scopes
-                    request.state.cli_session_id = cli_identity.session_id
-                else:
+                if exc.code == "AUTH_UNAUTHORIZED":
+                    cli_identity, cli_error = _resolve_cli_identity_from_bearer(
+                        request=request,
+                        request_id=request.state.request_id,
+                    )
+                    if cli_error is not None:
+                        final_exc = cli_error
+                if cli_identity is None:
                     request.state.tenant_id = "tenant-unauthenticated"
                     request.state.user_id = "user-unauthenticated"
                     request.state.user_email_authenticated = False
@@ -193,11 +205,12 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                         request=request,
                         component="api",
                         operation="request_rejected",
-                        status_code=exc.status_code,
-                        errorCode=exc.code,
+                        status_code=final_exc.status_code,
+                        errorCode=final_exc.code,
                         method=request.method,
                     )
-                    return await platform_api_error_handler(request, exc)
+                    return await platform_api_error_handler(request, final_exc)
+                _apply_cli_identity_to_request_state(request=request, cli_identity=cli_identity)
             else:
                 request.state.tenant_id = identity.tenant_id
                 request.state.user_id = identity.user_id
@@ -252,22 +265,15 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                         request_id=request.state.request_id,
                     )
                 except PlatformAPIError as exc:
-                    bearer_token = _parse_bearer_token(request.headers.get("Authorization"))
                     cli_identity = None
-                    if (
-                        exc.code == "AUTH_UNAUTHORIZED"
-                        and isinstance(bearer_token, str)
-                        and bearer_token.startswith("tnx.cli.")
-                    ):
-                        try:
-                            cli_identity = router_v2_module._identity_service.resolve_cli_access_token(  # noqa: SLF001
-                                access_token=bearer_token,
-                                tenant_header=request.headers.get("X-Tenant-Id"),
-                                user_header=request.headers.get("X-User-Id"),
-                                request_id=request.state.request_id,
-                            )
-                        except PlatformAPIError as cli_exc:
-                            exc = cli_exc
+                    final_exc = exc
+                    if exc.code == "AUTH_UNAUTHORIZED":
+                        cli_identity, cli_error = _resolve_cli_identity_from_bearer(
+                            request=request,
+                            request_id=request.state.request_id,
+                        )
+                        if cli_error is not None:
+                            final_exc = cli_error
                     if cli_identity is None:
                         request.state.tenant_id = "tenant-unauthenticated"
                         request.state.user_id = "user-unauthenticated"
@@ -281,18 +287,12 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                             request=request,
                             component="api",
                             operation="request_rejected",
-                            status_code=exc.status_code,
-                            errorCode=exc.code,
+                            status_code=final_exc.status_code,
+                            errorCode=final_exc.code,
                             method=request.method,
                         )
-                        return await platform_api_error_handler(request, exc)
-                    request.state.tenant_id = cli_identity.tenant_id
-                    request.state.user_id = cli_identity.user_id
-                    request.state.user_email_authenticated = False
-                    request.state.user_email = None
-                    request.state.auth_method = "cli_token"
-                    request.state.cli_scopes = cli_identity.scopes
-                    request.state.cli_session_id = cli_identity.session_id
+                        return await platform_api_error_handler(request, final_exc)
+                    _apply_cli_identity_to_request_state(request=request, cli_identity=cli_identity)
                 else:
                     request.state.tenant_id = identity.tenant_id
                     request.state.user_id = identity.user_id

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -156,28 +156,56 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                     request_id=request.state.request_id,
                 )
             except PlatformAPIError as exc:
-                request.state.tenant_id = "tenant-unauthenticated"
-                request.state.user_id = "user-unauthenticated"
-                request.state.user_email_authenticated = False
-                request.state.user_email = None
-                request.state.auth_method = "none"
-                log_request_event(
-                    logger,
-                    level=logging.WARNING,
-                    message="Platform API request rejected.",
-                    request=request,
-                    component="api",
-                    operation="request_rejected",
-                    status_code=exc.status_code,
-                    errorCode=exc.code,
-                    method=request.method,
+                bearer_token = _parse_bearer_token(request.headers.get("Authorization"))
+                cli_identity = None
+                if (
+                    exc.code == "AUTH_UNAUTHORIZED"
+                    and isinstance(bearer_token, str)
+                    and bearer_token.startswith("tnx.cli.")
+                ):
+                    try:
+                        cli_identity = router_v2_module._identity_service.resolve_cli_access_token(  # noqa: SLF001
+                            access_token=bearer_token,
+                            tenant_header=request.headers.get("X-Tenant-Id"),
+                            user_header=request.headers.get("X-User-Id"),
+                            request_id=request.state.request_id,
+                        )
+                    except PlatformAPIError as cli_exc:
+                        exc = cli_exc
+                if cli_identity is not None:
+                    request.state.tenant_id = cli_identity.tenant_id
+                    request.state.user_id = cli_identity.user_id
+                    request.state.user_email_authenticated = False
+                    request.state.user_email = None
+                    request.state.auth_method = "cli_token"
+                    request.state.cli_scopes = cli_identity.scopes
+                    request.state.cli_session_id = cli_identity.session_id
+                else:
+                    request.state.tenant_id = "tenant-unauthenticated"
+                    request.state.user_id = "user-unauthenticated"
+                    request.state.user_email_authenticated = False
+                    request.state.user_email = None
+                    request.state.auth_method = "none"
+                    log_request_event(
+                        logger,
+                        level=logging.WARNING,
+                        message="Platform API request rejected.",
+                        request=request,
+                        component="api",
+                        operation="request_rejected",
+                        status_code=exc.status_code,
+                        errorCode=exc.code,
+                        method=request.method,
+                    )
+                    return await platform_api_error_handler(request, exc)
+            else:
+                request.state.tenant_id = identity.tenant_id
+                request.state.user_id = identity.user_id
+                request.state.user_email_authenticated = bool(identity.user_email)
+                request.state.user_email = identity.user_email
+                request.state.auth_method = (
+                    "jwt" if _parse_bearer_token(request.headers.get("Authorization")) else "api_key"
                 )
-                return await platform_api_error_handler(request, exc)
-            request.state.tenant_id = identity.tenant_id
-            request.state.user_id = identity.user_id
-            request.state.user_email_authenticated = bool(identity.user_email)
-            request.state.user_email = identity.user_email
-            request.state.auth_method = "jwt" if _parse_bearer_token(request.headers.get("Authorization")) else "api_key"
         elif _is_v2_validation_request(request.url.path):
             is_public_registration_route = _is_v2_validation_public_registration_request(request.url.path)
             has_auth_headers = bool(

--- a/backend/src/platform_api/router_v1.py
+++ b/backend/src/platform_api/router_v1.py
@@ -17,6 +17,7 @@ from src.platform_api.adapters.data_knowledge_adapter import (
 )
 from src.platform_api.adapters.execution_adapter import InMemoryExecutionAdapter, LiveEngineExecutionAdapter
 from src.platform_api.adapters.lona_adapter import LonaAdapterBaseline
+from src.platform_api.errors import PlatformAPIError
 from src.platform_api.knowledge.ingestion import KnowledgeIngestionPipeline
 from src.platform_api.knowledge.query import KnowledgeQueryService
 from src.platform_api.schemas_v1 import (
@@ -123,6 +124,38 @@ _execution_service = ExecutionService(
 _dataset_service = DatasetOrchestrator(store=_store, data_bridge_adapter=_data_bridge_adapter)
 
 
+def _request_auth_method(request: Request) -> str:
+    raw = getattr(request.state, "auth_method", None)
+    return raw if isinstance(raw, str) else "none"
+
+
+def _normalized_request_path(path: str) -> str:
+    normalized = path.strip()
+    if normalized == "":
+        return "/"
+    return normalized if normalized == "/" else normalized.rstrip("/")
+
+
+def _is_single_resource_path(*, path: str, prefix: str) -> bool:
+    if not path.startswith(prefix):
+        return False
+    candidate = path[len(prefix):]
+    return candidate != "" and "/" not in candidate
+
+
+def _required_cli_scope(*, path: str, method: str) -> str | None:
+    normalized_path = _normalized_request_path(path)
+    if method.upper() != "GET":
+        return None
+    if normalized_path == "/v1/strategies" or _is_single_resource_path(path=normalized_path, prefix="/v1/strategies/"):
+        return "strategy:read"
+    if _is_single_resource_path(path=normalized_path, prefix="/v1/backtests/"):
+        return "backtest:read"
+    if normalized_path == "/v1/deployments" or _is_single_resource_path(path=normalized_path, prefix="/v1/deployments/"):
+        return "deployment:read"
+    return None
+
+
 async def _request_context(
     request: Request,
     x_request_id: str | None = Header(default=None, alias="X-Request-Id"),
@@ -136,6 +169,37 @@ async def _request_context(
     user_id = state_user_id if isinstance(state_user_id, str) and state_user_id.strip() else "user-local"
     request.state.tenant_id = tenant_id
     request.state.user_id = user_id
+
+    if _request_auth_method(request) == "cli_token":
+        raw_scopes = getattr(request.state, "cli_scopes", ())
+        normalized_scopes = {
+            scope.strip().lower()
+            for scope in raw_scopes
+            if isinstance(scope, str) and scope.strip()
+        }
+        required_scope = _required_cli_scope(path=request.url.path, method=request.method)
+        if required_scope is None:
+            raise PlatformAPIError(
+                status_code=403,
+                code="CLI_AUTH_SCOPE_FORBIDDEN",
+                message="CLI token is not authorized for this endpoint.",
+                request_id=request_id,
+                details={
+                    "requiredScope": None,
+                    "scopes": sorted(normalized_scopes),
+                    "path": _normalized_request_path(request.url.path),
+                    "method": request.method.upper(),
+                },
+            )
+        if required_scope not in normalized_scopes:
+            raise PlatformAPIError(
+                status_code=403,
+                code="CLI_AUTH_SCOPE_FORBIDDEN",
+                message=f"CLI token is missing required scope: {required_scope}.",
+                request_id=request_id,
+                details={"requiredScope": required_scope, "scopes": sorted(normalized_scopes)},
+            )
+
     return RequestContext(
         request_id=request_id,
         tenant_id=tenant_id,

--- a/backend/src/platform_api/router_v1.py
+++ b/backend/src/platform_api/router_v1.py
@@ -197,7 +197,12 @@ async def _request_context(
                 code="CLI_AUTH_SCOPE_FORBIDDEN",
                 message=f"CLI token is missing required scope: {required_scope}.",
                 request_id=request_id,
-                details={"requiredScope": required_scope, "scopes": sorted(normalized_scopes)},
+                details={
+                    "requiredScope": required_scope,
+                    "scopes": sorted(normalized_scopes),
+                    "path": _normalized_request_path(request.url.path),
+                    "method": request.method.upper(),
+                },
             )
 
     return RequestContext(

--- a/backend/src/platform_api/router_v2.py
+++ b/backend/src/platform_api/router_v2.py
@@ -105,6 +105,24 @@ _identity_service = ValidationIdentityService(store=router_v1_module._store)
 _validation_service = ValidationV2Service(store=router_v1_module._store, identity_service=_identity_service)
 
 
+def resolve_cli_access_token_identity(
+    *,
+    access_token: str | None,
+    tenant_header: str | None,
+    user_header: str | None,
+    request_id: str,
+    update_last_used: bool = True,
+):
+    """Public wrapper for CLI access token identity resolution."""
+    return _identity_service.resolve_cli_access_token(
+        access_token=access_token,
+        tenant_header=tenant_header,
+        user_header=user_header,
+        request_id=request_id,
+        update_last_used=update_last_used,
+    )
+
+
 async def _request_context(
     request: Request,
     x_request_id: str | None = Header(default=None, alias="X-Request-Id"),

--- a/backend/src/platform_api/schemas_v2.py
+++ b/backend/src/platform_api/schemas_v2.py
@@ -538,7 +538,13 @@ class ValidationRegressionReplayResponse(BaseModel):
 BotStatus = Literal["active", "suspended", "revoked"]
 BotRegistrationPath = Literal["invite_code_trial", "partner_bootstrap"]
 BotKeyStatus = Literal["active", "rotated", "revoked"]
-ValidationCliScope = Literal["validation:read", "validation:write"]
+ValidationCliScope = Literal[
+    "validation:read",
+    "validation:write",
+    "strategy:read",
+    "backtest:read",
+    "deployment:read",
+]
 ValidationSharePermission = Literal["view", "review"]
 ValidationInviteStatus = Literal["pending", "accepted", "revoked", "expired"]
 ValidationShareStatus = Literal["active", "revoked"]

--- a/backend/src/platform_api/services/validation_identity_service.py
+++ b/backend/src/platform_api/services/validation_identity_service.py
@@ -24,7 +24,13 @@ ActorType = Literal["user", "bot"]
 RegistrationMethod = Literal["invite", "partner"]
 SharePermission = Literal["view", "review"]
 ShareInviteStatus = Literal["pending", "accepted", "revoked", "expired"]
-CliScope = Literal["validation:read", "validation:write"]
+CliScope = Literal[
+    "validation:read",
+    "validation:write",
+    "strategy:read",
+    "backtest:read",
+    "deployment:read",
+]
 CliDeviceAuthorizationStatus = Literal["pending", "approved", "consumed", "expired"]
 
 
@@ -222,7 +228,13 @@ class ValidationIdentityService:
     _CLI_ACCESS_TOKEN_PREFIX = "tnx.cli"
     _CLI_DEVICE_CODE_PREFIX = "tnx_device"
     _CLI_DEFAULT_SCOPES: tuple[CliScope, ...] = ("validation:read", "validation:write")
-    _CLI_ALLOWED_SCOPES: tuple[CliScope, ...] = ("validation:read", "validation:write")
+    _CLI_ALLOWED_SCOPES: tuple[CliScope, ...] = (
+        "validation:read",
+        "validation:write",
+        "strategy:read",
+        "backtest:read",
+        "deployment:read",
+    )
     _CLI_USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
     _CLI_USER_CODE_LENGTH = 8
     _CLI_ACCESS_TOKEN_SECRET_BYTES = 24

--- a/backend/tests/contracts/test_validation_cli_auth_runtime.py
+++ b/backend/tests/contracts/test_validation_cli_auth_runtime.py
@@ -226,6 +226,8 @@ def test_cli_token_with_validation_only_scope_cannot_list_strategies_v1() -> Non
             "details": {
                 "requiredScope": "strategy:read",
                 "scopes": ["validation:read"],
+                "path": "/v1/strategies",
+                "method": "GET",
             },
         },
     }

--- a/backend/tests/contracts/test_validation_cli_auth_runtime.py
+++ b/backend/tests/contracts/test_validation_cli_auth_runtime.py
@@ -126,6 +126,153 @@ def test_cli_device_flow_issues_token_and_allows_whoami_and_validation_reads() -
     assert list_runs.status_code == 200
 
 
+def test_cli_token_with_core_read_scopes_allows_whoami_and_v1_core_reads() -> None:
+    client = TestClient(app)
+    owner_headers = _user_headers(
+        request_id="req-cli-owner-v1-read-001",
+        tenant_id="tenant-cli-runtime-v1-read-001",
+        user_id="user-cli-runtime-v1-read-001",
+        user_email="owner-cli-runtime-v1-read-001@example.com",
+    )
+    access_token, _ = _issue_cli_token(
+        client,
+        owner_headers=owner_headers,
+        request_suffix="v1-read-001",
+        scopes=["validation:read", "strategy:read", "backtest:read", "deployment:read"],
+    )
+
+    whoami = client.get(
+        "/v2/validation-cli-auth/whoami",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-whoami-001",
+        },
+    )
+    assert whoami.status_code == 200
+
+    strategy_list = client.get(
+        "/v1/strategies",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-strategy-list-001",
+        },
+    )
+    assert strategy_list.status_code == 200
+
+    strategy_get = client.get(
+        "/v1/strategies/strat-001",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-strategy-get-001",
+        },
+    )
+    assert strategy_get.status_code == 200
+
+    backtest_get = client.get(
+        "/v1/backtests/bt-001",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-backtest-get-001",
+        },
+    )
+    assert backtest_get.status_code == 200
+
+    deployment_list = client.get(
+        "/v1/deployments",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-deploy-list-001",
+        },
+    )
+    assert deployment_list.status_code == 200
+
+    deployment_get = client.get(
+        "/v1/deployments/dep-001",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-deploy-get-001",
+        },
+    )
+    assert deployment_get.status_code == 200
+
+
+def test_cli_token_with_validation_only_scope_cannot_list_strategies_v1() -> None:
+    client = TestClient(app)
+    owner_headers = _user_headers(
+        request_id="req-cli-owner-v1-denied-001",
+        tenant_id="tenant-cli-runtime-v1-denied-001",
+        user_id="user-cli-runtime-v1-denied-001",
+    )
+    access_token, _ = _issue_cli_token(
+        client,
+        owner_headers=owner_headers,
+        request_suffix="v1-denied-001",
+        scopes=["validation:read"],
+    )
+
+    strategy_list = client.get(
+        "/v1/strategies",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-denied-strategy-list-001",
+        },
+    )
+    assert strategy_list.status_code == 403
+    assert strategy_list.json() == {
+        "requestId": "req-cli-v1-denied-strategy-list-001",
+        "error": {
+            "code": "CLI_AUTH_SCOPE_FORBIDDEN",
+            "message": "CLI token is missing required scope: strategy:read.",
+            "details": {
+                "requiredScope": "strategy:read",
+                "scopes": ["validation:read"],
+            },
+        },
+    }
+
+
+def test_cli_scope_forbidden_error_payload_is_structured_and_deterministic() -> None:
+    client = TestClient(app)
+    owner_headers = _user_headers(
+        request_id="req-cli-owner-v1-forbidden-001",
+        tenant_id="tenant-cli-runtime-v1-forbidden-001",
+        user_id="user-cli-runtime-v1-forbidden-001",
+    )
+    access_token, _ = _issue_cli_token(
+        client,
+        owner_headers=owner_headers,
+        request_suffix="v1-forbidden-001",
+        scopes=["strategy:read"],
+    )
+
+    create_strategy = client.post(
+        "/v1/strategies",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-forbidden-write-001",
+        },
+        json={
+            "name": "Forbidden Write CLI",
+            "description": "CLI read scope should fail closed on write",
+            "provider": "xai",
+        },
+    )
+    assert create_strategy.status_code == 403
+    assert create_strategy.json() == {
+        "requestId": "req-cli-v1-forbidden-write-001",
+        "error": {
+            "code": "CLI_AUTH_SCOPE_FORBIDDEN",
+            "message": "CLI token is not authorized for this endpoint.",
+            "details": {
+                "requiredScope": None,
+                "scopes": ["strategy:read"],
+                "path": "/v1/strategies",
+                "method": "POST",
+            },
+        },
+    }
+
+
 def test_cli_token_with_read_scope_cannot_call_validation_writes() -> None:
     client = TestClient(app)
     owner_headers = _user_headers(

--- a/docs/architecture/specs/platform-api.openapi.yaml
+++ b/docs/architecture/specs/platform-api.openapi.yaml
@@ -5116,7 +5116,7 @@ components:
 
     ValidationCliScope:
       type: string
-      enum: ["validation:read", "validation:write"]
+      enum: ["validation:read", "validation:write", "strategy:read", "backtest:read", "deployment:read"]
 
     CreateValidationCliDeviceStartRequest:
       type: object

--- a/frontend/src/lib/validation/types.ts
+++ b/frontend/src/lib/validation/types.ts
@@ -322,7 +322,12 @@ export interface CreateValidationBotKeyRevocationPayload {
   reason?: string;
 }
 
-export type ValidationCliScope = 'validation:read' | 'validation:write';
+export type ValidationCliScope =
+  | 'validation:read'
+  | 'validation:write'
+  | 'strategy:read'
+  | 'backtest:read'
+  | 'deployment:read';
 
 export interface ValidationCliSession {
   id: string;

--- a/sdk/typescript/src/models/ValidationCliScope.ts
+++ b/sdk/typescript/src/models/ValidationCliScope.ts
@@ -19,7 +19,10 @@
  */
 export enum ValidationCliScope {
     ValidationRead = 'validation:read',
-    ValidationWrite = 'validation:write'
+    ValidationWrite = 'validation:write',
+    StrategyRead = 'strategy:read',
+    BacktestRead = 'backtest:read',
+    DeploymentRead = 'deployment:read'
 }
 
 


### PR DESCRIPTION
## Summary
- extends CLI scope model with explicit command-read scopes: `strategy:read`, `backtest:read`, `deployment:read`
- keeps validation behavior unchanged (`validation:read`/`validation:write` semantics and defaults stay intact)
- allows CLI device tokens on protected `/v1/*` runtime routes, but enforces an explicit fail-closed scope matrix
- keeps missing/invalid scope errors deterministic and structured (`CLI_AUTH_SCOPE_FORBIDDEN` with stable `details`)
- updates OpenAPI + generated SDK enum for `ValidationCliScope` (contract surface changed)

## Explicit CLI Scope Matrix
| Route surface | Methods | Required scope | Behavior |
|---|---|---|---|
| `/v2/validation*` (existing) | `GET` | `validation:read` | unchanged |
| `/v2/validation*` (existing) | non-`GET` | `validation:write` | unchanged |
| `/v1/strategies` and `/v1/strategies/{strategyId}` | `GET` | `strategy:read` | newly authorized for CLI token |
| `/v1/backtests/{backtestId}` | `GET` | `backtest:read` | newly authorized for CLI token |
| `/v1/deployments` and `/v1/deployments/{deploymentId}` | `GET` | `deployment:read` | newly authorized for CLI token |
| any other protected `/v1/*` with CLI token | any | _none_ | fail-closed (`CLI_AUTH_SCOPE_FORBIDDEN`) |

## Contract/Runtime Evidence
### Targeted contract/runtime
- `cd backend && uv run --extra dev pytest -q tests/contracts/test_validation_cli_auth_runtime.py`
- `cd backend && uv run --extra dev pytest -q tests/contracts/test_runtime_openapi_contract.py tests/contracts/test_runtime_openapi_contract_v2.py`
- `cd backend && uv run --extra dev pytest -q tests/contracts/test_validation_cli_auth_runtime.py tests/contracts/test_runtime_openapi_contract.py tests/contracts/test_runtime_openapi_contract_v2.py tests/contracts/test_openapi_contract_v2_baseline.py tests/contracts/test_openapi_contract_v2_validation_freeze.py tests/contracts/test_sdk_validation_contract_shape.py`

### Required governance matrix (from API_CONTRACT_GOVERNANCE)
1. `cd backend && uv run --extra dev pytest -q tests/contracts/test_openapi_contract_baseline.py` ✅
2. `cd backend && uv run --extra dev pytest -q tests/contracts/test_openapi_contract_freeze.py` ✅
3. `cd backend && uv run --extra dev pytest -q tests/contracts/test_openapi_contract_v2_baseline.py` ✅
4. `cd backend && uv run --extra dev pytest -q tests/contracts/test_openapi_contract_v2_validation_freeze.py` ✅
5. `cd backend && uv run --extra dev pytest -q tests/contracts/test_validation_schema_contract.py` ✅
6. `cd backend && uv run --extra dev pytest -q tests/contracts/test_sdk_validation_contract_shape.py` ✅
7. `cd backend && uv run --extra dev python -m src.platform_api.validation.release_gate_check` ✅
8. `cd backend && uv run --extra dev pytest -q tests/contracts --ignore=tests/contracts/test_openapi_contract_baseline.py --ignore=tests/contracts/test_openapi_contract_freeze.py --ignore=tests/contracts/test_openapi_contract_v2_baseline.py --ignore=tests/contracts/test_openapi_contract_v2_validation_freeze.py --ignore=tests/contracts/test_validation_schema_contract.py --ignore=tests/contracts/test_sdk_validation_contract_shape.py` ✅ (`391 passed`)
9. `python3 contracts/scripts/check-slo-alert-baseline.py` ✅
10. `bash contracts/scripts/verify-sdk-drift.sh` ✅ (`No SDK drift detected.`)
11. `NPM_CONFIG_CACHE=<repo>/.npm-cache bash contracts/scripts/mock-smoke-test.sh` ✅
12. `NPM_CONFIG_CACHE=<repo>/.npm-cache bash contracts/scripts/mock-consumer-contract-test.sh` ✅
13. `NPM_CONFIG_CACHE=<repo>/.npm-cache bash contracts/scripts/check-breaking-changes.sh` ⚠️ (`Skipping breaking-change check outside pull_request context.`)

## Deterministic Auth/Error Assertions Added
- `whoami` + v1 core reads succeed with proper scopes
- strategy list fails with validation-only scope
- forbidden v1 write from CLI token returns deterministic envelope + details shape

## Request IDs captured in contract tests
- success path: `req-cli-v1-read-whoami-001`, `req-cli-v1-read-strategy-list-001`, `req-cli-v1-read-strategy-get-001`, `req-cli-v1-read-backtest-get-001`, `req-cli-v1-read-deploy-list-001`, `req-cli-v1-read-deploy-get-001`
- forbidden path: `req-cli-v1-denied-strategy-list-001`, `req-cli-v1-forbidden-write-001`

## Replay/Gate Evidence IDs
- `valreplay-001`
- `valbase-001`
- `valrun-0002`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the CLI device auth model beyond validation-only routes by adding explicit read scopes (`strategy:read`, `backtest:read`, `deployment:read`) and wiring those scopes into a fail-closed scope enforcement matrix in the v1 route middleware. The contract surface (OpenAPI spec, TypeScript SDK enum, frontend types, backend schemas) is updated consistently across all layers.

Key changes:
- **`main.py`**: The v1 protected route middleware now falls back to CLI token resolution when standard JWT/API-key auth raises `AUTH_UNAUTHORIZED` and the bearer header looks like a CLI token. On success, request state is populated with `auth_method = "cli_token"` and `cli_scopes`, allowing the request to continue.
- **`router_v1.py`**: The `_request_context` dependency gains a CLI scope gate. Non-GET methods and GET paths outside the declared matrix are fail-closed (403). GET paths within the matrix require the corresponding scope in the token.
- **`validation_identity_service.py` / `schemas_v2.py`**: Three new scopes added to `CliScope`, `ValidationCliScope`, and `_CLI_ALLOWED_SCOPES`. Default scopes remain unchanged.
- **Contract tests**: Three new test cases cover the happy path (all new scopes), denial (validation-only scope blocked from v1), and the deterministic forbidden payload shape.
- **Design concern**: `main.py` accesses `router_v2_module._identity_service` directly (a private module attribute) to resolve CLI tokens, acknowledged via `# noqa: SLF001` in both locations. This tight coupling is a maintenance risk.
- **Envelope inconsistency**: The two `CLI_AUTH_SCOPE_FORBIDDEN` error shapes differ — the fail-closed variant includes `path` and `method` in `details` while the missing-scope variant does not, creating two distinct JSON shapes for the same error code.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style concerns; core auth logic is correct and well-tested.
- The scope enforcement is fail-closed by design, the happy/denial/forbidden contract tests are deterministic and cover all matrix entries, and the changes are consistent across all contract surfaces (OpenAPI, SDK, frontend types, backend schemas). The two flagged issues are style/coupling concerns rather than correctness bugs: the private attribute access is suppressed with a linter override, and the inconsistent error `details` shape is intentional per the contract tests. No new security surface is introduced beyond the explicitly declared scope matrix.
- `backend/src/main.py` and `backend/src/platform_api/router_v1.py` warrant the most attention — the former for the private attribute coupling pattern (duplicated in two branches) and the latter for the inconsistent error envelope shape.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/src/main.py | Middleware extended to fall back to CLI token resolution for v1 protected routes. Logic is correct but uses tight coupling via private module attribute access and an `exc` rebinding pattern that may confuse maintainers. |
| backend/src/platform_api/router_v1.py | Adds CLI scope enforcement to the v1 `_request_context` dependency with a fail-closed matrix. The scope routing logic is sound, but the two `CLI_AUTH_SCOPE_FORBIDDEN` error cases emit inconsistent `details` shapes (one includes `path`/`method`, the other does not). |
| backend/src/platform_api/schemas_v2.py | Extends `ValidationCliScope` literal type with three new read scopes. Straightforward additive change with no issues. |
| backend/src/platform_api/services/validation_identity_service.py | Adds three new scopes to `CliScope`, `_CLI_ALLOWED_SCOPES`. Default scopes remain unchanged (`validation:read`, `validation:write`). Clean, additive change. |
| backend/tests/contracts/test_validation_cli_auth_runtime.py | Three new contract tests covering success path with v1 read scopes, validation-only scope denial, and deterministic forbidden payload shape. Tests are well-structured but assert two different `details` shapes for the same error code, which locks in the inconsistency noted in `router_v1.py`. |
| docs/architecture/specs/platform-api.openapi.yaml | Updates `ValidationCliScope` enum in the OpenAPI spec to include the three new read scopes, in sync with the backend schema change. |
| frontend/src/lib/validation/types.ts | Extends `ValidationCliScope` union type with three new read scopes, matching the backend and OpenAPI contract. No issues. |
| sdk/typescript/src/models/ValidationCliScope.ts | Generated SDK enum extended with `StrategyRead`, `BacktestRead`, and `DeploymentRead` entries. Consistent with all other contract surfaces. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as CLI Client
    participant MW as Middleware
    participant V2Auth as ValidationIdentityService
    participant V1Ctx as _request_context
    participant Handler as v1 Route Handler

    CLI->>MW: GET /v1/strategies with CLI bearer header
    MW->>MW: resolve_validation_identity() raises AUTH_UNAUTHORIZED
    MW->>V2Auth: resolve CLI identity from bearer header
    alt identity resolved
        V2Auth-->>MW: CliIdentity with tenant, user, scopes
        MW->>MW: state.auth_method = cli_token
        MW->>Handler: call_next(request)
        Handler->>V1Ctx: Depends(_request_context)
        V1Ctx->>V1Ctx: _required_cli_scope(path, method)
        alt path in scope matrix AND scope present
            V1Ctx-->>Handler: RequestContext
            Handler-->>CLI: 200 OK
        else scope missing
            V1Ctx-->>CLI: 403 CLI_AUTH_SCOPE_FORBIDDEN
        else path not in scope matrix
            V1Ctx-->>CLI: 403 CLI_AUTH_SCOPE_FORBIDDEN fail-closed
        end
    else identity resolution failed
        V2Auth-->>MW: PlatformAPIError
        MW-->>CLI: error response
    end
```

<sub>Last reviewed commit: 7cbc779</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 3660d232891cf5305273bf81ea578d38b4fa09de. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->