### PR TITLE
fix(platform): CLI device-auth scope parity for v1 core reads (#381)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from typing import Any
 from uuid import uuid4
 
 from dotenv import load_dotenv
@@ -138,6 +139,32 @@ def _parse_bearer_token(authorization: str | None) -> str | None:
     return normalized if normalized else None
 
 
+def _resolve_cli_identity_from_bearer(*, request: Request, request_id: str) -> tuple[Any | None, PlatformAPIError | None]:
+    bearer_token = _parse_bearer_token(request.headers.get("Authorization"))
+    if not (isinstance(bearer_token, str) and bearer_token.startswith("tnx.cli.")):
+        return None, None
+    try:
+        cli_identity = router_v2_module.resolve_cli_access_token_identity(
+            access_token=bearer_token,
+            tenant_header=request.headers.get("X-Tenant-Id"),
+            user_header=request.headers.get("X-User-Id"),
+            request_id=request_id,
+        )
+    except PlatformAPIError as exc:
+        return None, exc
+    return cli_identity, None
+
+
+def _apply_cli_identity_to_request_state(*, request: Request, cli_identity: Any) -> None:
+    request.state.tenant_id = cli_identity.tenant_id
+    request.state.user_id = cli_identity.user_id
+    request.state.user_email_authenticated = False
+    request.state.user_email = None
+    request.state.auth_method = "cli_token"
+    request.state.cli_scopes = cli_identity.scopes
+    request.state.cli_session_id = cli_identity.session_id
+
+
 @app.middleware("http")
 async def platform_api_observability_context_middleware(request: Request, call_next):
     """Attach request correlation identifiers and emit structured request logs."""
@@ -156,31 +183,16 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                     request_id=request.state.request_id,
                 )
             except PlatformAPIError as exc:
-                bearer_token = _parse_bearer_token(request.headers.get("Authorization"))
+                final_exc = exc
                 cli_identity = None
-                if (
-                    exc.code == "AUTH_UNAUTHORIZED"
-                    and isinstance(bearer_token, str)
-                    and bearer_token.startswith("tnx.cli.")
-                ):
-                    try:
-                        cli_identity = router_v2_module._identity_service.resolve_cli_access_token(  # noqa: SLF001
-                            access_token=bearer_token,
-                            tenant_header=request.headers.get("X-Tenant-Id"),
-                            user_header=request.headers.get("X-User-Id"),
-                            request_id=request.state.request_id,
-                        )
-                    except PlatformAPIError as cli_exc:
-                        exc = cli_exc
-                if cli_identity is not None:
-                    request.state.tenant_id = cli_identity.tenant_id
-                    request.state.user_id = cli_identity.user_id
-                    request.state.user_email_authenticated = False
-                    request.state.user_email = None
-                    request.state.auth_method = "cli_token"
-                    request.state.cli_scopes = cli_identity.scopes
-                    request.state.cli_session_id = cli_identity.session_id
-                else:
+                if exc.code == "AUTH_UNAUTHORIZED":
+                    cli_identity, cli_error = _resolve_cli_identity_from_bearer(
+                        request=request,
+                        request_id=request.state.request_id,
+                    )
+                    if cli_error is not None:
+                        final_exc = cli_error
+                if cli_identity is None:
                     request.state.tenant_id = "tenant-unauthenticated"
                     request.state.user_id = "user-unauthenticated"
                     request.state.user_email_authenticated = False
@@ -193,11 +205,12 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                         request=request,
                         component="api",
                         operation="request_rejected",
-                        status_code=exc.status_code,
-                        errorCode=exc.code,
+                        status_code=final_exc.status_code,
+                        errorCode=final_exc.code,
                         method=request.method,
                     )
-                    return await platform_api_error_handler(request, exc)
+                    return await platform_api_error_handler(request, final_exc)
+                _apply_cli_identity_to_request_state(request=request, cli_identity=cli_identity)
             else:
                 request.state.tenant_id = identity.tenant_id
                 request.state.user_id = identity.user_id
@@ -252,22 +265,15 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                         request_id=request.state.request_id,
                     )
                 except PlatformAPIError as exc:
-                    bearer_token = _parse_bearer_token(request.headers.get("Authorization"))
                     cli_identity = None
