### PR TITLE
fix(cli): normalize --help/-h and strict parsing across all subcommands

### DIFF
--- a/frontend/cli/commands/__tests__/help-flags.test.ts
+++ b/frontend/cli/commands/__tests__/help-flags.test.ts
@@ -233,6 +233,14 @@ describe('subcommand --help / -h flags', () => {
     await pipelineCommand(['-h']);
     expect(getLogOutput()).toContain('Pipeline Command');
   });
+
+  test('moltbook replicate --help prints usage', async () => {
+    const { moltbookCommand } = await import('../moltbook');
+    await moltbookCommand(['replicate', '--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Usage:');
+    expect(output).toContain('--post-id');
+  });
 });
 
 describe('strict mode rejects unknown flags', () => {
@@ -264,31 +272,46 @@ describe('strict mode rejects unknown flags', () => {
 
   test('strategy list rejects --unknown-flag', async () => {
     const { strategyCommand } = await import('../strategy');
-    await expect(strategyCommand(['list', '--unknown-flag'])).rejects.toThrow();
+    await expect(strategyCommand(['list', '--unknown-flag'])).rejects.toThrow(/Unknown option/);
   });
 
   test('data list rejects --bogus', async () => {
     const { dataCommand } = await import('../data');
-    await expect(dataCommand(['list', '--bogus'])).rejects.toThrow();
+    await expect(dataCommand(['list', '--bogus'])).rejects.toThrow(/Unknown option/);
+  });
+
+  test('deploy list rejects --foo', async () => {
+    const { deployCommand } = await import('../deploy');
+    await expect(deployCommand(['list', '--foo'])).rejects.toThrow(/Unknown option/);
   });
 
   test('deploy stop rejects --foo', async () => {
     const { deployCommand } = await import('../deploy');
-    await expect(deployCommand(['stop', '--foo'])).rejects.toThrow();
+    await expect(deployCommand(['stop', '--foo'])).rejects.toThrow(/Unknown option/);
+  });
+
+  test('portfolio list rejects --extra', async () => {
+    const { portfolioCommand } = await import('../portfolio');
+    await expect(portfolioCommand(['list', '--extra'])).rejects.toThrow(/Unknown option/);
   });
 
   test('portfolio show rejects --extra', async () => {
     const { portfolioCommand } = await import('../portfolio');
-    await expect(portfolioCommand(['show', '--extra'])).rejects.toThrow();
+    await expect(portfolioCommand(['show', '--extra'])).rejects.toThrow(/Unknown option/);
+  });
+
+  test('report daily rejects --nope', async () => {
+    const { reportCommand } = await import('../report');
+    await expect(reportCommand(['daily', '--nope'])).rejects.toThrow(/Unknown option/);
   });
 
   test('report get rejects --nope', async () => {
     const { reportCommand } = await import('../report');
-    await expect(reportCommand(['get', '--nope'])).rejects.toThrow();
+    await expect(reportCommand(['get', '--nope'])).rejects.toThrow(/Unknown option/);
   });
 
   test('research rejects --invalid', async () => {
     const { researchCommand } = await import('../research');
-    await expect(researchCommand(['--invalid'])).rejects.toThrow();
+    await expect(researchCommand(['--invalid'])).rejects.toThrow(/Unknown option/);
   });
 });

--- a/frontend/cli/commands/__tests__/help-flags.test.ts
+++ b/frontend/cli/commands/__tests__/help-flags.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+
+const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
+const originalEnv = { ...process.env };
+
+describe('subcommand --help / -h flags', () => {
+  let consoleLogSpy: ReturnType<typeof spyOn>;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+  let stdoutWriteSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    stdoutWriteSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.exit = mock((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as unknown as typeof process.exit;
+    // Prevent any real fetch calls
+    globalThis.fetch = mock(() => {
+      throw new Error('fetch should not be called in help tests');
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+    globalThis.fetch = originalFetch;
+    process.exit = originalExit;
+    process.env = { ...originalEnv };
+  });
+
+  function getLogOutput(): string {
+    return consoleLogSpy.mock.calls.map(([line]: unknown[]) => String(line)).join('\n');
+  }
+
+  // ── strategy subcommands ──
+
+  test('strategy list --help prints usage', async () => {
+    const { strategyCommand } = await import('../strategy');
+    await strategyCommand(['list', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('strategy list -h prints usage', async () => {
+    const { strategyCommand } = await import('../strategy');
+    await strategyCommand(['list', '-h']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('strategy create --help prints usage and flags', async () => {
+    const { strategyCommand } = await import('../strategy');
+    await strategyCommand(['create', '--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Usage:');
+    expect(output).toContain('--description');
+  });
+
+  test('strategy backtest --help prints usage and flags', async () => {
+    const { strategyCommand } = await import('../strategy');
+    await strategyCommand(['backtest', '--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Usage:');
+    expect(output).toContain('--strategy-id');
+  });
+
+  test('strategy get --help prints usage', async () => {
+    const { strategyCommand } = await import('../strategy');
+    await strategyCommand(['get', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('strategy code --help prints usage', async () => {
+    const { strategyCommand } = await import('../strategy');
+    await strategyCommand(['code', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('strategy score --help prints usage', async () => {
+    const { strategyCommand } = await import('../strategy');
+    await strategyCommand(['score', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  // ── data subcommands ──
+
+  test('data list --help prints usage', async () => {
+    const { dataCommand } = await import('../data');
+    await dataCommand(['list', '--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Usage:');
+    expect(output).toContain('--global');
+  });
+
+  test('data download -h prints usage', async () => {
+    const { dataCommand } = await import('../data');
+    await dataCommand(['download', '-h']);
+    const output = getLogOutput();
+    expect(output).toContain('Usage:');
+    expect(output).toContain('--symbol');
+  });
+
+  test('data export --help prints usage', async () => {
+    const { dataCommand } = await import('../data');
+    await dataCommand(['export', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('data delete --help prints usage', async () => {
+    const { dataCommand } = await import('../data');
+    await dataCommand(['delete', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  // ── deploy subcommands ──
+
+  test('deploy --help prints usage', async () => {
+    const { deployCommand } = await import('../deploy');
+    await deployCommand(['--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Deploy Commands');
+  });
+
+  test('deploy list --help prints usage', async () => {
+    const { deployCommand } = await import('../deploy');
+    await deployCommand(['list', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('deploy stop --help prints usage', async () => {
+    const { deployCommand } = await import('../deploy');
+    await deployCommand(['stop', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('deploy logs --help prints usage and --limit flag', async () => {
+    const { deployCommand } = await import('../deploy');
+    await deployCommand(['logs', '--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Usage:');
+    expect(output).toContain('--limit');
+  });
+
+  // ── portfolio subcommands ──
+
+  test('portfolio list --help prints usage', async () => {
+    const { portfolioCommand } = await import('../portfolio');
+    await portfolioCommand(['list', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('portfolio show -h prints usage', async () => {
+    const { portfolioCommand } = await import('../portfolio');
+    await portfolioCommand(['show', '-h']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('portfolio trade --help prints flags', async () => {
+    const { portfolioCommand } = await import('../portfolio');
+    await portfolioCommand(['trade', '--help']);
+    const output = getLogOutput();
+    expect(output).toContain('--portfolio-id');
+    expect(output).toContain('--symbol');
+  });
+
+  // ── report subcommands ──
+
+  test('report get --help prints usage and flags', async () => {
+    const { reportCommand } = await import('../report');
+    await reportCommand(['get', '--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Usage:');
+    expect(output).toContain('--full');
+    expect(output).toContain('--timeline');
+  });
+
+  test('report daily -h prints usage', async () => {
+    const { reportCommand } = await import('../report');
+    await reportCommand(['daily', '-h']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  test('report strategy --help prints usage', async () => {
+    const { reportCommand } = await import('../report');
+    await reportCommand(['strategy', '--help']);
+    expect(getLogOutput()).toContain('Usage:');
+  });
+
+  // ── single-command files ──
+
+  test('research --help prints usage', async () => {
+    const { researchCommand } = await import('../research');
+    await researchCommand(['--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Research Command');
+    expect(output).toContain('--assets');
+  });
+
+  test('research -h prints usage', async () => {
+    const { researchCommand } = await import('../research');
+    await researchCommand(['-h']);
+    expect(getLogOutput()).toContain('Research Command');
+  });
+
+  test('news --help prints usage', async () => {
+    const { newsCommand } = await import('../news');
+    await newsCommand(['--help']);
+    const output = getLogOutput();
+    expect(output).toContain('News Command');
+    expect(output).toContain('--assets');
+  });
+
+  test('adjust --help prints usage', async () => {
+    const { adjustCommand } = await import('../adjust');
+    await adjustCommand(['--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Adjust Command');
+    expect(output).toContain('--portfolio-id');
+  });
+
+  test('pipeline --help prints usage', async () => {
+    const { pipelineCommand } = await import('../pipeline');
+    await pipelineCommand(['--help']);
+    const output = getLogOutput();
+    expect(output).toContain('Pipeline Command');
+    expect(output).toContain('--skip-deploy');
+  });
+
+  test('pipeline -h prints usage', async () => {
+    const { pipelineCommand } = await import('../pipeline');
+    await pipelineCommand(['-h']);
+    expect(getLogOutput()).toContain('Pipeline Command');
+  });
+});
+
+describe('strict mode rejects unknown flags', () => {
+  let consoleLogSpy: ReturnType<typeof spyOn>;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+  let stdoutWriteSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    stdoutWriteSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.exit = mock((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as unknown as typeof process.exit;
+    globalThis.fetch = mock(() => {
+      throw new Error('fetch should not be called');
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+    globalThis.fetch = originalFetch;
+    process.exit = originalExit;
+    process.env = { ...originalEnv };
+  });
+
+  test('strategy list rejects --unknown-flag', async () => {
+    const { strategyCommand } = await import('../strategy');
+    await expect(strategyCommand(['list', '--unknown-flag'])).rejects.toThrow();
+  });
+
+  test('data list rejects --bogus', async () => {
+    const { dataCommand } = await import('../data');
+    await expect(dataCommand(['list', '--bogus'])).rejects.toThrow();
+  });
+
+  test('deploy stop rejects --foo', async () => {
+    const { deployCommand } = await import('../deploy');
+    await expect(deployCommand(['stop', '--foo'])).rejects.toThrow();
+  });
+
+  test('portfolio show rejects --extra', async () => {
+    const { portfolioCommand } = await import('../portfolio');
+    await expect(portfolioCommand(['show', '--extra'])).rejects.toThrow();
+  });
+
+  test('report get rejects --nope', async () => {
+    const { reportCommand } = await import('../report');
+    await expect(reportCommand(['get', '--nope'])).rejects.toThrow();
+  });
+
+  test('research rejects --invalid', async () => {
+    const { researchCommand } = await import('../research');
+    await expect(researchCommand(['--invalid'])).rejects.toThrow();
+  });
+});

--- a/frontend/cli/commands/adjust.ts
+++ b/frontend/cli/commands/adjust.ts
@@ -14,6 +14,7 @@ import {
   printSuccess,
   red,
   spinner,
+  wantsHelp,
   yellow,
 } from '../lib/output';
 
@@ -34,10 +35,6 @@ Output as JSON:
   "risk_assessment": "current portfolio risk level and concerns",
   "next_review": "when to review again"
 }`;
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
-}
 
 export async function adjustCommand(args: string[]) {
   if (wantsHelp(args)) {

--- a/frontend/cli/commands/adjust.ts
+++ b/frontend/cli/commands/adjust.ts
@@ -35,24 +35,26 @@ Output as JSON:
   "next_review": "when to review again"
 }`;
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export async function adjustCommand(args: string[]) {
+  if (wantsHelp(args)) {
+    printHeader('Adjust Command');
+    console.log(`${bold('Usage:')}  nexus adjust [options]\n`);
+    console.log(`${bold('Options:')}`);
+    console.log(`  ${dim('--portfolio-id')}   Portfolio to analyze (optional, analyzes all if omitted)\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
       'portfolio-id': { type: 'string' },
-      help: { type: 'boolean', default: false },
     },
     allowPositionals: false,
+    strict: true,
   });
-
-  if (values.help) {
-    printHeader('Adjust Command');
-    console.log(`${bold('Usage:')}  nexus adjust [options]\n`);
-    console.log(`${bold('Options:')}`);
-    console.log('  --portfolio-id   Portfolio to analyze (optional, analyzes all if omitted)');
-    console.log('  --help           Show this help\n');
-    return;
-  }
 
   validateConfig(['LIVE_ENGINE_SERVICE_KEY', 'XAI_API_KEY']);
   const engine = getLiveEngineClient();

--- a/frontend/cli/commands/data.ts
+++ b/frontend/cli/commands/data.ts
@@ -15,6 +15,10 @@ import {
   spinner,
 } from '../lib/output';
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export async function dataCommand(args: string[]) {
   const subcommand = args[0];
 
@@ -64,6 +68,13 @@ function printHelp() {
 }
 
 async function listSymbols(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus data list [--global] [--limit 50]\n`);
+    console.log(`${bold('Flags:')}`);
+    console.log(`  ${dim('--global')}  List pre-loaded global symbols`);
+    console.log(`  ${dim('--limit')}   Max results (default: 50)\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
@@ -71,6 +82,7 @@ async function listSymbols(args: string[]) {
       limit: { type: 'string', default: '50' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   validateConfig(['LONA_AGENT_TOKEN']);
@@ -103,6 +115,16 @@ async function listSymbols(args: string[]) {
 }
 
 async function downloadData(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus data download --symbol <SYMBOL> --start YYYY-MM-DD --end YYYY-MM-DD [--interval 1h] [--force]\n`);
+    console.log(`${bold('Flags:')}`);
+    console.log(`  ${dim('--symbol')}    Binance symbol (e.g. BTCUSDT)`);
+    console.log(`  ${dim('--interval')}  Candle interval (default: 1h)`);
+    console.log(`  ${dim('--start')}     Start date (YYYY-MM-DD)`);
+    console.log(`  ${dim('--end')}       End date (YYYY-MM-DD)`);
+    console.log(`  ${dim('--force')}     Delete existing symbol first\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
@@ -113,6 +135,7 @@ async function downloadData(args: string[]) {
       force: { type: 'boolean', default: false },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.symbol || !values.start || !values.end) {
@@ -198,6 +221,10 @@ async function downloadData(args: string[]) {
 }
 
 async function exportSymbolData(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus data export --id <symbol-id> [--format json|csv] [--output /path]\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
@@ -206,6 +233,7 @@ async function exportSymbolData(args: string[]) {
       output: { type: 'string' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.id) {
@@ -264,12 +292,17 @@ function ohlcToCsv(data: OhlcDataPoint[]): string {
 }
 
 async function deleteSymbol(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus data delete --id <symbol-id>\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
       id: { type: 'string' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.id) {

--- a/frontend/cli/commands/data.ts
+++ b/frontend/cli/commands/data.ts
@@ -13,11 +13,8 @@ import {
   printSuccess,
   printTable,
   spinner,
+  wantsHelp,
 } from '../lib/output';
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
-}
 
 export async function dataCommand(args: string[]) {
   const subcommand = args[0];

--- a/frontend/cli/commands/deploy.ts
+++ b/frontend/cli/commands/deploy.ts
@@ -15,12 +15,9 @@ import {
   printTable,
   red,
   spinner,
+  wantsHelp,
   yellow,
 } from '../lib/output';
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
-}
 
 export async function deployCommand(args: string[]) {
   const subcommand = args[0];
@@ -162,6 +159,7 @@ async function deployList(args: string[]) {
     console.log(`Lists all deployed strategies on live-engine. No flags required.\n`);
     return;
   }
+  parseArgs({ args, options: {}, allowPositionals: false, strict: true });
   validateConfig(['LIVE_ENGINE_SERVICE_KEY']);
   const engine = getLiveEngineClient();
 

--- a/frontend/cli/commands/deploy.ts
+++ b/frontend/cli/commands/deploy.ts
@@ -18,10 +18,14 @@ import {
   yellow,
 } from '../lib/output';
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export async function deployCommand(args: string[]) {
   const subcommand = args[0];
 
-  if (subcommand === '--help' || subcommand === '-h') {
+  if (!subcommand || subcommand === '--help' || subcommand === '-h') {
     printHelp();
     return;
   }
@@ -50,6 +54,15 @@ function printHelp() {
 }
 
 async function deployStrategy(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus deploy --strategy-id <lona-id> [--capital 10000] [--asset btcusdt] [--interval 1m]\n`);
+    console.log(`${bold('Flags:')}`);
+    console.log(`  ${dim('--strategy-id')}  Lona strategy ID (required)`);
+    console.log(`  ${dim('--capital')}      Initial capital (default: 10000)`);
+    console.log(`  ${dim('--asset')}        Trading asset (default: btcusdt)`);
+    console.log(`  ${dim('--interval')}     Candle interval (default: 1m)\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
@@ -59,6 +72,7 @@ async function deployStrategy(args: string[]) {
       interval: { type: 'string', default: '1m' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values['strategy-id']) {
@@ -142,7 +156,12 @@ async function deployStrategy(args: string[]) {
   }
 }
 
-async function deployList(_args: string[]) {
+async function deployList(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus deploy list\n`);
+    console.log(`Lists all deployed strategies on live-engine. No flags required.\n`);
+    return;
+  }
   validateConfig(['LIVE_ENGINE_SERVICE_KEY']);
   const engine = getLiveEngineClient();
 
@@ -172,10 +191,15 @@ async function deployList(_args: string[]) {
 }
 
 async function deployStop(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus deploy stop --id <live-engine-strategy-id>\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: { id: { type: 'string' } },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.id) {
@@ -192,6 +216,13 @@ async function deployStop(args: string[]) {
 }
 
 async function deployLogs(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus deploy logs --id <live-engine-strategy-id> [--limit 50]\n`);
+    console.log(`${bold('Flags:')}`);
+    console.log(`  ${dim('--id')}     Strategy ID (required)`);
+    console.log(`  ${dim('--limit')}  Max log entries (default: 50)\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
@@ -199,6 +230,7 @@ async function deployLogs(args: string[]) {
       limit: { type: 'string', default: '50' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.id) {

--- a/frontend/cli/commands/moltbook.ts
+++ b/frontend/cli/commands/moltbook.ts
@@ -231,29 +231,32 @@ function printHelp() {
   console.log('  nexus moltbook replicate --author claw-n --strategy-name EMA33');
 }
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 async function replicateStrategy(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')} nexus moltbook replicate [options]\n`);
+    console.log(`${bold('Options:')}`);
+    console.log(`  ${dim('--post-id')}        Moltbook post ID to replicate`);
+    console.log(`  ${dim('--author')}         Filter by author name`);
+    console.log(`  ${dim('--strategy-name')}  Filter by strategy name\n`);
+    console.log(`${bold('Examples:')}`);
+    console.log('  nexus moltbook replicate --post-id 57bc7211-20a0-4c86-8b23-89288bc72f84');
+    console.log('  nexus moltbook replicate --author claw-n');
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
       'post-id': { type: 'string' },
       author: { type: 'string' },
       'strategy-name': { type: 'string' },
-      help: { type: 'boolean', short: 'h' },
     },
+    allowPositionals: false,
+    strict: true,
   });
-
-  if (values.help) {
-    console.log(`${bold('Usage:')} nexus moltbook replicate [options]\n`);
-    console.log(`${bold('Options:')}`);
-    console.log(`  ${cyan('--post-id')}        Moltbook post ID to replicate`);
-    console.log(`  ${cyan('--author')}         Filter by author name`);
-    console.log(`  ${cyan('--strategy-name')}  Filter by strategy name`);
-    console.log();
-    console.log(`${bold('Examples:')}`);
-    console.log('  nexus moltbook replicate --post-id 57bc7211-20a0-4c86-8b23-89288bc72f84');
-    console.log('  nexus moltbook replicate --author claw-n');
-    return;
-  }
 
   validateConfig(['LONA_AGENT_TOKEN']);
 

--- a/frontend/cli/commands/moltbook.ts
+++ b/frontend/cli/commands/moltbook.ts
@@ -15,6 +15,7 @@ import {
   printSuccess,
   printWarning,
   spinner,
+  wantsHelp,
 } from '../lib/output';
 
 const WORKSPACE_DIR = process.env.WORKSPACE_PATH || join(homedir(), 'lona', 'workspace');
@@ -229,10 +230,6 @@ function printHelp() {
   console.log(`${bold('Examples:')}`);
   console.log('  nexus moltbook replicate --post-id abc123');
   console.log('  nexus moltbook replicate --author claw-n --strategy-name EMA33');
-}
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
 }
 
 async function replicateStrategy(args: string[]) {

--- a/frontend/cli/commands/news.ts
+++ b/frontend/cli/commands/news.ts
@@ -40,26 +40,28 @@ Output as JSON:
   "trading_implications": "actionable summary"
 }`;
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export async function newsCommand(args: string[]) {
+  if (wantsHelp(args)) {
+    printHeader('News Command');
+    console.log(`${bold('Usage:')}  nexus news [options]\n`);
+    console.log(`${bold('Options:')}`);
+    console.log(`  ${dim('--assets')}        Comma-separated asset classes (default: crypto,stocks)`);
+    console.log(`  ${dim('--strategy-id')}   Analyze news for a specific strategy's assets\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
       assets: { type: 'string', default: 'crypto,stocks' },
       'strategy-id': { type: 'string' },
-      help: { type: 'boolean', default: false },
     },
     allowPositionals: false,
+    strict: true,
   });
-
-  if (values.help) {
-    printHeader('News Command');
-    console.log(`${bold('Usage:')}  nexus news [options]\n`);
-    console.log(`${bold('Options:')}`);
-    console.log('  --assets        Comma-separated asset classes (default: crypto,stocks)');
-    console.log(`  --strategy-id   Analyze news for a specific strategy's assets`);
-    console.log('  --help          Show this help\n');
-    return;
-  }
 
   validateConfig(['XAI_API_KEY']);
 

--- a/frontend/cli/commands/news.ts
+++ b/frontend/cli/commands/news.ts
@@ -14,6 +14,7 @@ import {
   printSuccess,
   red,
   spinner,
+  wantsHelp,
   yellow,
 } from '../lib/output';
 
@@ -39,10 +40,6 @@ Output as JSON:
   "risk_factors": ["factor 1", "factor 2"],
   "trading_implications": "actionable summary"
 }`;
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
-}
 
 export async function newsCommand(args: string[]) {
   if (wantsHelp(args)) {

--- a/frontend/cli/commands/pipeline.ts
+++ b/frontend/cli/commands/pipeline.ts
@@ -53,30 +53,32 @@ interface PipelineResult {
   portfolioId?: string;
 }
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export async function pipelineCommand(args: string[]) {
+  if (wantsHelp(args)) {
+    printHeader('Pipeline Command');
+    console.log(`${bold('Usage:')}  nexus pipeline [options]\n`);
+    console.log(`${bold('Options:')}`);
+    console.log(`  ${dim('--assets')}       Comma-separated asset classes (default: crypto)`);
+    console.log(`  ${dim('--capital')}      Total capital (default: 50000)`);
+    console.log(`  ${dim('--top')}          Number of top strategies to deploy (default: 3)`);
+    console.log(`  ${dim('--skip-deploy')}  Skip deployment to live-engine\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
       assets: { type: 'string', default: 'crypto' },
       capital: { type: 'string', default: '50000' },
       top: { type: 'string', default: '3' },
-      help: { type: 'boolean', default: false },
       'skip-deploy': { type: 'boolean', default: false },
     },
     allowPositionals: false,
+    strict: true,
   });
-
-  if (values.help) {
-    printHeader('Pipeline Command');
-    console.log(`${bold('Usage:')}  nexus pipeline [options]\n`);
-    console.log(`${bold('Options:')}`);
-    console.log('  --assets       Comma-separated asset classes (default: crypto)');
-    console.log('  --capital      Total capital (default: 50000)');
-    console.log('  --top          Number of top strategies to deploy (default: 3)');
-    console.log('  --skip-deploy  Skip deployment to live-engine');
-    console.log('  --help         Show this help\n');
-    return;
-  }
 
   const requiredVars = ['XAI_API_KEY', 'LONA_AGENT_TOKEN'];
   if (!values['skip-deploy']) {

--- a/frontend/cli/commands/pipeline.ts
+++ b/frontend/cli/commands/pipeline.ts
@@ -19,6 +19,7 @@ import {
   printTable,
   red,
   spinner,
+  wantsHelp,
   yellow,
 } from '../lib/output';
 
@@ -51,10 +52,6 @@ interface PipelineResult {
   metrics?: Record<string, number>;
   deployedId?: string;
   portfolioId?: string;
-}
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
 }
 
 export async function pipelineCommand(args: string[]) {

--- a/frontend/cli/commands/portfolio.ts
+++ b/frontend/cli/commands/portfolio.ts
@@ -14,6 +14,10 @@ import {
   spinner,
 } from '../lib/output';
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export async function portfolioCommand(args: string[]) {
   const subcommand = args[0];
 
@@ -53,7 +57,12 @@ function printHelp() {
   );
 }
 
-async function listPortfolios(_args: string[]) {
+async function listPortfolios(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus portfolio list\n`);
+    console.log(`Lists all paper portfolios. No flags required.\n`);
+    return;
+  }
   validateConfig(['LIVE_ENGINE_SERVICE_KEY']);
   const engine = getLiveEngineClient();
 
@@ -79,10 +88,15 @@ async function listPortfolios(_args: string[]) {
 }
 
 async function showPortfolio(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus portfolio show --id <portfolio-id>\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: { id: { type: 'string' } },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.id) {
@@ -132,6 +146,17 @@ async function showPortfolio(args: string[]) {
 }
 
 async function executeTrade(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus portfolio trade --portfolio-id <id> --symbol <BTCUSDT> --side <buy|sell> --quantity <amount> [--type market|limit] [--price <n>]\n`);
+    console.log(`${bold('Flags:')}`);
+    console.log(`  ${dim('--portfolio-id')}  Portfolio ID (required)`);
+    console.log(`  ${dim('--symbol')}        Trading symbol (required)`);
+    console.log(`  ${dim('--side')}          buy or sell (required)`);
+    console.log(`  ${dim('--quantity')}      Trade amount (required)`);
+    console.log(`  ${dim('--type')}          Order type (default: market)`);
+    console.log(`  ${dim('--price')}         Limit price (for limit orders)\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
@@ -143,6 +168,7 @@ async function executeTrade(args: string[]) {
       price: { type: 'string' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values['portfolio-id'] || !values.symbol || !values.side || !values.quantity) {

--- a/frontend/cli/commands/portfolio.ts
+++ b/frontend/cli/commands/portfolio.ts
@@ -12,11 +12,8 @@ import {
   printTable,
   red,
   spinner,
+  wantsHelp,
 } from '../lib/output';
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
-}
 
 export async function portfolioCommand(args: string[]) {
   const subcommand = args[0];
@@ -63,6 +60,7 @@ async function listPortfolios(args: string[]) {
     console.log(`Lists all paper portfolios. No flags required.\n`);
     return;
   }
+  parseArgs({ args, options: {}, allowPositionals: false, strict: true });
   validateConfig(['LIVE_ENGINE_SERVICE_KEY']);
   const engine = getLiveEngineClient();
 

--- a/frontend/cli/commands/report.ts
+++ b/frontend/cli/commands/report.ts
@@ -22,6 +22,10 @@ import {
   yellow,
 } from '../lib/output';
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export async function reportCommand(args: string[]) {
   const subcommand = args[0];
 
@@ -63,6 +67,15 @@ function printHelp() {
 }
 
 async function getReport(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus report get --id <report-id> [--full] [--timeline] [--output /path]\n`);
+    console.log(`${bold('Flags:')}`);
+    console.log(`  ${dim('--id')}        Report ID (required)`);
+    console.log(`  ${dim('--full')}      Output complete report data`);
+    console.log(`  ${dim('--timeline')}  Output backtest timeline only`);
+    console.log(`  ${dim('--output')}    Write to file instead of stdout\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
@@ -72,6 +85,7 @@ async function getReport(args: string[]) {
       output: { type: 'string' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.id) {
@@ -188,7 +202,12 @@ function formatStatValue(key: string, value: number): string {
   return String(value);
 }
 
-async function dailyReport(_args: string[]) {
+async function dailyReport(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus report daily\n`);
+    console.log(`Generates a daily trading summary with AI insights. No flags required.\n`);
+    return;
+  }
   validateConfig(['LIVE_ENGINE_SERVICE_KEY', 'XAI_API_KEY']);
   const engine = getLiveEngineClient();
 
@@ -298,10 +317,15 @@ Keep it to 3-5 sentences focusing on actionable insights.`,
 }
 
 async function strategyReport(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus report strategy --id <live-engine-strategy-id>\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: { id: { type: 'string' } },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.id) {

--- a/frontend/cli/commands/report.ts
+++ b/frontend/cli/commands/report.ts
@@ -19,12 +19,9 @@ import {
   printTable,
   red,
   spinner,
+  wantsHelp,
   yellow,
 } from '../lib/output';
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
-}
 
 export async function reportCommand(args: string[]) {
   const subcommand = args[0];
@@ -208,6 +205,7 @@ async function dailyReport(args: string[]) {
     console.log(`Generates a daily trading summary with AI insights. No flags required.\n`);
     return;
   }
+  parseArgs({ args, options: {}, allowPositionals: false, strict: true });
   validateConfig(['LIVE_ENGINE_SERVICE_KEY', 'XAI_API_KEY']);
   const engine = getLiveEngineClient();
 

--- a/frontend/cli/commands/research.ts
+++ b/frontend/cli/commands/research.ts
@@ -3,7 +3,16 @@ import { xai } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 
 import { validateConfig } from '../lib/config';
-import { bold, cyan, dim, printError, printHeader, printSuccess, spinner } from '../lib/output';
+import {
+  bold,
+  cyan,
+  dim,
+  printError,
+  printHeader,
+  printSuccess,
+  spinner,
+  wantsHelp,
+} from '../lib/output';
 
 const MARKET_RESEARCH_PROMPT = `You are an elite quantitative market analyst. Analyze market conditions and generate strategy ideas.
 
@@ -26,10 +35,6 @@ Output as JSON:
     { "name": "Strategy Name", "asset_class": "crypto|stocks|forex", "type": "trend|mean_reversion|volatility|arbitrage", "description": "strategy logic", "rationale": "why it fits current conditions" }
   ]
 }`;
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
-}
 
 export async function researchCommand(args: string[]) {
   if (wantsHelp(args)) {

--- a/frontend/cli/commands/research.ts
+++ b/frontend/cli/commands/research.ts
@@ -27,26 +27,28 @@ Output as JSON:
   ]
 }`;
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export async function researchCommand(args: string[]) {
+  if (wantsHelp(args)) {
+    printHeader('Research Command');
+    console.log(`${bold('Usage:')}  nexus research [options]\n`);
+    console.log(`${bold('Options:')}`);
+    console.log(`  ${dim('--assets')}    Comma-separated asset classes (default: crypto,stocks,forex)`);
+    console.log(`  ${dim('--capital')}   Total capital (default: 100000)\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
       assets: { type: 'string', default: 'crypto,stocks,forex' },
       capital: { type: 'string', default: '100000' },
-      help: { type: 'boolean', default: false },
     },
     allowPositionals: false,
+    strict: true,
   });
-
-  if (values.help) {
-    printHeader('Research Command');
-    console.log(`${bold('Usage:')}  nexus research [options]\n`);
-    console.log(`${bold('Options:')}`);
-    console.log('  --assets    Comma-separated asset classes (default: crypto,stocks,forex)');
-    console.log('  --capital   Total capital (default: 100000)');
-    console.log('  --help      Show this help\n');
-    return;
-  }
 
   validateConfig(['XAI_API_KEY']);
 

--- a/frontend/cli/commands/strategy.ts
+++ b/frontend/cli/commands/strategy.ts
@@ -11,11 +11,8 @@ import {
   printTable,
   printWarning,
   spinner,
+  wantsHelp,
 } from '../lib/output';
-
-function wantsHelp(args: string[]): boolean {
-  return args.includes('--help') || args.includes('-h');
-}
 
 export async function strategyCommand(args: string[]) {
   const subcommand = args[0];
@@ -66,6 +63,7 @@ async function listStrategies(args: string[]) {
     console.log(`Lists all strategies on Lona. No flags required.\n`);
     return;
   }
+  parseArgs({ args, options: {}, allowPositionals: false, strict: true });
   validateConfig(['LONA_AGENT_TOKEN']);
   const client = getLonaClient();
 

--- a/frontend/cli/commands/strategy.ts
+++ b/frontend/cli/commands/strategy.ts
@@ -13,6 +13,10 @@ import {
   spinner,
 } from '../lib/output';
 
+function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export async function strategyCommand(args: string[]) {
   const subcommand = args[0];
 
@@ -56,7 +60,12 @@ function printHelp() {
   console.log(`  ${dim('--start YYYY-MM-DD --end YYYY-MM-DD')}\n`);
 }
 
-async function listStrategies(_args: string[]) {
+async function listStrategies(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus strategy list\n`);
+    console.log(`Lists all strategies on Lona. No flags required.\n`);
+    return;
+  }
   validateConfig(['LONA_AGENT_TOKEN']);
   const client = getLonaClient();
 
@@ -82,6 +91,14 @@ async function listStrategies(_args: string[]) {
 }
 
 async function createStrategy(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus strategy create --description "..." [--name "..."] [--provider xai]\n`);
+    console.log(`${bold('Flags:')}`);
+    console.log(`  ${dim('--description')}  Strategy description (required)`);
+    console.log(`  ${dim('--name')}         Optional strategy name`);
+    console.log(`  ${dim('--provider')}     AI provider (default: xai)\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
@@ -90,6 +107,7 @@ async function createStrategy(args: string[]) {
       provider: { type: 'string', default: 'xai' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.description) {
@@ -131,10 +149,15 @@ async function createStrategy(args: string[]) {
 }
 
 async function getStrategy(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus strategy get --id <strategy-id>\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: { id: { type: 'string' } },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.id) {
@@ -159,10 +182,15 @@ async function getStrategy(args: string[]) {
 }
 
 async function getStrategyCode(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus strategy code --id <strategy-id>\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: { id: { type: 'string' } },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.id) {
@@ -181,6 +209,16 @@ async function getStrategyCode(args: string[]) {
 }
 
 export async function runBacktest(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus strategy backtest --strategy-id <id> --symbol-id <id> --start YYYY-MM-DD --end YYYY-MM-DD [--capital 100000]\n`);
+    console.log(`${bold('Flags:')}`);
+    console.log(`  ${dim('--strategy-id')}  Strategy ID (primary, alias: --id)`);
+    console.log(`  ${dim('--symbol-id')}    Data symbol ID (primary, alias: --data)`);
+    console.log(`  ${dim('--start')}        Start date (YYYY-MM-DD)`);
+    console.log(`  ${dim('--end')}          End date (YYYY-MM-DD)`);
+    console.log(`  ${dim('--capital')}      Initial capital (default: 100000)\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
@@ -193,6 +231,7 @@ export async function runBacktest(args: string[]) {
       capital: { type: 'string', default: '100000' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (
@@ -289,12 +328,17 @@ export async function runBacktest(args: string[]) {
 }
 
 async function scoreStrategies(args: string[]) {
+  if (wantsHelp(args)) {
+    console.log(`${bold('Usage:')}  nexus strategy score --ids <report-id-1>,<report-id-2>\n`);
+    return;
+  }
   const { values } = parseArgs({
     args,
     options: {
       ids: { type: 'string' },
     },
     allowPositionals: false,
+    strict: true,
   });
 
   if (!values.ids) {

--- a/frontend/cli/lib/output.ts
+++ b/frontend/cli/lib/output.ts
@@ -30,6 +30,10 @@ export function printInfo(msg: string) {
   console.log(`${blue('i')} ${msg}`);
 }
 
+export function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export function printTable(headers: string[], rows: string[][]) {
   const colWidths = headers.map((h, i) =>
     Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
     "test": "bun test src cli",
+    "ci": "bun run lint && bun run typecheck && bun run test",
     "test:e2e": "playwright test",
     "strategist": "bun run cli/strategist.ts",
     "nexus": "bun run cli/nexus.ts"


### PR DESCRIPTION
## Summary
- Add consistent `wantsHelp()` guard before `parseArgs` in every CLI command handler so `--help`/`-h` prints usage text instead of crashing with unknown-flag errors
- Enable `strict: true` on all `parseArgs` calls across 10 command files to reject unknown flags early with clear errors
- Remove `help` as a `parseArgs` option in files that used it inconsistently (research, news, adjust, pipeline, moltbook) — help is now checked before parsing
- Add `ci` script to `package.json` (`lint && typecheck && test`)
- Add 33 smoke tests covering help output and strict-mode rejection for all command groups

## Files changed
- `cli/commands/strategy.ts` — 6 subcommand handlers updated
- `cli/commands/data.ts` — 4 subcommand handlers updated
- `cli/commands/deploy.ts` — 4 subcommand handlers updated
- `cli/commands/portfolio.ts` — 3 subcommand handlers updated
- `cli/commands/report.ts` — 3 subcommand handlers updated
- `cli/commands/research.ts` — single command updated
- `cli/commands/news.ts` — single command updated
- `cli/commands/adjust.ts` — single command updated
- `cli/commands/pipeline.ts` — single command updated
- `cli/commands/moltbook.ts` — replicate subcommand updated
- `cli/commands/__tests__/help-flags.test.ts` — new test file (33 tests)
- `package.json` — added `ci` script

## Test plan
- [x] All 33 new help-flag smoke tests pass
- [x] All 144 existing CLI tests pass (0 regressions)
- [x] TypeScript compilation passes (pre-existing errors only)
- [ ] Manual: `bun run nexus strategy backtest --help` prints usage
- [ ] Manual: `bun run nexus data list --bogus` rejects with error
- [ ] Manual: `bun run nexus deploy logs -h` prints usage with `--limit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI argument parsing/help output and add tests; main risk is breaking scripts that previously relied on unknown flags being ignored.
> 
> **Overview**
> Normalizes `--help`/`-h` across CLI commands by adding a shared `wantsHelp()` guard that prints usage *before* `parseArgs`, and removes the prior per-command `help` flag handling.
> 
> Enables `strict: true` on `parseArgs` throughout command/subcommand handlers (including “no-flags” subcommands via empty-option parsing) so unknown flags fail fast with consistent errors.
> 
> Adds a new `help-flags.test.ts` suite covering help output and unknown-flag rejection across command groups, and introduces a `ci` script (`lint && typecheck && test`) in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe206c6f4af9317419fa09da461cc243e3768d0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes CLI help handling across all 10 command files by adding a pre-parse `wantsHelp()` guard (checking `--help` / `-h`) before `parseArgs`, enabling `strict: true` throughout, and removing the old `help` option from `parseArgs` calls. It also adds 33 smoke tests and a `ci` script to `package.json`. The approach is consistent and the majority of command handlers are correctly updated.

**Key issues found:**

- **False-positive strict-mode test** (`help-flags.test.ts:265`): `strategy list rejects --unknown-flag` passes only because `validateConfig` fails on a missing env var, not because strict mode rejects the flag. `listStrategies` has no `parseArgs` call, so strict mode is never exercised for this subcommand.
- **Four "no-flags" subcommands silently ignore unknown flags**: `listStrategies` (`strategy.ts`), `deployList` (`deploy.ts`), `listPortfolios` (`portfolio.ts`), and `dailyReport` (`report.ts`) have no `parseArgs` call after the `wantsHelp` guard. Unknown flags passed to these subcommands are silently ignored rather than being rejected, which is inconsistent with the PR's stated goal.
- **`wantsHelp` function duplicated across 10 files**: The same 3-line helper is copy-pasted into every command file. Extracting it to `cli/lib/output.ts` or a new `cli/lib/args.ts` would eliminate the duplication.
- **Missing `moltbook replicate --help` test**: The test suite covers all command groups except `moltbook`, which was also updated in this PR.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for its help-printing goals, but the strict-mode rejection goal is incomplete for "no-flags" subcommands and one test is a false positive.
- The core fix (moving help checks before parseArgs and adding strict: true) works correctly for all command handlers that use parseArgs. However, four "no-flags" subcommands (listStrategies, deployList, listPortfolios, dailyReport) have no parseArgs at all, so they silently accept any unknown flag — contradicting the PR's stated goal. Additionally, the strict-mode test for `strategy list` is a false positive that would hide any regression in this area.
- `frontend/cli/commands/__tests__/help-flags.test.ts` (false-positive test), `frontend/cli/commands/strategy.ts`, `frontend/cli/commands/deploy.ts`, `frontend/cli/commands/portfolio.ts`, and `frontend/cli/commands/report.ts` (all have "no-flags" subcommands missing strict parsing).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/cli/commands/__tests__/help-flags.test.ts | New test file with 33 smoke tests; contains a false-positive strict-mode test for `strategy list` (passes due to missing env var, not strict parsing), and lacks `moltbook replicate --help` coverage. |
| frontend/cli/commands/strategy.ts | 6 subcommand handlers updated with `wantsHelp` guard and `strict: true`; `listStrategies` has no `parseArgs` call so unknown flags are silently ignored despite the PR goal of rejecting them. |
| frontend/cli/commands/deploy.ts | 4 subcommand handlers updated; `deployList` has no `parseArgs` call so unknown flags are silently ignored; also adds `!subcommand` guard to show top-level help when `nexus deploy` is run with no args. |
| frontend/cli/commands/portfolio.ts | 3 subcommand handlers updated; `listPortfolios` has no `parseArgs` so unknown flags pass silently; `showPortfolio` and `executeTrade` correctly use `strict: true`. |
| frontend/cli/commands/report.ts | 3 subcommand handlers updated; `dailyReport` has no `parseArgs` so unknown flags pass silently; `getReport` and `strategyReport` correctly use `strict: true`. |
| frontend/cli/commands/data.ts | 4 subcommand handlers updated; all have `parseArgs` with `strict: true` and a `wantsHelp` early return — consistent and correct. |
| frontend/cli/commands/moltbook.ts | Moves help check before `parseArgs`, removes `help` option, adds `allowPositionals: false` and `strict: true` — clean and correct. |
| frontend/package.json | Adds `ci` script combining `lint`, `typecheck`, and `test` — straightforward and correct. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CLI arg array (args[])"] --> B{"wantsHelp(args)\n--help / -h?"}
    B -- Yes --> C["Print usage text\nreturn"]
    B -- No --> D{"Has subcommand?\ne.g. list / stop / logs"}
    D -- "Subcommand with flags\n(create, backtest, stop, logs…)" --> E["parseArgs\nstrict: true"]
    E -- "Unknown flag" --> F["Throw TypeError\n(strict rejection ✓)"]
    E -- "Known flags only" --> G["Execute command"]
    D -- "No-flags subcommand\n(list, daily, listPortfolios…)" --> H["validateConfig\n(no parseArgs call)"]
    H -- "Unknown flag passed" --> I["Flag silently ignored ⚠️"]
    H -- "Valid execution" --> G
```

<sub>Last reviewed commit: 9e9d8c3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->