-                    if (
-                        exc.code == "AUTH_UNAUTHORIZED"
-                        and isinstance(bearer_token, str)
-                        and bearer_token.startswith("tnx.cli.")
-                    ):
-                        try:
-                            cli_identity = router_v2_module._identity_service.resolve_cli_access_token(  # noqa: SLF001
-                                access_token=bearer_token,
-                                tenant_header=request.headers.get("X-Tenant-Id"),
-                                user_header=request.headers.get("X-User-Id"),
-                                request_id=request.state.request_id,
-                            )
-                        except PlatformAPIError as cli_exc:
-                            exc = cli_exc
+                    final_exc = exc
+                    if exc.code == "AUTH_UNAUTHORIZED":
+                        cli_identity, cli_error = _resolve_cli_identity_from_bearer(
+                            request=request,
+                            request_id=request.state.request_id,
+                        )
+                        if cli_error is not None:
+                            final_exc = cli_error
                     if cli_identity is None:
                         request.state.tenant_id = "tenant-unauthenticated"
                         request.state.user_id = "user-unauthenticated"
@@ -281,18 +287,12 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                             request=request,
                             component="api",
                             operation="request_rejected",
-                            status_code=exc.status_code,
-                            errorCode=exc.code,
+                            status_code=final_exc.status_code,
+                            errorCode=final_exc.code,
                             method=request.method,
                         )
-                        return await platform_api_error_handler(request, exc)
-                    request.state.tenant_id = cli_identity.tenant_id
-                    request.state.user_id = cli_identity.user_id
-                    request.state.user_email_authenticated = False
-                    request.state.user_email = None
-                    request.state.auth_method = "cli_token"
-                    request.state.cli_scopes = cli_identity.scopes
-                    request.state.cli_session_id = cli_identity.session_id
+                        return await platform_api_error_handler(request, final_exc)
+                    _apply_cli_identity_to_request_state(request=request, cli_identity=cli_identity)
                 else:
                     request.state.tenant_id = identity.tenant_id
                     request.state.user_id = identity.user_id

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -156,28 +156,56 @@ async def platform_api_observability_context_middleware(request: Request, call_n
                     request_id=request.state.request_id,
                 )
             except PlatformAPIError as exc:
-                request.state.tenant_id = "tenant-unauthenticated"
-                request.state.user_id = "user-unauthenticated"
-                request.state.user_email_authenticated = False
-                request.state.user_email = None
-                request.state.auth_method = "none"
-                log_request_event(
-                    logger,
-                    level=logging.WARNING,
-                    message="Platform API request rejected.",
-                    request=request,
-                    component="api",
-                    operation="request_rejected",
-                    status_code=exc.status_code,
-                    errorCode=exc.code,
-                    method=request.method,
+                bearer_token = _parse_bearer_token(request.headers.get("Authorization"))
+                cli_identity = None
+                if (
+                    exc.code == "AUTH_UNAUTHORIZED"
+                    and isinstance(bearer_token, str)
+                    and bearer_token.startswith("tnx.cli.")
+                ):
+                    try:
+                        cli_identity = router_v2_module._identity_service.resolve_cli_access_token(  # noqa: SLF001
+                            access_token=bearer_token,
+                            tenant_header=request.headers.get("X-Tenant-Id"),
+                            user_header=request.headers.get("X-User-Id"),
+                            request_id=request.state.request_id,
+                        )
+                    except PlatformAPIError as cli_exc:
+                        exc = cli_exc
+                if cli_identity is not None:
+                    request.state.tenant_id = cli_identity.tenant_id
+                    request.state.user_id = cli_identity.user_id
+                    request.state.user_email_authenticated = False
+                    request.state.user_email = None
+                    request.state.auth_method = "cli_token"
+                    request.state.cli_scopes = cli_identity.scopes
+                    request.state.cli_session_id = cli_identity.session_id
+                else:
+                    request.state.tenant_id = "tenant-unauthenticated"
+                    request.state.user_id = "user-unauthenticated"
+                    request.state.user_email_authenticated = False
+                    request.state.user_email = None
+                    request.state.auth_method = "none"
+                    log_request_event(
+                        logger,
+                        level=logging.WARNING,
+                        message="Platform API request rejected.",
+                        request=request,
+                        component="api",
+                        operation="request_rejected",
+                        status_code=exc.status_code,
+                        errorCode=exc.code,
+                        method=request.method,
+                    )
+                    return await platform_api_error_handler(request, exc)
+            else:
+                request.state.tenant_id = identity.tenant_id
+                request.state.user_id = identity.user_id
+                request.state.user_email_authenticated = bool(identity.user_email)
+                request.state.user_email = identity.user_email
+                request.state.auth_method = (
+                    "jwt" if _parse_bearer_token(request.headers.get("Authorization")) else "api_key"
                 )
-                return await platform_api_error_handler(request, exc)
-            request.state.tenant_id = identity.tenant_id
-            request.state.user_id = identity.user_id
-            request.state.user_email_authenticated = bool(identity.user_email)
-            request.state.user_email = identity.user_email
-            request.state.auth_method = "jwt" if _parse_bearer_token(request.headers.get("Authorization")) else "api_key"
         elif _is_v2_validation_request(request.url.path):
             is_public_registration_route = _is_v2_validation_public_registration_request(request.url.path)
             has_auth_headers = bool(

--- a/backend/src/platform_api/router_v1.py
+++ b/backend/src/platform_api/router_v1.py
@@ -17,6 +17,7 @@ from src.platform_api.adapters.data_knowledge_adapter import (
 )
 from src.platform_api.adapters.execution_adapter import InMemoryExecutionAdapter, LiveEngineExecutionAdapter
 from src.platform_api.adapters.lona_adapter import LonaAdapterBaseline
+from src.platform_api.errors import PlatformAPIError
 from src.platform_api.knowledge.ingestion import KnowledgeIngestionPipeline
 from src.platform_api.knowledge.query import KnowledgeQueryService
 from src.platform_api.schemas_v1 import (
@@ -123,6 +124,38 @@ _execution_service = ExecutionService(
 _dataset_service = DatasetOrchestrator(store=_store, data_bridge_adapter=_data_bridge_adapter)
 
 
+def _request_auth_method(request: Request) -> str:
+    raw = getattr(request.state, "auth_method", None)
+    return raw if isinstance(raw, str) else "none"
+
+
+def _normalized_request_path(path: str) -> str:
+    normalized = path.strip()
+    if normalized == "":
+        return "/"
+    return normalized if normalized == "/" else normalized.rstrip("/")
+
+
+def _is_single_resource_path(*, path: str, prefix: str) -> bool:
+    if not path.startswith(prefix):
+        return False
+    candidate = path[len(prefix):]
+    return candidate != "" and "/" not in candidate
+
+
+def _required_cli_scope(*, path: str, method: str) -> str | None:
+    normalized_path = _normalized_request_path(path)
+    if method.upper() != "GET":
+        return None
+    if normalized_path == "/v1/strategies" or _is_single_resource_path(path=normalized_path, prefix="/v1/strategies/"):
+        return "strategy:read"
+    if _is_single_resource_path(path=normalized_path, prefix="/v1/backtests/"):
+        return "backtest:read"
+    if normalized_path == "/v1/deployments" or _is_single_resource_path(path=normalized_path, prefix="/v1/deployments/"):
+        return "deployment:read"
+    return None
+
+
 async def _request_context(
     request: Request,
     x_request_id: str | None = Header(default=None, alias="X-Request-Id"),
@@ -136,6 +169,37 @@ async def _request_context(
     user_id = state_user_id if isinstance(state_user_id, str) and state_user_id.strip() else "user-local"
     request.state.tenant_id = tenant_id
     request.state.user_id = user_id
+
+    if _request_auth_method(request) == "cli_token":
+        raw_scopes = getattr(request.state, "cli_scopes", ())
+        normalized_scopes = {
+            scope.strip().lower()
+            for scope in raw_scopes
+            if isinstance(scope, str) and scope.strip()
+        }
+        required_scope = _required_cli_scope(path=request.url.path, method=request.method)
+        if required_scope is None:
+            raise PlatformAPIError(
+                status_code=403,
+                code="CLI_AUTH_SCOPE_FORBIDDEN",
+                message="CLI token is not authorized for this endpoint.",
+                request_id=request_id,
+                details={
+                    "requiredScope": None,
+                    "scopes": sorted(normalized_scopes),
+                    "path": _normalized_request_path(request.url.path),
+                    "method": request.method.upper(),
+                },
+            )
+        if required_scope not in normalized_scopes:
+            raise PlatformAPIError(
+                status_code=403,
+                code="CLI_AUTH_SCOPE_FORBIDDEN",
+                message=f"CLI token is missing required scope: {required_scope}.",
+                request_id=request_id,
+                details={"requiredScope": required_scope, "scopes": sorted(normalized_scopes)},
+            )
+
     return RequestContext(
         request_id=request_id,
         tenant_id=tenant_id,

--- a/backend/src/platform_api/router_v1.py
+++ b/backend/src/platform_api/router_v1.py
@@ -197,7 +197,12 @@ async def _request_context(
                 code="CLI_AUTH_SCOPE_FORBIDDEN",
                 message=f"CLI token is missing required scope: {required_scope}.",
                 request_id=request_id,
-                details={"requiredScope": required_scope, "scopes": sorted(normalized_scopes)},
+                details={
+                    "requiredScope": required_scope,
+                    "scopes": sorted(normalized_scopes),
+                    "path": _normalized_request_path(request.url.path),
+                    "method": request.method.upper(),
+                },
             )
 
     return RequestContext(

--- a/backend/src/platform_api/router_v2.py
+++ b/backend/src/platform_api/router_v2.py
@@ -105,6 +105,24 @@ _identity_service = ValidationIdentityService(store=router_v1_module._store)
 _validation_service = ValidationV2Service(store=router_v1_module._store, identity_service=_identity_service)
 
 
+def resolve_cli_access_token_identity(
+    *,
+    access_token: str | None,
+    tenant_header: str | None,
+    user_header: str | None,
+    request_id: str,
+    update_last_used: bool = True,
+):
+    """Public wrapper for CLI access token identity resolution."""
+    return _identity_service.resolve_cli_access_token(
+        access_token=access_token,
+        tenant_header=tenant_header,
+        user_header=user_header,
+        request_id=request_id,
+        update_last_used=update_last_used,
+    )
+
+
 async def _request_context(
     request: Request,
     x_request_id: str | None = Header(default=None, alias="X-Request-Id"),

--- a/backend/src/platform_api/schemas_v2.py
+++ b/backend/src/platform_api/schemas_v2.py
@@ -538,7 +538,13 @@ class ValidationRegressionReplayResponse(BaseModel):
 BotStatus = Literal["active", "suspended", "revoked"]
 BotRegistrationPath = Literal["invite_code_trial", "partner_bootstrap"]
 BotKeyStatus = Literal["active", "rotated", "revoked"]
-ValidationCliScope = Literal["validation:read", "validation:write"]
+ValidationCliScope = Literal[
+    "validation:read",
+    "validation:write",
+    "strategy:read",
+    "backtest:read",
+    "deployment:read",
+]
 ValidationSharePermission = Literal["view", "review"]
 ValidationInviteStatus = Literal["pending", "accepted", "revoked", "expired"]
 ValidationShareStatus = Literal["active", "revoked"]

--- a/backend/src/platform_api/services/validation_identity_service.py
+++ b/backend/src/platform_api/services/validation_identity_service.py
@@ -24,7 +24,13 @@ ActorType = Literal["user", "bot"]
 RegistrationMethod = Literal["invite", "partner"]
 SharePermission = Literal["view", "review"]
 ShareInviteStatus = Literal["pending", "accepted", "revoked", "expired"]
-CliScope = Literal["validation:read", "validation:write"]
+CliScope = Literal[
+    "validation:read",
+    "validation:write",
+    "strategy:read",
+    "backtest:read",
+    "deployment:read",
+]
 CliDeviceAuthorizationStatus = Literal["pending", "approved", "consumed", "expired"]
 
 
@@ -222,7 +228,13 @@ class ValidationIdentityService:
     _CLI_ACCESS_TOKEN_PREFIX = "tnx.cli"
     _CLI_DEVICE_CODE_PREFIX = "tnx_device"
     _CLI_DEFAULT_SCOPES: tuple[CliScope, ...] = ("validation:read", "validation:write")
-    _CLI_ALLOWED_SCOPES: tuple[CliScope, ...] = ("validation:read", "validation:write")
+    _CLI_ALLOWED_SCOPES: tuple[CliScope, ...] = (
+        "validation:read",
+        "validation:write",
+        "strategy:read",
+        "backtest:read",
+        "deployment:read",
+    )
     _CLI_USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
     _CLI_USER_CODE_LENGTH = 8
     _CLI_ACCESS_TOKEN_SECRET_BYTES = 24

--- a/backend/tests/contracts/test_validation_cli_auth_runtime.py
+++ b/backend/tests/contracts/test_validation_cli_auth_runtime.py
@@ -226,6 +226,8 @@ def test_cli_token_with_validation_only_scope_cannot_list_strategies_v1() -> Non
             "details": {
                 "requiredScope": "strategy:read",
                 "scopes": ["validation:read"],
+                "path": "/v1/strategies",
+                "method": "GET",
             },
         },
     }

--- a/backend/tests/contracts/test_validation_cli_auth_runtime.py
+++ b/backend/tests/contracts/test_validation_cli_auth_runtime.py
@@ -126,6 +126,153 @@ def test_cli_device_flow_issues_token_and_allows_whoami_and_validation_reads() -
     assert list_runs.status_code == 200
 
 
+def test_cli_token_with_core_read_scopes_allows_whoami_and_v1_core_reads() -> None:
+    client = TestClient(app)
+    owner_headers = _user_headers(
+        request_id="req-cli-owner-v1-read-001",
+        tenant_id="tenant-cli-runtime-v1-read-001",
+        user_id="user-cli-runtime-v1-read-001",
+        user_email="owner-cli-runtime-v1-read-001@example.com",
+    )
+    access_token, _ = _issue_cli_token(
+        client,
+        owner_headers=owner_headers,
+        request_suffix="v1-read-001",
+        scopes=["validation:read", "strategy:read", "backtest:read", "deployment:read"],
+    )
+
+    whoami = client.get(
+        "/v2/validation-cli-auth/whoami",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-whoami-001",
+        },
+    )
+    assert whoami.status_code == 200
+
+    strategy_list = client.get(
+        "/v1/strategies",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-strategy-list-001",
+        },
+    )
+    assert strategy_list.status_code == 200
+
+    strategy_get = client.get(
+        "/v1/strategies/strat-001",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-strategy-get-001",
+        },
+    )
+    assert strategy_get.status_code == 200
+
+    backtest_get = client.get(
+        "/v1/backtests/bt-001",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-backtest-get-001",
+        },
+    )
+    assert backtest_get.status_code == 200
+
+    deployment_list = client.get(
+        "/v1/deployments",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-deploy-list-001",
+        },
+    )
+    assert deployment_list.status_code == 200
+
+    deployment_get = client.get(
+        "/v1/deployments/dep-001",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-read-deploy-get-001",
+        },
+    )
+    assert deployment_get.status_code == 200
+
+
+def test_cli_token_with_validation_only_scope_cannot_list_strategies_v1() -> None:
+    client = TestClient(app)
+    owner_headers = _user_headers(
+        request_id="req-cli-owner-v1-denied-001",
+        tenant_id="tenant-cli-runtime-v1-denied-001",
+        user_id="user-cli-runtime-v1-denied-001",
+    )
+    access_token, _ = _issue_cli_token(
+        client,
+        owner_headers=owner_headers,
+        request_suffix="v1-denied-001",
+        scopes=["validation:read"],
+    )
+
+    strategy_list = client.get(
+        "/v1/strategies",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-denied-strategy-list-001",
+        },
+    )
+    assert strategy_list.status_code == 403
+    assert strategy_list.json() == {
+        "requestId": "req-cli-v1-denied-strategy-list-001",
+        "error": {
+            "code": "CLI_AUTH_SCOPE_FORBIDDEN",
+            "message": "CLI token is missing required scope: strategy:read.",
+            "details": {
+                "requiredScope": "strategy:read",
+                "scopes": ["validation:read"],
+            },
+        },
+    }
+
+
+def test_cli_scope_forbidden_error_payload_is_structured_and_deterministic() -> None:
+    client = TestClient(app)
+    owner_headers = _user_headers(
+        request_id="req-cli-owner-v1-forbidden-001",
+        tenant_id="tenant-cli-runtime-v1-forbidden-001",
+        user_id="user-cli-runtime-v1-forbidden-001",
+    )
+    access_token, _ = _issue_cli_token(
+        client,
+        owner_headers=owner_headers,
+        request_suffix="v1-forbidden-001",
+        scopes=["strategy:read"],
+    )
+
+    create_strategy = client.post(
+        "/v1/strategies",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Request-Id": "req-cli-v1-forbidden-write-001",
+        },
+        json={
+            "name": "Forbidden Write CLI",
+            "description": "CLI read scope should fail closed on write",
+            "provider": "xai",
+        },
+    )
+    assert create_strategy.status_code == 403
+    assert create_strategy.json() == {
+        "requestId": "req-cli-v1-forbidden-write-001",
+        "error": {
+            "code": "CLI_AUTH_SCOPE_FORBIDDEN",
+            "message": "CLI token is not authorized for this endpoint.",
+            "details": {
+                "requiredScope": None,
+                "scopes": ["strategy:read"],
+                "path": "/v1/strategies",
+                "method": "POST",
+            },
+        },
+    }
+
+
 def test_cli_token_with_read_scope_cannot_call_validation_writes() -> None:
     client = TestClient(app)
     owner_headers = _user_headers(

--- a/docs/architecture/specs/platform-api.openapi.yaml
+++ b/docs/architecture/specs/platform-api.openapi.yaml
@@ -5116,7 +5116,7 @@ components:
 
     ValidationCliScope:
       type: string
-      enum: ["validation:read", "validation:write"]
+      enum: ["validation:read", "validation:write", "strategy:read", "backtest:read", "deployment:read"]
 
     CreateValidationCliDeviceStartRequest:
       type: object

--- a/docs/portal/cli/authenticate-cli.md
+++ b/docs/portal/cli/authenticate-cli.md
@@ -3,7 +3,7 @@ title: Authenticate CLI
 summary: End-user quickstart for human and bot authentication in trading-cli.
 owners:
   - Gate1 Docs Team
-updated: 2026-03-02
+updated: 2026-03-04
 ---
 
 # Authenticate CLI
@@ -31,6 +31,29 @@ trading-cli bot list
 ```bash
 unset PLATFORM_API_BEARER_TOKEN PLATFORM_API_TOKEN PLATFORM_API_KEY
 ```
+
+## Device Auth Scope Matrix
+
+`/v2/validation-cli-auth/device/start` accepts explicit `scopes` and fails closed on unsupported values (`CLI_AUTH_SCOPE_INVALID`).
+
+Default device-login scopes when `scopes` is omitted:
+- `validation:read`
+- `validation:write`
+
+Supported scopes and command domains:
+
+| Scope | Domain | Representative endpoints | Representative CLI commands |
+| --- | --- | --- | --- |
+| `validation:read` | Validation read | `GET /v2/validation-runs`, `GET /v2/validation-runs/{runId}` | `trading-cli validation run list`, `trading-cli validation run get --run-id <id>` |
+| `validation:write` | Validation write | `POST /v2/validation-runs`, `POST /v2/validation-runs/{runId}/review` | `trading-cli validation run create ...`, `trading-cli validation run review ...` |
+| `strategy:read` | Core strategy read | `GET /v1/strategies`, `GET /v1/strategies/{strategyId}` | `trading-cli strategy list`, `trading-cli strategy get --strategy-id <id>` |
+| `backtest:read` | Core backtest read | `GET /v1/backtests/{backtestId}` | `trading-cli backtest get --backtest-id <id>` |
+| `deployment:read` | Core deployment read | `GET /v1/deployments`, `GET /v1/deployments/{deploymentId}` | `trading-cli deploy list`, `trading-cli deploy get --deployment-id <id>` |
+
+Fail-closed policy for CLI bearer tokens (`tnx.cli...`):
+- Missing required scope: `403 CLI_AUTH_SCOPE_FORBIDDEN`
+- Endpoint outside authorized CLI scope domains: `403 CLI_AUTH_SCOPE_FORBIDDEN`
+- Invalid/revoked/expired CLI token: `401 CLI_ACCESS_TOKEN_INVALID|CLI_ACCESS_TOKEN_REVOKED|CLI_ACCESS_TOKEN_EXPIRED`
 
 ## Bot Auth vs Human Auth
 

--- a/frontend/src/lib/validation/types.ts
+++ b/frontend/src/lib/validation/types.ts
@@ -322,7 +322,12 @@ export interface CreateValidationBotKeyRevocationPayload {
   reason?: string;
 }
 
-export type ValidationCliScope = 'validation:read' | 'validation:write';
+export type ValidationCliScope =
+  | 'validation:read'
+  | 'validation:write'
+  | 'strategy:read'
+  | 'backtest:read'
+  | 'deployment:read';
 
 export interface ValidationCliSession {
   id: string;

--- a/sdk/typescript/src/models/ValidationCliScope.ts
+++ b/sdk/typescript/src/models/ValidationCliScope.ts
@@ -19,7 +19,10 @@
  */
 export enum ValidationCliScope {
     ValidationRead = 'validation:read',
-    ValidationWrite = 'validation:write'
+    ValidationWrite = 'validation:write',
+    StrategyRead = 'strategy:read',
+    BacktestRead = 'backtest:read',
+    DeploymentRead = 'deployment:read'
 }
 
 


### PR DESCRIPTION
## Summary
Implements #381 from `origin/main` in an isolated worktree branch with explicit CLI scope domains for core read commands.

### What changed
- Extended CLI scope model (explicit, no implicit widening):
  - `validation:read`
  - `validation:write`
  - `strategy:read`
  - `backtest:read`
  - `deployment:read`
- Enabled CLI bearer token (`tnx.cli...`) identity fallback for protected `/v1/*` routes with no bypass of auth checks.
- Added explicit v1 runtime scope gate (fail-closed):
  - `GET /v1/strategies`, `GET /v1/strategies/{strategyId}` -> `strategy:read`
  - `GET /v1/backtests/{backtestId}` -> `backtest:read`
  - `GET /v1/deployments`, `GET /v1/deployments/{deploymentId}` -> `deployment:read`
  - Any other `/v1/*` usage under CLI token remains forbidden (`CLI_AUTH_SCOPE_FORBIDDEN`).
- Kept validation behavior unchanged and preserved existing validation scope gates.
- Added docs scope matrix in `docs/portal/cli/authenticate-cli.md`.
- Updated OpenAPI + SDK/frontend type artifacts where contract surface changed.

## Explicit scope matrix
| Scope | Authorized command domain |
| --- | --- |
| `validation:read` | validation read endpoints |
| `validation:write` | validation write endpoints |
| `strategy:read` | v1 strategy list/get |
| `backtest:read` | v1 backtest get |
| `deployment:read` | v1 deployment list/get |

## Contract/runtime evidence
### Required behavior checks
- `whoami + strategy list` with proper scope token: PASS
- `strategy list` with validation-only token: FAILS as expected with `CLI_AUTH_SCOPE_FORBIDDEN`
- auth errors structured + deterministic envelope: PASS

### Request IDs exercised in runtime contracts
- allow-path evidence:
  - `req-cli-v1-read-whoami-001`
  - `req-cli-v1-read-strategy-list-001`
  - `req-cli-v1-read-strategy-get-001`
  - `req-cli-v1-read-backtest-get-001`
  - `req-cli-v1-read-deploy-list-001`
  - `req-cli-v1-read-deploy-get-001`
- deny-path evidence:
  - `req-cli-v1-denied-strategy-list-001` (validation-only token)
  - `req-cli-v1-forbidden-write-001` (fail-closed write on read-only scope)

## Validation run evidence
### Targeted/runtime contracts
- `uv run --extra dev pytest -q tests/contracts/test_validation_cli_auth_runtime.py tests/contracts/test_runtime_openapi_contract_v2.py tests/contracts/test_runtime_openapi_contract.py tests/contracts/test_sdk_validation_contract_shape.py tests/contracts/test_openapi_contract_v2_baseline.py tests/contracts/test_openapi_contract_v2_validation_freeze.py`
- Result: `33 passed`

### Governance checks
- `bash contracts/scripts/verify-sdk-drift.sh` -> PASS (`No SDK drift detected.`)
- `python3 contracts/scripts/check-slo-alert-baseline.py` -> PASS
- `bash contracts/scripts/mock-smoke-test.sh` -> PASS
- `bash contracts/scripts/mock-consumer-contract-test.sh` -> PASS
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main bash contracts/scripts/check-breaking-changes.sh` -> PASS (`No incompatible OpenAPI changes detected.`)
- `npm --prefix docs/portal-site run ci` -> PASS

Closes #381.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 4ecf6f06907c19eee7c08473ec73b25f48b95598. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends CLI device-auth scope parity to the v1 core read surface by adding three new scopes (`strategy:read`, `backtest:read`, `deployment:read`), wiring a CLI bearer-token fallback into the v1 protected middleware path, and enforcing a fail-closed scope gate inside the shared `_request_context` dependency. The scope model is updated consistently across backend types, OpenAPI spec, TypeScript SDK, and frontend types.

**Key changes:**
- New helper `_resolve_cli_identity_from_bearer` / `_apply_cli_identity_to_request_state` consolidate CLI identity hydration previously duplicated across the v1 and v2 middleware branches.
- `resolve_cli_access_token_identity` public wrapper in `router_v2.py` removes the previous `_identity_service` private-member access (`# noqa: SLF001`) from `main.py`.
- `_required_cli_scope` implements a strict path+method allow-list (GET only on `/v1/strategies`, `/v1/strategies/{id}`, `/v1/backtests/{id}`, `/v1/deployments`, `/v1/deployments/{id}`); everything else is `CLI_AUTH_SCOPE_FORBIDDEN` (fail-closed).
- `_CLI_DEFAULT_SCOPES` is intentionally left unchanged (`validation:read`, `validation:write`) — users must explicitly request the new scopes at device-login time.

**Issue found:** The new contract test `test_cli_token_with_core_read_scopes_allows_whoami_and_v1_core_reads` has three assertions at lines 169, 178, and 196 that assert `status_code == 200` for individual resource GET endpoints (`/v1/strategies/strat-001`, `/v1/backtests/bt-001`, `/v1/deployments/dep-001`) without creating those resources first. Since the backend services raise 404 for unknown resource IDs, these assertions will fail with 404 responses instead of 200. Either create the resources before fetching them or broaden the assertions to check `!= 403` to verify the scope gate passed.

<h3>Confidence Score: 2/5</h3>

- Test suite contains failing assertions that must be fixed before merge; production auth logic is correct and safe.
- The PR's production auth logic is sound—the scope gate implementation, middleware refactoring, and fail-closed policy are all correct. However, the new contract test `test_cli_token_with_core_read_scopes_allows_whoami_and_v1_core_reads` has three assertions (lines 169, 178, 196) that expect 200 responses for resource GET endpoints when those resources do not exist in the in-memory store. The backend services correctly return 404 for unknown resource IDs, so these assertions will fail. This is a blocker: the test must be fixed (either by creating the resources or broadening assertions to check `!= 403`) before this PR can be merged.
- backend/tests/contracts/test_validation_cli_auth_runtime.py — lines 169, 178, 196 require assertion corrections.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming v1 Request] --> B{Is v1 protected path?}
    B -- No --> C[Public route, skip auth]
    B -- Yes --> D[resolve_validation_identity]
    D -- Success --> E[Set auth_method = jwt or api_key]
    D -- AUTH_UNAUTHORIZED --> F[_resolve_cli_identity_from_bearer]
    F -- not a CLI prefix --> G[Return original 401 error]
    F -- CLI identity resolved --> H[Set auth_method = cli_token + scopes]
    F -- CLI token invalid --> I[Return CLI error]
    H --> J[_request_context dependency runs]
    J --> K{_required_cli_scope for path+method}
    K -- None returned --> L[403 CLI_AUTH_SCOPE_FORBIDDEN]
    K -- Required scope found --> M{Scope in token scopes?}
    M -- No --> L
    M -- Yes --> N[Route handler executes]
```

<sub>Last reviewed commit: 4ecf6f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->